### PR TITLE
Pdf rr file substitution

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,7 +12,7 @@ pub struct AppState {
     pub session: Mutex<Option<RrSession>>,
 }
 
-/// Open a .rr file or import a PDF
+/// Open a .rr file or import a PDF (converted to .rr)
 #[tauri::command]
 pub fn open_file(path: String, state: State<AppState>) -> Result<DocumentInfo, String> {
     let path = PathBuf::from(&path);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -12,9 +12,14 @@ pub struct AppState {
     pub session: Mutex<Option<RrSession>>,
 }
 
-/// Open a .rr file or import a PDF (converted to .rr)
+/// Open a .rr file or import a PDF.
+/// For PDFs, `replace_pdf` defaults to true (replace source with .rr).
 #[tauri::command]
-pub fn open_file(path: String, state: State<AppState>) -> Result<DocumentInfo, String> {
+pub fn open_file(
+    path: String,
+    replace_pdf: Option<bool>,
+    state: State<AppState>,
+) -> Result<DocumentInfo, String> {
     let path = PathBuf::from(&path);
     let ext = path
         .extension()
@@ -24,7 +29,7 @@ pub fn open_file(path: String, state: State<AppState>) -> Result<DocumentInfo, S
 
     let session = match ext.as_str() {
         "rr" => rr_file::open_rr(&path)?,
-        "pdf" => rr_file::import_pdf(&path, None)?,
+        "pdf" => rr_file::import_pdf(&path, None, replace_pdf.unwrap_or(true))?,
         _ => return Err(format!("Unsupported file type: .{}", ext)),
     };
 

--- a/src-tauri/src/rr_file.rs
+++ b/src-tauri/src/rr_file.rs
@@ -71,11 +71,13 @@ pub fn open_rr(rr_path: &Path) -> Result<RrSession, String> {
 
 /// Import a raw PDF into a new .rr file.
 /// Creates the .rr container next to the PDF (or at the specified output path).
+/// When no output path is provided, the original PDF is removed after a successful pack.
 pub fn import_pdf(pdf_path: &Path, output_path: Option<&Path>) -> Result<RrSession, String> {
     let rr_path = match output_path {
         Some(p) => p.to_path_buf(),
         None => pdf_path.with_extension("rr"),
     };
+    let should_replace_source_pdf = output_path.is_none() && rr_path != pdf_path;
 
     let work_dir = tempfile::tempdir()
         .map_err(|e| format!("Failed to create temp dir: {}", e))?
@@ -112,6 +114,11 @@ pub fn import_pdf(pdf_path: &Path, output_path: Option<&Path>) -> Result<RrSessi
 
     // Pack immediately so the .rr file exists on disk
     save_rr(&session)?;
+
+    if should_replace_source_pdf {
+        fs::remove_file(pdf_path)
+            .map_err(|e| format!("Failed to remove original PDF after conversion: {}", e))?;
+    }
 
     Ok(session)
 }

--- a/src-tauri/src/rr_file.rs
+++ b/src-tauri/src/rr_file.rs
@@ -71,13 +71,17 @@ pub fn open_rr(rr_path: &Path) -> Result<RrSession, String> {
 
 /// Import a raw PDF into a new .rr file.
 /// Creates the .rr container next to the PDF (or at the specified output path).
-/// When no output path is provided, the original PDF is removed after a successful pack.
-pub fn import_pdf(pdf_path: &Path, output_path: Option<&Path>) -> Result<RrSession, String> {
+/// When `replace_source_pdf` is true, the source PDF is removed after a successful pack.
+pub fn import_pdf(
+    pdf_path: &Path,
+    output_path: Option<&Path>,
+    replace_source_pdf: bool,
+) -> Result<RrSession, String> {
     let rr_path = match output_path {
         Some(p) => p.to_path_buf(),
         None => pdf_path.with_extension("rr"),
     };
-    let should_replace_source_pdf = output_path.is_none() && rr_path != pdf_path;
+    let should_replace_source_pdf = replace_source_pdf && rr_path != pdf_path;
 
     let work_dir = tempfile::tempdir()
         .map_err(|e| format!("Failed to create temp dir: {}", e))?

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,10 @@ export default function App() {
       const selected = await open({
         multiple: false,
         filters: [
-          { name: "Research Reader / PDF", extensions: ["rr", "pdf"] },
+          {
+            name: "Research Reader / PDF (convert to .rr)",
+            extensions: ["rr", "pdf"],
+          },
         ],
       });
       const selectedPath = Array.isArray(selected) ? selected[0] : selected;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { AnnotationSidebar } from "@/components/annotations/AnnotationSidebar";
 import { AiPanel } from "@/components/ai/AiPanel";
 import { WelcomeScreen } from "@/components/WelcomeScreen";
 import * as commands from "@/lib/tauri-commands";
-import { confirmPdfImport } from "@/lib/pdf-import";
+import { getPdfImportDecision } from "@/lib/pdf-import";
 import { MessageSquare, PanelRightClose, PanelRightOpen, Sparkles } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -66,8 +66,12 @@ export default function App() {
         ],
       });
       const selectedPath = Array.isArray(selected) ? selected[0] : selected;
-      if (!selectedPath || !confirmPdfImport(selectedPath)) return;
-      await usePdfStore.getState().openFile(selectedPath);
+      if (!selectedPath) return;
+      const decision = getPdfImportDecision(selectedPath);
+      if (!decision.shouldOpen) return;
+      await usePdfStore
+        .getState()
+        .openFile(selectedPath, { replacePdf: decision.replacePdf });
     }
 
     if (isCtrl && e.key === "s") {

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,7 +1,7 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { usePdfStore } from "@/stores/pdf-store";
 import { FileText, FolderOpen } from "lucide-react";
-import { confirmPdfImport } from "@/lib/pdf-import";
+import { getPdfImportDecision } from "@/lib/pdf-import";
 
 export function WelcomeScreen() {
   const { openFile, isLoading, error } = usePdfStore();
@@ -17,8 +17,10 @@ export function WelcomeScreen() {
       ],
     });
     const selectedPath = Array.isArray(selected) ? selected[0] : selected;
-    if (!selectedPath || !confirmPdfImport(selectedPath)) return;
-    await openFile(selectedPath);
+    if (!selectedPath) return;
+    const decision = getPdfImportDecision(selectedPath);
+    if (!decision.shouldOpen) return;
+    await openFile(selectedPath, { replacePdf: decision.replacePdf });
   };
 
   return (
@@ -27,7 +29,7 @@ export function WelcomeScreen() {
         <FileText size={48} className="text-muted-foreground" />
         <h1 className="text-2xl font-semibold">Research Reader</h1>
         <p className="text-sm text-muted-foreground">
-          Open a .rr file, or import a PDF (it will be converted to .rr)
+          Open a .rr file, or import a PDF (replace by default)
         </p>
       </div>
 

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -11,7 +11,7 @@ export function WelcomeScreen() {
       multiple: false,
       filters: [
         {
-          name: "Research Reader / PDF",
+          name: "Research Reader / PDF (convert to .rr)",
           extensions: ["rr", "pdf"],
         },
       ],
@@ -27,7 +27,7 @@ export function WelcomeScreen() {
         <FileText size={48} className="text-muted-foreground" />
         <h1 className="text-2xl font-semibold">Research Reader</h1>
         <p className="text-sm text-muted-foreground">
-          Open a PDF or .rr file to get started
+          Open a .rr file, or import a PDF (it will be converted to .rr)
         </p>
       </div>
 

--- a/src/components/pdf/Toolbar.tsx
+++ b/src/components/pdf/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { usePdfStore } from "@/stores/pdf-store";
 import * as commands from "@/lib/tauri-commands";
-import { confirmPdfImport } from "@/lib/pdf-import";
+import { getPdfImportDecision } from "@/lib/pdf-import";
 import {
   FolderOpen,
   ZoomIn,
@@ -65,8 +65,10 @@ export function Toolbar() {
       ],
     });
     const selectedPath = Array.isArray(selected) ? selected[0] : selected;
-    if (!selectedPath || !confirmPdfImport(selectedPath)) return;
-    await openFile(selectedPath);
+    if (!selectedPath) return;
+    const decision = getPdfImportDecision(selectedPath);
+    if (!decision.shouldOpen) return;
+    await openFile(selectedPath, { replacePdf: decision.replacePdf });
   };
 
   const handleSave = async () => {

--- a/src/components/pdf/Toolbar.tsx
+++ b/src/components/pdf/Toolbar.tsx
@@ -59,7 +59,7 @@ export function Toolbar() {
       multiple: false,
       filters: [
         {
-          name: "Research Reader / PDF",
+          name: "Research Reader / PDF (convert to .rr)",
           extensions: ["rr", "pdf"],
         },
       ],

--- a/src/lib/pdf-import.ts
+++ b/src/lib/pdf-import.ts
@@ -1,9 +1,26 @@
-export function confirmPdfImport(path: string): boolean {
+export interface PdfImportDecision {
+  shouldOpen: boolean;
+  replacePdf: boolean;
+}
+
+export function getPdfImportDecision(path: string): PdfImportDecision {
   if (!path.toLowerCase().endsWith(".pdf")) {
-    return true;
+    return { shouldOpen: true, replacePdf: true };
   }
 
-  return window.confirm(
-    "Convert this PDF to a .rr file and replace the original PDF?",
+  const replacePdf = window.confirm(
+    "Replace this PDF with a .rr file and open it?\n\nChoose Cancel to keep the PDF and create a .rr copy instead.",
   );
+  if (replacePdf) {
+    return { shouldOpen: true, replacePdf: true };
+  }
+
+  const keepOriginalPdf = window.confirm(
+    "Keep the original PDF and create a .rr copy before opening?",
+  );
+  if (keepOriginalPdf) {
+    return { shouldOpen: true, replacePdf: false };
+  }
+
+  return { shouldOpen: false, replacePdf: true };
 }

--- a/src/lib/pdf-import.ts
+++ b/src/lib/pdf-import.ts
@@ -4,6 +4,6 @@ export function confirmPdfImport(path: string): boolean {
   }
 
   return window.confirm(
-    "Import this PDF into a new .rr file next to the original PDF?",
+    "Convert this PDF to a .rr file and replace the original PDF?",
   );
 }

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -8,8 +8,18 @@ import type {
   UpdateAnnotationInput,
 } from "@/types";
 
-export async function openFile(path: string): Promise<DocumentInfo> {
-  return invoke<DocumentInfo>("open_file", { path });
+export interface OpenFileOptions {
+  replacePdf?: boolean;
+}
+
+export async function openFile(
+  path: string,
+  options?: OpenFileOptions,
+): Promise<DocumentInfo> {
+  return invoke<DocumentInfo>("open_file", {
+    path,
+    replacePdf: options?.replacePdf ?? null,
+  });
 }
 
 export async function saveFile(): Promise<void> {

--- a/src/stores/pdf-store.ts
+++ b/src/stores/pdf-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { DocumentInfo } from "@/types";
 import * as commands from "@/lib/tauri-commands";
+import type { OpenFileOptions } from "@/lib/tauri-commands";
 
 export type InteractionMode = "view" | "note";
 
@@ -20,7 +21,7 @@ interface PdfState {
   mode: InteractionMode;
 
   // Actions
-  openFile: (path: string) => Promise<void>;
+  openFile: (path: string, options?: OpenFileOptions) => Promise<void>;
   closeFile: () => Promise<void>;
   setCurrentPage: (page: number) => void;
   setNumPages: (num: number) => void;
@@ -46,10 +47,10 @@ export const usePdfStore = create<PdfState>((set, get) => ({
   visiblePages: [],
   mode: "view",
 
-  openFile: async (path: string) => {
+  openFile: async (path: string, options?: OpenFileOptions) => {
     set({ isLoading: true, error: null });
     try {
-      const doc = await commands.openFile(path);
+      const doc = await commands.openFile(path, options);
       set({
         document: doc,
         isLoading: false,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement PDF to .rr file substitution to prevent duplicate file storage.

---
<p><a href="https://cursor.com/agents/bc-940104cb-a697-43b8-921f-47b332c437af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-940104cb-a697-43b8-921f-47b332c437af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->