### PR TITLE
Add live webpage reading mode

### DIFF
--- a/PLAN-WEBPAGES.md
+++ b/PLAN-WEBPAGES.md
@@ -1,0 +1,178 @@
+# Webpage Support — Plan
+
+## Goal
+
+Let the user add a webpage (blog post, research article, docs page) to Vellum as a
+first-class tab, with the same tools a PDF gets: highlights, sticky notes, bookmarks,
+and the AI panel (context, chat, `goToPage` / `addNote` / `addHighlight` actions).
+The page is **not** converted to a PDF — it stays a live, interactive webpage
+(embedded videos, code toggles, footnote popovers, etc. keep working). Saved
+webpages appear in a library so they can be reopened later.
+
+---
+
+## Architecture Decision: How to Render the Page
+
+Three options were considered:
+
+| Option | Fidelity / interactivity | Tool integration | Complexity |
+|---|---|---|---|
+| **A. Proxied iframe** (recommended) | High — real HTML/JS runs | Good — injected content script + `postMessage` | Medium |
+| B. Tauri child webview | Highest | Poor — native webview sits *above* the React UI; no overlays, IPC from remote pages needs `dangerousRemoteDomainIpcAccess`; multiwebview is behind an unstable flag | High |
+| C. Reader-mode extraction (Readability → React DOM) | None — static article only | Best | Low |
+
+**Recommendation: Option A — a sandboxed iframe fed by a Rust proxy over a Tauri
+custom protocol.** Option C fails the interactivity requirement outright (though it
+makes a nice future "Reader view" toggle). Option B renders pixels perfectly but
+breaks the entire annotation/AI overlay model: Vellum's popovers, highlight layers,
+and sidebar interactions cannot be composited over a separate native webview.
+
+### How Option A works
+
+1. User enters a URL. The iframe's `src` is `vellum-web://<encoded-url>`.
+2. A Rust custom-protocol handler (`register_uri_scheme_protocol("vellum-web", …)`)
+   fetches the URL with `reqwest`, then:
+   - strips `X-Frame-Options` and `Content-Security-Policy` response headers that
+     would block framing;
+   - injects `<base href="<original-url>">` so relative subresources resolve
+     against the real origin (images, CSS, scripts load directly from the web);
+   - injects the **Vellum content script** as the first `<script>` in `<head>`.
+3. The page runs inside the iframe as normal HTML/JS — fully interactive.
+4. The content script is Vellum's agent inside the page. It talks to the React app
+   exclusively via `window.parent.postMessage` (the iframe is cross-origin to the
+   app shell, so neither side can touch the other's DOM — which is also the
+   security boundary we want).
+
+**Content script responsibilities** (single bundled file, `src/webpage/content-script.ts`,
+built as an extra Vite entry and embedded into the proxied HTML by Rust):
+
+- Report metadata: `<title>`, canonical URL, favicon, byline/og tags.
+- Extract readable text and chunk it into **virtual pages** (see below).
+- Report text selections: selected string, prefix/suffix context, viewport rects
+  → drives the existing `SelectionPopover` (rendered by React in the app shell,
+  positioned using forwarded rects + the iframe's offset).
+- Apply/remove highlights using the **CSS Custom Highlight API** (no DOM
+  mutation, so page scripts don't break), re-anchoring by text quote on load.
+- Scroll to a virtual page / anchored text on command.
+- Intercept link clicks: same-document anchors scroll normally; other links
+  navigate the tab through the proxy (with simple back/forward); a modifier-click
+  opens in the system browser.
+- Report scroll position (for restoring reading position later).
+
+### Virtual pages
+
+Webpages have no pages, but Vellum's tab state, annotation schema
+(`page_number`), AI context format (`[Page N] …`), and the `goToPage` tool are all
+page-indexed. Rather than rework all of that, the content script chunks the
+extracted text into virtual pages (split on `h1/h2/h3` boundaries, merged/split to
+roughly 3–4k chars each) and remembers a scroll anchor for each chunk. Then:
+
+- `goToPage(n)` → scroll to virtual page *n*'s anchor.
+- `currentPage` / `visiblePages` → derived from scroll position via the chunk anchors.
+- `setPageText(n, text)` → populated once at load; the AI context block and
+  `MAX_CONTEXT_CHARS` bounding work unchanged.
+- `addHighlight(page, text)` → content script text-search within chunk *n* (same
+  philosophy as `locateTextOnPage`: geometry is resolved from real text, never
+  trusted from the model).
+
+### Annotation anchoring & persistence
+
+PDF annotations are embedded in the file itself; there is no equivalent for a
+webpage we don't own. Instead:
+
+- **Anchor model:** W3C-style text-quote anchors — `{ exact, prefix, suffix }` plus
+  a character-offset hint. Robust to minor page edits; if re-anchoring fails on a
+  later visit, the annotation is listed as "orphaned" in the sidebar instead of
+  silently dropped. Reuses the existing `Annotation` shape: `position_data.selected_text`,
+  `start_offset`/`end_offset`, `page_number` = virtual page; `rects` are computed
+  live by the content script rather than stored as gospel.
+- **Store:** JSON sidecar per page in the app data dir —
+  `app_data_dir/web/<sha256(normalized-url)>.json` containing metadata +
+  annotations. New Rust module `web_session.rs` with commands mirroring the PDF
+  ones (`open_web_document`, `create/update/delete_annotation`, `set_document_metadata`)
+  so `annotation-store.ts` needs only a dispatch on document kind.
+- **URL normalization:** strip fragments and tracking params (`utm_*`, `fbclid`, …),
+  prefer `<link rel="canonical">` when present, so the same article maps to one record.
+
+### Saving & the library
+
+- "Save" (bookmark icon in the toolbar / auto-save on first annotation) records the
+  page in the library: URL, title, favicon, excerpt, saved-at, last scroll position.
+- **Offline snapshot:** on save, the Rust side stores the proxied HTML (post-injection,
+  pre-render) to `app_data_dir/web/<hash>/snapshot.html`. Reopening loads **live
+  first, snapshot as fallback** when offline or the page 404s/link-rots. A per-page
+  "pin snapshot" toggle can force the frozen copy (useful for citing).
+- `WelcomeScreen` gains a second list ("Saved pages") next to recent PDFs; recents
+  logic generalizes from `recent-pdfs.ts` to `recent-documents.ts`.
+
+### Data model changes (frontend)
+
+```ts
+type DocumentKind = "pdf" | "web";
+
+interface DocumentInfo {
+  kind: DocumentKind;        // new
+  uri: string;               // pdf_path or normalized URL (pdf_path kept as alias during migration)
+  title: string | null;
+  page_count: number | null; // virtual page count for web
+  last_page: number | null;
+}
+```
+
+`PdfTab` → `DocumentTab { kind, … }`. `pdf-store.ts` becomes `document-store.ts`
+(or gains `openUrl(url)` alongside `openFile(path)`); zoom for web tabs maps to
+iframe CSS `zoom`/text scale. Conversation storage in `ai-store.ts` already keys by
+`pdf_path` — keying by normalized URL works with zero changes beyond the rename.
+
+### AI integration
+
+- Context block: identical format; virtual page texts feed `pageTexts`.
+- Tools: `goToPage`, `addNote`, `addHighlight` all work via the mappings above.
+- `currentPageImage`: **not available for web tabs initially** (an app-shell webview
+  cannot screenshot a cross-origin iframe). Ship without it — the extracted text is
+  strong context for articles — and later optionally add a Rust-side headless
+  capture or `Window::screenshot` if it proves needed. The system prompt gets a
+  line telling the model when it's reading a webpage vs a PDF.
+
+### Security notes
+
+- The proxied page's JS runs inside a cross-origin iframe: it cannot reach the app
+  shell's DOM, localStorage, or Tauri IPC (Tauri 2 capabilities are webview/origin
+  scoped and no remote capability is granted). `postMessage` handlers in the app
+  validate origin + message schema.
+- The proxy sends **no cookies** and a plain browser User-Agent; it follows
+  redirects with a cap and enforces a response-size limit. Auth-walled/paywalled
+  pages therefore won't load — acceptable for the blog/article use case.
+- CSP stripping happens only inside the sandboxed iframe origin, never for the app
+  shell. `tauri.conf.json` CSP gains `frame-src vellum-web:`.
+
+---
+
+## Phases
+
+**Phase 1 — Live web tabs.** URL entry (Welcome screen "Add webpage" + Cmd+L),
+Rust proxy protocol, iframe viewer component, `DocumentTab.kind`, tab bar/toolbar
+adaptation (hide PDF-only controls for web tabs), title via content script.
+
+**Phase 2 — Tools parity.** Content script bridge (selection → popover, highlights
+via Custom Highlight API, notes, bookmarks), text-quote anchoring, JSON sidecar
+persistence in Rust, annotation sidebar working for web tabs.
+
+**Phase 3 — AI parity.** Virtual paging → `pageTexts`, `goToPage`/`addHighlight`/
+`addNote` execution for web tabs, prompt updates, per-URL conversations.
+
+**Phase 4 — Library.** Save action, saved-pages list on Welcome screen, offline
+snapshots with live-first/snapshot-fallback, scroll-position restore.
+
+---
+
+## Open questions
+
+1. **Link navigation default** — navigate in-tab through the proxy (proposed) vs
+   always opening external links in the system browser.
+2. **Snapshot policy** — snapshot on save (proposed) vs snapshot on every visit
+   (keeps annotations anchorable even as pages change, costs disk).
+3. **Reader-mode toggle** — worth adding later as an alternate view for hostile
+   pages (heavy ads/layout) where the proxy renders poorly?
+4. **Page image context for AI** — skip for web (proposed) or invest in a capture
+   path early?

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -91,6 +91,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +450,24 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "convert_case"
@@ -441,6 +483,16 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -466,9 +518,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -479,7 +531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -911,12 +963,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -929,6 +990,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1334,6 +1401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1418,6 +1504,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1519,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1455,6 +1548,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,9 +1581,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2003,6 +2114,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,10 +2459,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2938,6 +3103,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3121,7 +3326,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3158,6 +3363,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3247,7 +3458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3384,6 +3595,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3657,6 +3880,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3677,7 +3921,7 @@ checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3773,7 +4017,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3962,7 +4206,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "semver",
  "serde",
@@ -3976,7 +4220,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -4178,6 +4422,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,7 +4469,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -4356,13 +4634,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4560,15 +4843,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vellum"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "encoding_rs",
  "log",
  "lopdf",
+ "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4577,7 +4870,11 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-updater",
  "tempfile",
+ "tiny_http",
+ "tokio",
+ "url",
  "uuid",
+ "zip 2.4.2",
 ]
 
 [[package]]
@@ -4976,6 +5273,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5493,6 +5801,23 @@ dependencies = [
 
 [[package]]
 name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.13.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
+name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -5508,3 +5833,15 @@ name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,18 @@ lopdf = "0.34"
 uuid = { version = "1", features = ["v4"] }
 tempfile = "3"
 chrono = { version = "0.4", features = ["serde"] }
+reqwest = { version = "0.12", features = ["gzip", "brotli", "deflate"] }
+encoding_rs = "0.8"
+url = "2"
+sha2 = "0.10"
+regex = "1"
+# deflate-zopfli enables compression levels 10-264 (Zopfli iterations) for
+# denser .vellumweb archives; plain deflate stays available for big entries.
+zip = { version = "2", default-features = false, features = ["deflate", "deflate-zopfli"] }
+
+[dev-dependencies]
+tiny_http = "0.12"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [target.'cfg(any(target_os = "macos", windows, target_os = "linux"))'.dependencies]
 tauri-plugin-process = "2.3.1"

--- a/src-tauri/assets/vellum-content-script.js
+++ b/src-tauri/assets/vellum-content-script.js
@@ -1,0 +1,965 @@
+/*
+ * Vellum content script — injected into proxied webpages by the vellum-web
+ * custom protocol. Runs inside the page's own JS context (cross-origin from
+ * the app shell) and talks to the app exclusively via postMessage.
+ *
+ * Responsibilities:
+ *  - extract readable text and chunk it into "virtual pages"
+ *  - report scroll position / current virtual page
+ *  - report text selections (text + raw offsets + viewport rects)
+ *  - render highlight overlays anchored by text offsets
+ *  - locate arbitrary text for AI-created highlights
+ *  - capture / scroll to exact reading positions (point bookmarks)
+ *  - intercept link clicks so navigation stays inside the proxy
+ */
+(function () {
+  "use strict";
+  if (window.top === window) return; // only meaningful when framed by Vellum
+  if (window.__vellumLoaded) return;
+  window.__vellumLoaded = true;
+
+  var PAGE_URL = window.__VELLUM_PAGE_URL__ || location.href;
+  var PAGE_TARGET_CHARS = 3600;
+  var MAX_PAGES = 200;
+
+  // Raw text domain: concatenation of all accepted text nodes.
+  var entries = []; // [{ node, start, end }] raw offsets per text node
+  var rawText = "";
+  // Normalized domain: whitespace-collapsed text for search/AI context.
+  var normText = "";
+  var normMap = []; // normMap[i] = raw offset of normText[i]
+  var pages = []; // [{ number, start(raw), end(raw), normStart, normEnd, text }]
+  var pageTops = null; // cached document-Y of each page start
+  var overlayRoot = null;
+  var appliedHighlights = []; // [{ id, color, start, end, text }]
+  var initialized = false;
+
+  function post(type, payload) {
+    var msg = { vellum: true, type: type };
+    if (payload) {
+      for (var k in payload) msg[k] = payload[k];
+    }
+    try {
+      window.parent.postMessage(msg, "*");
+    } catch (err) {
+      /* parent gone */
+    }
+  }
+
+  function debounce(fn, ms) {
+    var t = null;
+    return function () {
+      if (t) clearTimeout(t);
+      t = setTimeout(fn, ms);
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Text extraction
+  // ------------------------------------------------------------------
+
+  var SKIP_TAGS = {
+    SCRIPT: 1, STYLE: 1, NOSCRIPT: 1, TEMPLATE: 1, IFRAME: 1,
+    OBJECT: 1, TEXTAREA: 1, SELECT: 1, HEAD: 1, TITLE: 1, svg: 1, SVG: 1,
+  };
+
+  function buildTextMap() {
+    entries = [];
+    rawText = "";
+    normText = "";
+    normMap = [];
+
+    var root = document.body || document.documentElement;
+    if (!root) return;
+
+    var walker = document.createTreeWalker(
+      root,
+      NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+      {
+        acceptNode: function (node) {
+          if (node.nodeType === 1) {
+            if (SKIP_TAGS[node.tagName]) return NodeFilter.FILTER_REJECT;
+            if (node.hasAttribute && (node.hasAttribute("hidden") || node.getAttribute("aria-hidden") === "true")) {
+              return NodeFilter.FILTER_REJECT;
+            }
+            // Cheap inline-style visibility check (computed styles for every
+            // element would be too slow on large pages).
+            if (
+              node.style &&
+              (node.style.display === "none" || node.style.visibility === "hidden")
+            ) {
+              return NodeFilter.FILTER_REJECT;
+            }
+            if (node === overlayRoot) return NodeFilter.FILTER_REJECT;
+            return NodeFilter.FILTER_SKIP;
+          }
+          return NodeFilter.FILTER_ACCEPT;
+        },
+      }
+    );
+
+    var n;
+    while ((n = walker.nextNode())) {
+      var t = n.nodeValue;
+      if (!t) continue;
+      var start = rawText.length;
+      rawText += t;
+      entries.push({ node: n, start: start, end: rawText.length });
+    }
+
+    // Build the whitespace-collapsed view with a norm->raw index map.
+    var lastWasSpace = true;
+    for (var i = 0; i < rawText.length; i++) {
+      var isSpace = isSpaceCode(rawText.charCodeAt(i));
+      if (isSpace) {
+        if (!lastWasSpace) {
+          normText += " ";
+          normMap.push(i);
+          lastWasSpace = true;
+        }
+      } else {
+        normText += rawText[i];
+        normMap.push(i);
+        lastWasSpace = false;
+      }
+    }
+  }
+
+  function buildPages() {
+    pages = [];
+    pageTops = null;
+    var total = normText.length;
+    if (total === 0) {
+      pages.push({ number: 1, start: 0, end: 0, normStart: 0, normEnd: 0, text: "" });
+      return;
+    }
+
+    var cursor = 0;
+    while (cursor < total && pages.length < MAX_PAGES) {
+      var end = Math.min(cursor + PAGE_TARGET_CHARS, total);
+      if (end < total) {
+        // Prefer breaking at a sentence, then any space, inside the last 40%.
+        var slice = normText.slice(cursor, end);
+        var minBreak = Math.floor(slice.length * 0.6);
+        var sentence = slice.lastIndexOf(". ");
+        var space = slice.lastIndexOf(" ");
+        var breakAt = sentence > minBreak ? sentence + 1 : space > minBreak ? space : slice.length;
+        end = cursor + breakAt;
+      }
+      if (pages.length === MAX_PAGES - 1) end = total; // merge remainder
+      pages.push({
+        number: pages.length + 1,
+        start: normMap[cursor],
+        end: normMap[end - 1] + 1,
+        normStart: cursor,
+        normEnd: end,
+        text: normText.slice(cursor, end).trim(),
+      });
+      cursor = end;
+      while (cursor < total && normText[cursor] === " ") cursor++;
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Raw offset <-> DOM Range mapping
+  // ------------------------------------------------------------------
+
+  function entryIndexForRaw(offset) {
+    var lo = 0;
+    var hi = entries.length - 1;
+    while (lo <= hi) {
+      var mid = (lo + hi) >> 1;
+      var e = entries[mid];
+      if (offset < e.start) hi = mid - 1;
+      else if (offset >= e.end) lo = mid + 1;
+      else return mid;
+    }
+    return -1;
+  }
+
+  function rangeFromRaw(start, end) {
+    if (entries.length === 0) return null;
+    start = Math.max(0, Math.min(start, rawText.length - 1));
+    end = Math.max(start + 1, Math.min(end, rawText.length));
+    var si = entryIndexForRaw(start);
+    var ei = entryIndexForRaw(end - 1);
+    if (si === -1 || ei === -1) return null;
+    var se = entries[si];
+    var ee = entries[ei];
+    try {
+      var range = document.createRange();
+      range.setStart(se.node, start - se.start);
+      range.setEnd(ee.node, end - ee.start);
+      return range;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  function rawOffsetOfBoundary(container, offset) {
+    if (container.nodeType === 3) {
+      for (var i = 0; i < entries.length; i++) {
+        if (entries[i].node === container) return entries[i].start + offset;
+      }
+      return null;
+    }
+    // Element boundary: find the first text entry at/after the boundary point.
+    var probe = document.createRange();
+    try {
+      probe.setStart(container, offset);
+      probe.collapse(true);
+    } catch (err) {
+      return null;
+    }
+    for (var j = 0; j < entries.length; j++) {
+      try {
+        // comparePoint: -1 = entry before the boundary, 0/1 = at or after.
+        // We want the first entry at/after the boundary point.
+        if (probe.comparePoint(entries[j].node, 0) >= 0) return entries[j].start;
+      } catch (err2) {
+        /* node not comparable (detached) */
+      }
+    }
+    return rawText.length;
+  }
+
+  function pageForRaw(offset) {
+    for (var i = pages.length - 1; i >= 0; i--) {
+      if (offset >= pages[i].start) return pages[i].number;
+    }
+    return 1;
+  }
+
+  function normalizeStr(s) {
+    return (s || "").replace(/\s+/g, " ").trim().toLowerCase();
+  }
+
+  // Collapse whitespace runs to single spaces without lowercasing or trimming.
+  function collapseWs(s) {
+    return (s || "").replace(/\s+/g, " ");
+  }
+
+  // Case-insensitive search is only safe when lowercasing preserves string
+  // length — Unicode case folds like İ (U+0130) expand, which would desync
+  // indexes into normMap and corrupt anchor offsets. When folding changes
+  // either side's length, fall back to case-sensitive matching.
+  function searchPair(needleRaw) {
+    var hayFolded = normText.toLowerCase();
+    var needleFolded = needleRaw.toLowerCase();
+    if (
+      hayFolded.length !== normText.length ||
+      needleFolded.length !== needleRaw.length
+    ) {
+      return { hay: normText, needle: needleRaw, folded: false };
+    }
+    return { hay: hayFolded, needle: needleFolded, folded: true };
+  }
+
+  // Text-quote anchor context (W3C-style) around a raw-offset range:
+  // normalized prefix/suffix, ~32 chars each side, drawn from up to 200 raw
+  // chars of surrounding text. Case is preserved; lowercase only to compare.
+  function quoteContext(start, end) {
+    var prefix = collapseWs(rawText.slice(Math.max(0, start - 200), start));
+    var suffix = collapseWs(rawText.slice(end, end + 200));
+    if (prefix.length > 32) prefix = prefix.slice(prefix.length - 32);
+    if (suffix.length > 32) suffix = suffix.slice(0, 32);
+    return { prefix: prefix, suffix: suffix };
+  }
+
+  // ------------------------------------------------------------------
+  // Point anchors (bookmarks at an arbitrary reading position)
+  // ------------------------------------------------------------------
+
+  // Mirrors JS /\s/ so the text map and the collapse-based needle
+  // normalization agree; a mismatch (e.g. thin/ideographic spaces) would make
+  // locate/re-anchor searches miss on pages that use them.
+  function isSpaceCode(code) {
+    return (
+      code <= 32 ||
+      code === 160 ||
+      code === 0x1680 ||
+      (code >= 0x2000 && code <= 0x200a) ||
+      code === 0x2028 ||
+      code === 0x2029 ||
+      code === 0x202f ||
+      code === 0x205f ||
+      code === 0x3000 ||
+      code === 0xfeff
+    );
+  }
+
+  // A fixed/sticky ancestor means the node is pinned to the viewport (header,
+  // nav, cookie bar) rather than scrolling with the article. Such nodes must
+  // never anchor a "bookmark this spot" — they'd resolve to the same place at
+  // every scroll position.
+  function isPinned(node) {
+    var el = node && node.nodeType === 3 ? node.parentElement : node;
+    while (el && el !== document.body && el !== document.documentElement) {
+      var pos;
+      try {
+        pos = window.getComputedStyle(el).position;
+      } catch (err) {
+        pos = "";
+      }
+      if (pos === "fixed" || pos === "sticky") return true;
+      el = el.parentElement;
+    }
+    return false;
+  }
+
+  // Raw offset for the caret at a viewport point, or null if the point misses
+  // text or lands on pinned (fixed/sticky) chrome.
+  function rawOffsetAtPoint(x, y) {
+    var range = null;
+    if (document.caretRangeFromPoint) {
+      range = document.caretRangeFromPoint(x, y);
+    } else if (document.caretPositionFromPoint) {
+      var pos = document.caretPositionFromPoint(x, y);
+      if (pos && pos.offsetNode) {
+        try {
+          range = document.createRange();
+          range.setStart(pos.offsetNode, pos.offset);
+        } catch (err) {
+          range = null;
+        }
+      }
+    }
+    if (!range) return null;
+    if (isPinned(range.startContainer)) return null;
+    return rawOffsetOfBoundary(range.startContainer, range.startOffset);
+  }
+
+  // Anchor for "bookmark this spot": the first flowing text at the top of the
+  // viewport, described the same way as a highlight (raw offsets + snippet +
+  // text-quote context) so it re-anchors after reflows and re-renders. We scan
+  // downward from the top edge so a pinned header doesn't hijack the anchor,
+  // and validate that the chosen offset actually renders at the current scroll
+  // position before trusting it.
+  function captureViewportAnchor() {
+    if (rawText.length === 0) return null;
+
+    var xs = [Math.floor(window.innerWidth / 2), 24, Math.max(24, window.innerWidth - 24)];
+    var scrollTop = window.scrollY;
+    var start = null;
+
+    // Probe progressively further down the viewport until we hit real,
+    // non-pinned text that sits at/after the current scroll position.
+    for (var y = 8; y < window.innerHeight * 0.9 && start === null; y += 16) {
+      for (var xi = 0; xi < xs.length && start === null; xi++) {
+        var candidate = rawOffsetAtPoint(xs[xi], y);
+        if (candidate === null) continue;
+        var probe = rangeFromRaw(candidate, Math.min(rawText.length, candidate + 1));
+        if (!probe) continue;
+        // A caret over non-text content resolves to a *nearby* text node,
+        // which may itself be pinned chrome — recheck the resolved node, not
+        // just where the caret landed.
+        if (isPinned(probe.startContainer)) continue;
+        var docTop = probe.getBoundingClientRect().top + scrollTop;
+        // Reject anything that resolves above the viewport top (stale).
+        if (docTop >= scrollTop - 4) start = candidate;
+      }
+    }
+
+    if (start === null) {
+      // Hit-testing failed everywhere (e.g. an image fills the viewport top):
+      // fall back to the start of the current virtual page.
+      if (!pageTops) computePageTops();
+      start = pages.length > 0 ? pages[0].start : 0;
+      for (var i = pages.length - 1; i >= 0; i--) {
+        if (pageTops[i] <= scrollTop + 16) {
+          start = pages[i].start;
+          break;
+        }
+      }
+    }
+
+    while (start < rawText.length && isSpaceCode(rawText.charCodeAt(start))) start++;
+    if (start >= rawText.length) start = Math.max(0, rawText.length - 1);
+    var end = Math.min(rawText.length, start + 160);
+    var text = collapseWs(rawText.slice(start, end)).trim();
+    if (!text) return null;
+
+    // Where the anchor text sits in the viewport right now. Non-text content
+    // (images, figures) can push the first text well below the viewport top;
+    // restoring to this offset puts the whole captured view back, not just
+    // the text.
+    var viewportY = 16;
+    var anchorRange = rangeFromRaw(start, Math.min(rawText.length, start + 1));
+    if (anchorRange) {
+      var anchorTop = anchorRange.getBoundingClientRect().top;
+      if (isFinite(anchorTop)) {
+        viewportY = Math.max(0, Math.min(window.innerHeight, anchorTop));
+      }
+    }
+
+    var ctx = quoteContext(start, end);
+    return {
+      start: start,
+      end: end,
+      text: text,
+      prefix: ctx.prefix,
+      suffix: ctx.suffix,
+      offset: viewportY,
+      pageNumber: pageForRaw(start),
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Highlight overlays (document-coordinate divs; pointer-events: none)
+  // ------------------------------------------------------------------
+
+  function ensureOverlayRoot() {
+    if (overlayRoot && overlayRoot.isConnected) return overlayRoot;
+    overlayRoot = document.createElement("div");
+    overlayRoot.id = "__vellum-highlights";
+    overlayRoot.setAttribute("aria-hidden", "true");
+    overlayRoot.style.cssText =
+      "position:absolute;left:0;top:0;width:0;height:0;overflow:visible;" +
+      "pointer-events:none;z-index:2147483646;";
+    (document.documentElement || document.body).appendChild(overlayRoot);
+    return overlayRoot;
+  }
+
+  function resolveHighlight(h) {
+    var normSel = normalizeStr(h.text);
+    if (
+      typeof h.start === "number" &&
+      typeof h.end === "number" &&
+      h.end > h.start &&
+      h.end <= rawText.length
+    ) {
+      var current = normalizeStr(rawText.slice(h.start, h.end));
+      if (normSel && current === normSel) return { start: h.start, end: h.end };
+      if (!normSel) return { start: h.start, end: h.end };
+    }
+    if (!normSel) return null;
+
+    // Score every occurrence: distance from the offset hint, minus a large
+    // bonus per matching side of the stored text-quote context. Occurrences
+    // whose surroundings match the annotation's prefix/suffix win even when
+    // the page has shifted the raw offsets a long way.
+    var CONTEXT_BONUS = 100000;
+    var pair = searchPair(collapseWs(h.text).trim());
+    var hay = pair.hay;
+    var needle = pair.needle;
+    var hPrefix = typeof h.prefix === "string" ? collapseWs(h.prefix) : "";
+    var hSuffix = typeof h.suffix === "string" ? collapseWs(h.suffix) : "";
+    if (pair.folded) {
+      hPrefix = hPrefix.toLowerCase();
+      hSuffix = hSuffix.toLowerCase();
+    }
+    var best = -1;
+    var bestScore = Infinity;
+    var idx = hay.indexOf(needle);
+    while (idx !== -1) {
+      var rawStart = normMap[idx];
+      var score = typeof h.start === "number" ? Math.abs(rawStart - h.start) : idx;
+      if (hPrefix) {
+        var before = hay.slice(Math.max(0, idx - hPrefix.length), idx);
+        if (before && hPrefix.slice(hPrefix.length - before.length) === before) {
+          score -= CONTEXT_BONUS;
+        }
+      }
+      if (hSuffix) {
+        var afterStart = idx + needle.length;
+        var after = hay.slice(afterStart, afterStart + hSuffix.length);
+        if (after && hSuffix.slice(0, after.length) === after) {
+          score -= CONTEXT_BONUS;
+        }
+      }
+      if (score < bestScore) {
+        bestScore = score;
+        best = idx;
+      }
+      idx = hay.indexOf(needle, idx + 1);
+    }
+    if (best === -1) return null;
+    return {
+      start: normMap[best],
+      end: normMap[best + needle.length - 1] + 1,
+    };
+  }
+
+  function renderHighlights() {
+    var root = ensureOverlayRoot();
+    while (root.firstChild) root.removeChild(root.firstChild);
+
+    for (var i = 0; i < appliedHighlights.length; i++) {
+      var h = appliedHighlights[i];
+      var resolved = resolveHighlight(h);
+      if (!resolved) continue;
+      var range = rangeFromRaw(resolved.start, resolved.end);
+      if (!range) continue;
+      var rects = range.getClientRects();
+      for (var r = 0; r < rects.length; r++) {
+        var rect = rects[r];
+        if (rect.width < 1 || rect.height < 1) continue;
+        var div = document.createElement("div");
+        div.setAttribute("data-vellum-id", h.id);
+        div.style.cssText =
+          "position:absolute;pointer-events:none;border-radius:2px;" +
+          "mix-blend-mode:multiply;opacity:0.55;";
+        div.style.left = rect.left + window.scrollX + "px";
+        div.style.top = rect.top + window.scrollY + "px";
+        div.style.width = rect.width + "px";
+        div.style.height = rect.height + "px";
+        try {
+          div.style.backgroundColor = h.color || "#fef08a";
+        } catch (err) {
+          div.style.backgroundColor = "#fef08a";
+        }
+        root.appendChild(div);
+      }
+    }
+  }
+
+  var relayout = debounce(function () {
+    pageTops = null;
+    renderHighlights();
+    reportScroll(true);
+  }, 250);
+
+  // ------------------------------------------------------------------
+  // Virtual page positions & scroll reporting
+  // ------------------------------------------------------------------
+
+  function computePageTops() {
+    pageTops = [];
+    for (var i = 0; i < pages.length; i++) {
+      var p = pages[i];
+      var range = rangeFromRaw(p.start, Math.min(p.start + 1, p.end || p.start + 1));
+      var top = 0;
+      if (range) {
+        var rect = range.getBoundingClientRect();
+        top = rect.top + window.scrollY;
+      }
+      // Keep tops monotonically increasing so lookup is well-defined.
+      if (i > 0 && top < pageTops[i - 1]) top = pageTops[i - 1];
+      pageTops.push(top);
+    }
+  }
+
+  var lastReported = { current: 0, visible: "" };
+
+  function reportScroll(force) {
+    if (pages.length === 0) return;
+    if (!pageTops) computePageTops();
+    var viewTop = window.scrollY;
+    var viewBottom = viewTop + window.innerHeight;
+    var anchor = viewTop + window.innerHeight * 0.35;
+
+    var current = 1;
+    var visible = [];
+    for (var i = 0; i < pages.length; i++) {
+      var top = pageTops[i];
+      var bottom = i + 1 < pageTops.length ? pageTops[i + 1] : Infinity;
+      if (top <= anchor) current = pages[i].number;
+      if (top < viewBottom && bottom > viewTop) visible.push(pages[i].number);
+    }
+    if (visible.length === 0) visible = [current];
+
+    var visibleKey = visible.join(",");
+    if (!force && current === lastReported.current && visibleKey === lastReported.visible) return;
+    lastReported = { current: current, visible: visibleKey };
+    // Raw-offset span of the visible virtual pages, so the app shell can tell
+    // whether a point bookmark is currently on screen.
+    var firstPage = pages[visible[0] - 1];
+    var lastPage = pages[visible[visible.length - 1] - 1];
+    post("scroll", {
+      currentPage: current,
+      visiblePages: visible,
+      visibleStart: firstPage ? firstPage.start : 0,
+      visibleEnd: lastPage ? lastPage.end : 0,
+    });
+  }
+
+  var scrollTicking = false;
+  function onScroll() {
+    if (scrollTicking) return;
+    scrollTicking = true;
+    requestAnimationFrame(function () {
+      scrollTicking = false;
+      // Unconditional (reportScroll dedupes): the app shell hides the
+      // selection popover, whose position is viewport-anchored.
+      post("viewport-scrolled");
+      reportScroll(false);
+    });
+  }
+
+  function scrollToVirtualPage(pageNumber) {
+    if (!pageTops) computePageTops();
+    var idx = Math.max(1, Math.min(pages.length, pageNumber)) - 1;
+    window.scrollTo({ top: Math.max(0, pageTops[idx] - 12), behavior: "auto" });
+  }
+
+  // ------------------------------------------------------------------
+  // Selection reporting
+  // ------------------------------------------------------------------
+
+  function reportSelection() {
+    var sel = window.getSelection();
+    if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
+      post("selection-cleared");
+      return;
+    }
+    var text = sel.toString().replace(/\s+/g, " ").trim();
+    if (!text) {
+      post("selection-cleared");
+      return;
+    }
+    var range = sel.getRangeAt(0);
+    var rects = range.getClientRects();
+    if (rects.length === 0) return;
+
+    var start = rawOffsetOfBoundary(range.startContainer, range.startOffset);
+    var end = rawOffsetOfBoundary(range.endContainer, range.endOffset);
+    if (start === null || end === null || end <= start) return;
+
+    var mapped = [];
+    for (var i = 0; i < rects.length && i < 60; i++) {
+      mapped.push({
+        x: rects[i].left,
+        y: rects[i].top,
+        width: rects[i].width,
+        height: rects[i].height,
+      });
+    }
+
+    var ctx = quoteContext(start, end);
+    post("selection", {
+      text: text,
+      start: start,
+      end: end,
+      pageNumber: pageForRaw(start),
+      rects: mapped,
+      prefix: ctx.prefix,
+      suffix: ctx.suffix,
+    });
+  }
+
+  document.addEventListener("mouseup", function () {
+    setTimeout(reportSelection, 30);
+  });
+
+  document.addEventListener(
+    "selectionchange",
+    debounce(function () {
+      var sel = window.getSelection();
+      if (!sel || sel.isCollapsed) post("selection-cleared");
+    }, 200)
+  );
+
+  // ------------------------------------------------------------------
+  // Link interception — keep navigation inside the proxy
+  // ------------------------------------------------------------------
+
+  document.addEventListener(
+    "click",
+    function (e) {
+      if (e.defaultPrevented) return;
+      var target = e.target;
+      if (!target || !target.closest) return;
+      var link = target.closest("a[href]");
+      if (!link) return;
+
+      var rawHref = link.getAttribute("href") || "";
+      if (rawHref.charAt(0) === "#") return; // same-document anchor
+
+      // SVG <a> exposes href as SVGAnimatedString; without unwrapping it the
+      // regex tests fail and the click would navigate the iframe out of the
+      // proxy entirely.
+      var href = link.href;
+      if (href && typeof href === "object" && typeof href.baseVal === "string") {
+        try {
+          href = new URL(href.baseVal, document.baseURI).href;
+        } catch (err) {
+          href = "";
+        }
+      }
+      if (/^https?:/i.test(href)) {
+        e.preventDefault();
+        e.stopPropagation();
+        post("navigate", { url: href });
+      } else if (/^(mailto|tel):/i.test(href)) {
+        e.preventDefault();
+      }
+    },
+    true
+  );
+
+  // GET form submissions (e.g. site search) become proxied navigations.
+  document.addEventListener(
+    "submit",
+    function (e) {
+      var form = e.target;
+      if (!form || !form.action) return;
+      var method = (form.method || "get").toLowerCase();
+      if (method !== "get") return;
+      if (!/^https?:/i.test(form.action)) return;
+      e.preventDefault();
+      try {
+        var url = new URL(form.action);
+        var data = new FormData(form);
+        data.forEach(function (value, key) {
+          if (typeof value === "string") url.searchParams.append(key, value);
+        });
+        post("navigate", { url: url.toString() });
+      } catch (err) {
+        /* leave as-is */
+      }
+    },
+    true
+  );
+
+  window.open = function (u) {
+    try {
+      var abs = new URL(u, PAGE_URL).toString();
+      if (/^https?:/i.test(abs)) post("navigate", { url: abs });
+    } catch (err) {
+      /* ignore */
+    }
+    return null;
+  };
+
+  // ------------------------------------------------------------------
+  // Commands from the app shell
+  // ------------------------------------------------------------------
+
+  window.addEventListener("message", function (e) {
+    if (e.source !== window.parent) return;
+    var d = e.data;
+    if (!d || typeof d.vellumCmd !== "string") return;
+
+    switch (d.vellumCmd) {
+      case "scroll-to-page":
+        scrollToVirtualPage(Number(d.page) || 1);
+        break;
+
+      case "apply-annotations":
+        appliedHighlights = Array.isArray(d.highlights) ? d.highlights : [];
+        renderHighlights();
+        break;
+
+      case "scroll-to-annotation": {
+        var match = null;
+        for (var i = 0; i < appliedHighlights.length; i++) {
+          if (appliedHighlights[i].id === d.id) {
+            match = resolveHighlight(appliedHighlights[i]);
+            break;
+          }
+        }
+        if (match) {
+          var range = rangeFromRaw(match.start, match.end);
+          if (range) {
+            var rect = range.getBoundingClientRect();
+            window.scrollTo({
+              top: Math.max(0, rect.top + window.scrollY - window.innerHeight * 0.3),
+              behavior: "auto",
+            });
+          }
+        }
+        break;
+      }
+
+      case "locate-text": {
+        var found = null;
+        var locateRaw = collapseWs(d.text || "").trim();
+        if (locateRaw) {
+          var locatePair = searchPair(locateRaw);
+          var hay = locatePair.hay;
+          var needle = locatePair.needle;
+          var pageIdx = Math.max(1, Math.min(pages.length, Number(d.page) || 1)) - 1;
+          var page = pages[pageIdx];
+          var from = page ? page.normStart : 0;
+          var idx = hay.indexOf(needle, from);
+          if (idx === -1 || (page && idx >= page.normEnd)) idx = hay.indexOf(needle);
+          if (idx !== -1) {
+            found = {
+              start: normMap[idx],
+              end: normMap[idx + needle.length - 1] + 1,
+            };
+          }
+        }
+        var foundCtx = found ? quoteContext(found.start, found.end) : null;
+        post("locate-result", {
+          requestId: d.requestId,
+          found: !!found,
+          start: found ? found.start : null,
+          end: found ? found.end : null,
+          prefix: foundCtx ? foundCtx.prefix : null,
+          suffix: foundCtx ? foundCtx.suffix : null,
+          // The whole-document fallback may land on a different virtual page
+          // than requested; report where the text actually is.
+          pageNumber: found ? pageForRaw(found.start) : null,
+        });
+        break;
+      }
+
+      case "capture-position": {
+        var anchor = captureViewportAnchor();
+        post("position-result", {
+          requestId: d.requestId,
+          found: !!anchor,
+          start: anchor ? anchor.start : null,
+          end: anchor ? anchor.end : null,
+          text: anchor ? anchor.text : null,
+          prefix: anchor ? anchor.prefix : null,
+          suffix: anchor ? anchor.suffix : null,
+          offset: anchor ? anchor.offset : null,
+          pageNumber: anchor ? anchor.pageNumber : null,
+        });
+        break;
+      }
+
+      case "scroll-to-position": {
+        var posPayload = {
+          start: typeof d.start === "number" ? d.start : null,
+          end: typeof d.end === "number" ? d.end : null,
+          text: typeof d.text === "string" ? d.text : "",
+          prefix: typeof d.prefix === "string" ? d.prefix : null,
+          suffix: typeof d.suffix === "string" ? d.suffix : null,
+        };
+        var anchorOffset = typeof d.offset === "number" ? d.offset : 16;
+
+        var desiredTop = function () {
+          var resolved = resolveHighlight(posPayload);
+          var range = resolved ? rangeFromRaw(resolved.start, resolved.end) : null;
+          if (!range) return null;
+          return Math.max(0, range.getBoundingClientRect().top + window.scrollY - anchorOffset);
+        };
+
+        var firstTop = desiredTop();
+        if (firstTop === null) {
+          if (typeof d.page === "number") scrollToVirtualPage(d.page);
+          break;
+        }
+        window.scrollTo({ top: firstTop, behavior: "auto" });
+        // scrollTo clamps at the document end; remember where we landed.
+        var expectedY = window.scrollY;
+
+        // Late-loading content above the anchor (lazy images, ads) shifts
+        // layout after the jump. Re-correct briefly, but back off as soon as
+        // the user scrolls somewhere else themselves.
+        var settle = function () {
+          if (Math.abs(window.scrollY - expectedY) > 150) return;
+          var top = desiredTop();
+          if (top !== null && Math.abs(top - window.scrollY) > 24) {
+            window.scrollTo({ top: top, behavior: "auto" });
+            expectedY = window.scrollY;
+          }
+        };
+        setTimeout(settle, 400);
+        setTimeout(settle, 1200);
+        break;
+      }
+
+      case "clear-selection": {
+        var sel = window.getSelection();
+        if (sel) sel.removeAllRanges();
+        break;
+      }
+
+      case "history":
+        try {
+          history.go(Number(d.delta) || 0);
+        } catch (err) {
+          /* ignore */
+        }
+        break;
+
+      case "request-init":
+        initialize(true);
+        break;
+    }
+  });
+
+  // ------------------------------------------------------------------
+  // Init
+  // ------------------------------------------------------------------
+
+  function sendInit() {
+    post("init", {
+      url: PAGE_URL,
+      title: document.title || null,
+      offline: !!window.__VELLUM_OFFLINE__,
+      // Capability handshake: this script understands capture-position /
+      // scroll-to-position. Lets the app shell degrade to page bookmarks
+      // when an older embedded script is running.
+      positionAnchors: true,
+      pageCount: pages.length,
+      pages: pages.map(function (p) {
+        return { number: p.number, text: p.text };
+      }),
+    });
+    reportScroll(true);
+  }
+
+  function initialize(force) {
+    var previousLength = rawText.length;
+    buildTextMap();
+    buildPages();
+    if (!initialized || force || Math.abs(rawText.length - previousLength) > previousLength * 0.15) {
+      initialized = true;
+      sendInit();
+    }
+    renderHighlights();
+  }
+
+  var started = false;
+
+  function start() {
+    if (started) return;
+    started = true;
+    initialize(true);
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", relayout);
+    if (window.ResizeObserver && document.body) {
+      new ResizeObserver(relayout).observe(document.body);
+    }
+    if (document.fonts && document.fonts.ready) {
+      document.fonts.ready.then(function () {
+        relayout();
+      });
+    }
+
+    // SPA re-renders detach the text nodes our entries point at, which would
+    // silently kill highlights and freeze the text map. Re-extract (debounced)
+    // on subtree mutations, ignoring our own overlay churn. Observing the
+    // documentElement survives full <body> replacement.
+    if (window.MutationObserver) {
+      var remap = debounce(function () {
+        initialize(false); // resends init only if the text changed >15%
+        pageTops = null;
+        renderHighlights();
+        reportScroll(true);
+      }, 600);
+      new MutationObserver(function (records) {
+        for (var i = 0; i < records.length; i++) {
+          var target = records[i].target;
+          if (overlayRoot && (target === overlayRoot || overlayRoot.contains(target))) {
+            continue;
+          }
+          remap();
+          return;
+        }
+      }).observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+      });
+    }
+
+    // Late-rendering pages (client-side hydration): re-extract once settled.
+    setTimeout(function () {
+      initialize(false);
+    }, 2000);
+  }
+
+  if (document.readyState === "complete") {
+    start();
+  } else {
+    window.addEventListener("load", start);
+    // Fall back in case load stalls on a slow subresource.
+    setTimeout(start, 4000);
+  }
+})();

--- a/src-tauri/assets/vellum-content-script.js
+++ b/src-tauri/assets/vellum-content-script.js
@@ -33,6 +33,10 @@
   var overlayRoot = null;
   var appliedHighlights = []; // [{ id, color, start, end, text, prefix, suffix }]
   var appliedNotes = []; // same anchor shape + { content } for the marker tooltip
+  // Point bookmarks: same anchor shape. Re-resolved against the current DOM
+  // so the "bookmarked here?" toolbar state survives restarts and reflows.
+  var appliedBookmarks = [];
+  var resolvedBookmarks = []; // [{ id, start }] after re-anchoring
   var noteMode = false;
   var initialized = false;
 
@@ -482,9 +486,20 @@
     };
   }
 
+  function resolveBookmarks() {
+    resolvedBookmarks = [];
+    for (var i = 0; i < appliedBookmarks.length; i++) {
+      var resolved = resolveHighlight(appliedBookmarks[i]);
+      if (resolved) {
+        resolvedBookmarks.push({ id: appliedBookmarks[i].id, start: resolved.start });
+      }
+    }
+  }
+
   function renderHighlights() {
     var root = ensureOverlayRoot();
     while (root.firstChild) root.removeChild(root.firstChild);
+    resolveBookmarks();
 
     for (var i = 0; i < appliedHighlights.length; i++) {
       var h = appliedHighlights[i];
@@ -605,7 +620,7 @@
     }
   }
 
-  var lastReported = { current: 0, visible: "" };
+  var lastReported = { current: 0, visible: "", bookmarks: "" };
 
   function reportScroll(force) {
     if (pages.length === 0) return;
@@ -624,11 +639,36 @@
     }
     if (visible.length === 0) visible = [current];
 
+    // Point bookmarks actually on screen right now: check each re-anchored
+    // bookmark's rendered position against the viewport. This is precise to
+    // the visible text (a virtual-page span would light the toolbar star for
+    // an entire ~3600-char page — or the whole document on short articles).
+    var visibleBookmarks = [];
+    for (var bi = 0; bi < resolvedBookmarks.length; bi++) {
+      var bookmarkRange = rangeFromRaw(
+        resolvedBookmarks[bi].start,
+        resolvedBookmarks[bi].start + 1
+      );
+      if (!bookmarkRange) continue;
+      var bookmarkRect = bookmarkRange.getBoundingClientRect();
+      if (bookmarkRect.bottom > 0 && bookmarkRect.top < window.innerHeight) {
+        visibleBookmarks.push(resolvedBookmarks[bi].id);
+      }
+    }
+    var bookmarksKey = visibleBookmarks.join(",");
+
     var visibleKey = visible.join(",");
-    if (!force && current === lastReported.current && visibleKey === lastReported.visible) return;
-    lastReported = { current: current, visible: visibleKey };
-    // Raw-offset span of the visible virtual pages, so the app shell can tell
-    // whether a point bookmark is currently on screen.
+    if (
+      !force &&
+      current === lastReported.current &&
+      visibleKey === lastReported.visible &&
+      bookmarksKey === lastReported.bookmarks
+    ) {
+      return;
+    }
+    lastReported = { current: current, visible: visibleKey, bookmarks: bookmarksKey };
+    // Raw-offset span of the visible virtual pages (legacy fallback for the
+    // app shell when visibleBookmarks is absent).
     var firstPage = pages[visible[0] - 1];
     var lastPage = pages[visible[visible.length - 1] - 1];
     post("scroll", {
@@ -636,6 +676,7 @@
       visiblePages: visible,
       visibleStart: firstPage ? firstPage.start : 0,
       visibleEnd: lastPage ? lastPage.end : 0,
+      visibleBookmarks: visibleBookmarks,
     });
   }
 
@@ -886,7 +927,10 @@
       case "apply-annotations":
         appliedHighlights = Array.isArray(d.highlights) ? d.highlights : [];
         appliedNotes = Array.isArray(d.notes) ? d.notes : [];
+        appliedBookmarks = Array.isArray(d.bookmarks) ? d.bookmarks : [];
         renderHighlights();
+        // Bookmark visibility may have changed with the new set.
+        reportScroll(true);
         break;
 
       case "set-mode": {

--- a/src-tauri/assets/vellum-content-script.js
+++ b/src-tauri/assets/vellum-content-script.js
@@ -31,7 +31,9 @@
   var pages = []; // [{ number, start(raw), end(raw), normStart, normEnd, text }]
   var pageTops = null; // cached document-Y of each page start
   var overlayRoot = null;
-  var appliedHighlights = []; // [{ id, color, start, end, text }]
+  var appliedHighlights = []; // [{ id, color, start, end, text, prefix, suffix }]
+  var appliedNotes = []; // same anchor shape + { content } for the marker tooltip
+  var noteMode = false;
   var initialized = false;
 
   function post(type, payload) {
@@ -511,6 +513,70 @@
         root.appendChild(div);
       }
     }
+
+    // Sticky-note markers: a small clickable badge at the note's anchor. The
+    // full note UI lives in the app-shell sidebar; clicking a marker selects
+    // the note there. Notes sharing an anchor fan out so none is buried.
+    var seenAnchors = {};
+    for (var ni = 0; ni < appliedNotes.length; ni++) {
+      renderNoteMarker(root, appliedNotes[ni], seenAnchors);
+    }
+  }
+
+  function renderNoteMarker(root, note, seenAnchors) {
+    var resolved = resolveHighlight(note);
+    if (!resolved) return;
+    var anchorKey = String(resolved.start);
+    var duplicateIndex = seenAnchors[anchorKey] || 0;
+    seenAnchors[anchorKey] = duplicateIndex + 1;
+    var range = rangeFromRaw(resolved.start, Math.min(resolved.start + 1, resolved.end));
+    if (!range) return;
+    var rect = range.getBoundingClientRect();
+    if (!isFinite(rect.top) || (rect.width === 0 && rect.height === 0 && rect.top === 0)) {
+      return;
+    }
+
+    var marker = document.createElement("div");
+    marker.setAttribute("data-vellum-note", note.id);
+    marker.style.cssText =
+      "position:absolute;pointer-events:auto;cursor:pointer;width:18px;height:18px;" +
+      "border-radius:4px 4px 4px 1px;background:#fbbf24;border:1px solid #b4530999;" +
+      "box-shadow:0 1px 3px rgba(0,0,0,0.25);display:flex;align-items:center;" +
+      "justify-content:center;font-size:11px;line-height:1;user-select:none;";
+    marker.textContent = "✎"; // pencil
+    // Sit in the margin just left of the anchored text when there's room;
+    // when the text touches the edge, float just above the line instead of
+    // covering the words. Duplicate anchors fan out downward.
+    var left = rect.left + window.scrollX - 24;
+    var top = rect.top + window.scrollY + Math.max(0, (rect.height - 18) / 2);
+    if (left < 2) {
+      left = Math.max(2, rect.left + window.scrollX - 2);
+      top = rect.top + window.scrollY - 20;
+      if (top < 2) top = rect.top + window.scrollY + rect.height + 2;
+    }
+    top += duplicateIndex * 22;
+    marker.style.left = left + "px";
+    marker.style.top = top + "px";
+    if (note.content) {
+      marker.title = String(note.content).slice(0, 200);
+    }
+    marker.addEventListener("mousedown", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    marker.addEventListener("click", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      // Viewport coords of the marker so the app shell can anchor the note
+      // viewer popover next to it.
+      var box = marker.getBoundingClientRect();
+      post("annotation-click", {
+        id: note.id,
+        x: box.left + box.width / 2,
+        y: box.top,
+      });
+    });
+    root.appendChild(marker);
   }
 
   var relayout = debounce(function () {
@@ -650,6 +716,87 @@
   );
 
   // ------------------------------------------------------------------
+  // Sticky-note placement (note mode click / right-click menu): anchor a
+  // note to the text under the pointer
+  // ------------------------------------------------------------------
+
+  // Text-quote anchor for the caret at/near a viewport point, or null when
+  // no anchorable text is nearby. Probes around the point so clicks in gaps
+  // (image margins, padding) still anchor.
+  function noteAnchorAtPoint(clientX, clientY) {
+    if (rawText.length === 0) return null;
+    var offset = null;
+    var probes = [
+      [clientX, clientY],
+      [clientX - 40, clientY],
+      [clientX + 40, clientY],
+      [clientX, clientY - 20],
+      [clientX, clientY + 20],
+    ];
+    for (var i = 0; i < probes.length && offset === null; i++) {
+      offset = rawOffsetAtPoint(probes[i][0], probes[i][1]);
+    }
+    if (offset === null) return null;
+
+    var start = Math.max(0, Math.min(offset, rawText.length - 1));
+    while (start < rawText.length && isSpaceCode(rawText.charCodeAt(start))) start++;
+    if (start >= rawText.length) start = Math.max(0, rawText.length - 1);
+    // Snap back to the start of the word so the anchored quote doesn't begin
+    // mid-word ("ent on a hike..." instead of "went on a hike...").
+    while (start > 0 && !isSpaceCode(rawText.charCodeAt(start - 1))) start--;
+    var end = Math.min(rawText.length, start + 80);
+    // Finish the trailing word too (capped) so the quote ends cleanly.
+    var endCap = Math.min(rawText.length, start + 100);
+    while (end < endCap && !isSpaceCode(rawText.charCodeAt(end))) end++;
+    var snippet = collapseWs(rawText.slice(start, end)).trim();
+    if (!snippet) return null;
+
+    var ctx = quoteContext(start, end);
+    return {
+      start: start,
+      end: end,
+      text: snippet,
+      prefix: ctx.prefix,
+      suffix: ctx.suffix,
+      pageNumber: pageForRaw(start),
+    };
+  }
+
+  document.addEventListener(
+    "click",
+    function (e) {
+      if (!noteMode) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+
+      var anchor = noteAnchorAtPoint(e.clientX, e.clientY);
+      if (!anchor) return; // stay in note mode
+      anchor.x = e.clientX;
+      anchor.y = e.clientY;
+      post("note-placed", anchor);
+    },
+    true
+  );
+
+  // Right-click: replace the native menu with the app shell's context menu
+  // (mirrors the PDF viewer's "Add note here").
+  document.addEventListener(
+    "contextmenu",
+    function (e) {
+      var anchor = noteAnchorAtPoint(e.clientX, e.clientY);
+      e.preventDefault();
+      var payload = { x: e.clientX, y: e.clientY, found: !!anchor };
+      if (anchor) {
+        for (var k in anchor) payload[k] = anchor[k];
+        payload.x = e.clientX;
+        payload.y = e.clientY;
+      }
+      post("context-menu", payload);
+    },
+    true
+  );
+
+  // ------------------------------------------------------------------
   // Link interception — keep navigation inside the proxy
   // ------------------------------------------------------------------
 
@@ -657,6 +804,7 @@
     "click",
     function (e) {
       if (e.defaultPrevented) return;
+      if (noteMode) return; // note placement owns clicks in note mode
       var target = e.target;
       if (!target || !target.closest) return;
       var link = target.closest("a[href]");
@@ -737,15 +885,30 @@
 
       case "apply-annotations":
         appliedHighlights = Array.isArray(d.highlights) ? d.highlights : [];
+        appliedNotes = Array.isArray(d.notes) ? d.notes : [];
         renderHighlights();
         break;
 
+      case "set-mode": {
+        noteMode = d.mode === "note";
+        try {
+          document.documentElement.style.cursor = noteMode ? "crosshair" : "";
+        } catch (err) {
+          /* ignore */
+        }
+        break;
+      }
+
       case "scroll-to-annotation": {
         var match = null;
-        for (var i = 0; i < appliedHighlights.length; i++) {
-          if (appliedHighlights[i].id === d.id) {
-            match = resolveHighlight(appliedHighlights[i]);
-            break;
+        var annotationLists = [appliedHighlights, appliedNotes];
+        for (var li = 0; li < annotationLists.length && !match; li++) {
+          var list = annotationLists[li];
+          for (var i = 0; i < list.length; i++) {
+            if (list[i].id === d.id) {
+              match = resolveHighlight(list[i]);
+              break;
+            }
           }
         }
         if (match) {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
 use tauri::ipc::Response;
@@ -12,10 +12,33 @@ use tauri::State;
 use crate::models::*;
 use crate::pdf_annotations;
 use crate::pdf_session::{self, PdfSession};
+use crate::web_archive;
+use crate::web_page::{self, WebLibraryEntry, WebSession};
 
-/// Application state holding all open PDF tab sessions.
+/// A tab session: either an on-disk PDF or a proxied webpage.
+pub enum Session {
+    Pdf(PdfSession),
+    Web(WebSession),
+}
+
+/// Application state holding all open tab sessions.
 pub struct AppState {
-    pub sessions: Mutex<HashMap<String, PdfSession>>,
+    pub sessions: Mutex<HashMap<String, Session>>,
+}
+
+fn web_store_dir(app: &tauri::AppHandle) -> Result<PathBuf, String> {
+    use tauri::Manager;
+    app.path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to resolve app data dir: {}", e))
+}
+
+fn close_session(session: &Session) -> Result<(), String> {
+    match session {
+        Session::Pdf(pdf) => pdf_session::save_session(pdf),
+        // Webpage mutations are written to the sidecar immediately.
+        Session::Web(_) => Ok(()),
+    }
 }
 
 /// Open a PDF without creating a custom document container.
@@ -41,6 +64,7 @@ pub fn open_file(
     let (title, page_count, last_page) = pdf_annotations::document_info(&session.pdf_path)?;
 
     let info = DocumentInfo {
+        kind: "pdf".to_string(),
         pdf_path,
         title,
         page_count: Some(page_count),
@@ -49,9 +73,39 @@ pub fn open_file(
 
     let mut sessions = state.sessions.lock().map_err(|e| e.to_string())?;
     if let Some(prev) = sessions.remove(&session_id) {
-        pdf_session::save_session(&prev)?;
+        close_session(&prev)?;
     }
-    sessions.insert(session_id, session);
+    sessions.insert(session_id, Session::Pdf(session));
+
+    Ok(info)
+}
+
+/// Open a webpage as a tab session. Re-invoking with an existing session id
+/// rebinds that tab to a new URL (in-tab navigation).
+#[tauri::command]
+pub fn open_web_document(
+    url: String,
+    session_id: String,
+    app: tauri::AppHandle,
+    state: State<AppState>,
+) -> Result<DocumentInfo, String> {
+    let data_dir = web_store_dir(&app)?;
+    let (session, record) = web_page::open_session(&data_dir, &url)?;
+    let (title, page_count, last_page) = web_page::document_info(&record);
+
+    let info = DocumentInfo {
+        kind: "web".to_string(),
+        pdf_path: session.url.clone(),
+        title,
+        page_count,
+        last_page,
+    };
+
+    let mut sessions = state.sessions.lock().map_err(|e| e.to_string())?;
+    if let Some(prev) = sessions.remove(&session_id) {
+        close_session(&prev)?;
+    }
+    sessions.insert(session_id, Session::Web(session));
 
     Ok(info)
 }
@@ -63,7 +117,7 @@ pub fn save_file(session_id: String, state: State<AppState>) -> Result<(), Strin
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    pdf_session::save_session(session)
+    close_session(session)
 }
 
 /// Close a tab session.
@@ -71,7 +125,7 @@ pub fn save_file(session_id: String, state: State<AppState>) -> Result<(), Strin
 pub fn close_file(session_id: String, state: State<AppState>) -> Result<(), String> {
     let mut sessions = state.sessions.lock().map_err(|e| e.to_string())?;
     if let Some(prev) = sessions.remove(&session_id) {
-        pdf_session::save_session(&prev)?;
+        close_session(&prev)?;
     }
     Ok(())
 }
@@ -87,7 +141,10 @@ pub fn get_annotations(
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    pdf_annotations::get_annotations(&session.pdf_path, page_number)
+    match session {
+        Session::Pdf(pdf) => pdf_annotations::get_annotations(&pdf.pdf_path, page_number),
+        Session::Web(web) => web_page::get_annotations(web, page_number),
+    }
 }
 
 /// Create a new annotation
@@ -101,7 +158,10 @@ pub fn create_annotation(
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    pdf_annotations::create_annotation(&session.pdf_path, &input)
+    match session {
+        Session::Pdf(pdf) => pdf_annotations::create_annotation(&pdf.pdf_path, &input),
+        Session::Web(web) => web_page::create_annotation(web, &input),
+    }
 }
 
 /// Update an existing annotation
@@ -115,7 +175,10 @@ pub fn update_annotation(
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    pdf_annotations::update_annotation(&session.pdf_path, &input)
+    match session {
+        Session::Pdf(pdf) => pdf_annotations::update_annotation(&pdf.pdf_path, &input),
+        Session::Web(web) => web_page::update_annotation(web, &input),
+    }
 }
 
 /// Delete an annotation
@@ -129,7 +192,10 @@ pub fn delete_annotation(
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    pdf_annotations::delete_annotation(&session.pdf_path, &id)
+    match session {
+        Session::Pdf(pdf) => pdf_annotations::delete_annotation(&pdf.pdf_path, &id),
+        Session::Web(web) => web_page::delete_annotation(web, &id),
+    }
 }
 
 /// Set document metadata (e.g., page_count, last_page, title)
@@ -144,7 +210,10 @@ pub fn set_document_metadata(
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    pdf_annotations::set_metadata(&session.pdf_path, &key, &value)
+    match session {
+        Session::Pdf(pdf) => pdf_annotations::set_metadata(&pdf.pdf_path, &key, &value),
+        Session::Web(web) => web_page::set_metadata(web, &key, &value),
+    }
 }
 
 /// Read the PDF bytes for a tab session.
@@ -155,10 +224,301 @@ pub fn read_pdf_bytes(session_id: String, state: State<AppState>) -> Result<Resp
     let session = sessions
         .get(&session_id)
         .ok_or_else(|| format!("No session found for tab {}", session_id))?;
-    let pdf_path = session.pdf_path();
+    let pdf = match session {
+        Session::Pdf(pdf) => pdf,
+        Session::Web(_) => return Err("This tab is a webpage, not a PDF".to_string()),
+    };
+    let pdf_path = pdf.pdf_path();
     let bytes = std::fs::read(&pdf_path)
         .map_err(|e| format!("Failed to read PDF at {}: {}", pdf_path.display(), e))?;
     Ok(Response::new(bytes))
+}
+
+/// Mark the current webpage tab as saved (or unsaved) in the library.
+#[tauri::command]
+pub fn set_webpage_saved(
+    session_id: String,
+    saved: bool,
+    state: State<AppState>,
+) -> Result<(), String> {
+    let sessions = state.sessions.lock().map_err(|e| e.to_string())?;
+    let session = sessions
+        .get(&session_id)
+        .ok_or_else(|| format!("No session found for tab {}", session_id))?;
+    match session {
+        Session::Web(web) => web_page::set_saved(web, saved),
+        Session::Pdf(_) => Err("This tab is a PDF, not a webpage".to_string()),
+    }
+}
+
+/// Whether the current webpage tab is saved in the library.
+#[tauri::command]
+pub fn get_webpage_saved(session_id: String, state: State<AppState>) -> Result<bool, String> {
+    let sessions = state.sessions.lock().map_err(|e| e.to_string())?;
+    let session = sessions
+        .get(&session_id)
+        .ok_or_else(|| format!("No session found for tab {}", session_id))?;
+    match session {
+        Session::Web(web) => Ok(web_page::is_saved(web)),
+        Session::Pdf(_) => Ok(false),
+    }
+}
+
+/// List all saved webpages for the welcome screen library.
+#[tauri::command]
+pub fn list_saved_webpages(app: tauri::AppHandle) -> Result<Vec<WebLibraryEntry>, String> {
+    let data_dir = web_store_dir(&app)?;
+    Ok(web_page::list_saved(&data_dir))
+}
+
+/// Remove a webpage from the saved library (annotations are kept).
+#[tauri::command]
+pub fn remove_saved_webpage(url: String, app: tauri::AppHandle) -> Result<(), String> {
+    let data_dir = web_store_dir(&app)?;
+    web_page::remove_saved(&data_dir, &url)
+}
+
+/// Export (or update) a `.vellumweb` archive for a webpage tab.
+///
+/// Prefers a fresh live capture; falls back to the locally installed
+/// self-contained snapshot, then the plain saved snapshot. `pages` is the
+/// virtual-page text currently extracted by the reader (the AI context),
+/// bundled so external consumers get the text without re-parsing HTML.
+#[tauri::command]
+pub async fn export_vellumweb(
+    session_id: String,
+    dest_path: String,
+    pages: Vec<web_archive::PageText>,
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<web_archive::ExportSummary, String> {
+    let (url, record_path, snapshot_path) = web_session_paths(&state, &session_id)?;
+    let data_dir = web_store_dir(&app)?;
+    let dest = PathBuf::from(&dest_path);
+    write_web_archive(&url, &record_path, &snapshot_path, &data_dir, pages, &dest).await
+}
+
+/// Session-tab lookup shared by the archive commands.
+fn web_session_paths(
+    state: &State<AppState>,
+    session_id: &str,
+) -> Result<(String, PathBuf, PathBuf), String> {
+    let sessions = state.sessions.lock().map_err(|e| e.to_string())?;
+    match sessions.get(session_id) {
+        Some(Session::Web(web)) => Ok((
+            web.url.clone(),
+            web.record_path.clone(),
+            web.snapshot_path.clone(),
+        )),
+        Some(Session::Pdf(_)) => {
+            Err("PDFs are already portable — archiving applies to webpage tabs".into())
+        }
+        None => Err(format!("No session found for tab {}", session_id)),
+    }
+}
+
+/// Capture the best available snapshot, refresh the installed archive dir, and
+/// write a `.vellumweb` archive to `dest` atomically. Shared by the explicit
+/// export command and the automatic on-open archiver.
+async fn write_web_archive(
+    url: &str,
+    record_path: &Path,
+    snapshot_path: &Path,
+    data_dir: &Path,
+    pages: Vec<web_archive::PageText>,
+    dest: &Path,
+) -> Result<web_archive::ExportSummary, String> {
+    let key = web_page::page_key(url);
+    let record = web_page::load_record(record_path);
+
+    // Best available snapshot: live capture > installed archive dir > plain
+    // saved snapshot (assets skipped when offline).
+    let captured = match web_page::fetch_page(url).await {
+        Ok(web_page::FetchedPage::Html { html, final_url }) => {
+            // Resolve relative asset URLs against where the page actually
+            // came from (after redirects), not the requested URL.
+            let base = web_page::normalize_url(&final_url).unwrap_or_else(|_| url.to_string());
+            web_archive::capture_snapshot(&base, &html).await?
+        }
+        _ => {
+            if let Some((html, assets)) = web_archive::load_archive_dir(data_dir, &key) {
+                web_archive::CapturedSnapshot {
+                    html,
+                    assets: assets
+                        .into_iter()
+                        .map(|(name, bytes)| web_archive::CapturedAsset {
+                            content_type: web_archive::content_type_for_name(&name).to_string(),
+                            url: String::new(),
+                            name,
+                            bytes,
+                        })
+                        .collect(),
+                    skipped: 0,
+                }
+            } else if let Ok(html) = std::fs::read_to_string(snapshot_path) {
+                web_archive::capture_snapshot(url, &html).await?
+            } else {
+                return Err("The page could not be fetched and no local snapshot exists yet".into());
+            }
+        }
+    };
+
+    let pages_json =
+        serde_json::to_vec(&pages).map_err(|e| format!("Failed to serialize page text: {}", e))?;
+
+    let (title, mut page_count, last_page) = match &record {
+        Some(record) => web_page::document_info(record),
+        None => (None, None, None),
+    };
+    if !pages.is_empty() {
+        page_count = Some(pages.len() as u32);
+    }
+    let annotations = record.map(|r| r.annotations).unwrap_or_default();
+
+    let manifest = web_archive::build_manifest(
+        url,
+        title,
+        page_count,
+        last_page,
+        "live-first",
+        &captured.html,
+        &pages_json,
+        &captured.assets,
+        captured.skipped,
+    );
+
+    // Refresh the local self-contained snapshot so offline fallback matches
+    // what was just archived.
+    let dir_assets: Vec<(String, Vec<u8>)> = captured
+        .assets
+        .iter()
+        .map(|a| (a.name.clone(), a.bytes.clone()))
+        .collect();
+    web_archive::install_archive_dir(data_dir, &key, &captured.html, &dir_assets, Some(&manifest))?;
+
+    let asset_count = captured.assets.len() as u32;
+    let assets_skipped = captured.skipped;
+    let dest = dest.to_path_buf();
+    let dest_display = dest.to_string_lossy().to_string();
+    let bytes = tauri::async_runtime::spawn_blocking(move || {
+        web_archive::write_archive(
+            &dest,
+            &manifest,
+            &captured.html,
+            &captured.assets,
+            &pages_json,
+            &annotations,
+        )
+    })
+    .await
+    .map_err(|e| format!("Archive task failed: {}", e))??;
+
+    Ok(web_archive::ExportSummary {
+        path: dest_display,
+        bytes,
+        asset_count,
+        assets_skipped,
+    })
+}
+
+/// Automatically archive a freshly opened webpage into the managed library as
+/// a `.vellumweb` file. This is the default persistence path: every opened
+/// page becomes a portable archive without a save dialog. Fire-and-forget from
+/// the frontend once the page's text has been extracted. No-op semantics are
+/// signalled by returning `false` when the tab isn't a live webpage.
+#[tauri::command]
+pub async fn archive_webpage_default(
+    session_id: String,
+    pages: Vec<web_archive::PageText>,
+    expected_url: Option<String>,
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<bool, String> {
+    let (url, record_path, snapshot_path) = web_session_paths(&state, &session_id)?;
+    // The frontend debounces this call; if the tab navigated in the meantime,
+    // the session is bound to a different URL than the page texts describe —
+    // skip rather than archive mismatched content.
+    if let Some(expected) = expected_url {
+        let expected_normalized = web_page::normalize_url(&expected).unwrap_or(expected);
+        if expected_normalized != url {
+            return Ok(false);
+        }
+    }
+    let data_dir = web_store_dir(&app)?;
+    let dest = web_page::managed_archive_path(&data_dir, &web_page::page_key(&url));
+
+    write_web_archive(&url, &record_path, &snapshot_path, &data_dir, pages, &dest).await?;
+
+    // Opening a page now means it's kept: mark it saved so it lands in the
+    // library, without disturbing an existing saved_at timestamp.
+    web_page::mark_saved_if_absent(&record_path, &url)?;
+    Ok(true)
+}
+
+/// Open a `.vellumweb` archive: install its snapshot locally, merge its
+/// annotations into the sidecar, and open the page as a normal web tab
+/// (live-first with automatic snapshot fallback).
+#[tauri::command]
+pub async fn open_vellumweb_file(
+    path: String,
+    session_id: String,
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<DocumentInfo, String> {
+    let archive_path = PathBuf::from(&path);
+    let imported =
+        tauri::async_runtime::spawn_blocking(move || web_archive::read_archive(&archive_path))
+            .await
+            .map_err(|e| format!("Archive task failed: {}", e))??;
+
+    let data_dir = web_store_dir(&app)?;
+    let (session, mut record) = web_page::open_session(&data_dir, &imported.manifest.url)?;
+    let key = web_page::page_key(&session.url);
+
+    web_archive::install_archive_dir(
+        &data_dir,
+        &key,
+        &imported.snapshot_html,
+        &imported.assets,
+        Some(&imported.manifest),
+    )?;
+
+    // Merge archive metadata without clobbering local reading state.
+    if record.title.is_none() {
+        record.title = imported.manifest.title.clone();
+    }
+    if record.page_count.is_none() {
+        record.page_count = imported.manifest.page_count;
+    }
+    if record.last_page.is_none() {
+        record.last_page = imported.manifest.last_page;
+    }
+    if imported.manifest.loading_policy == "snapshot-only" {
+        record.loading_policy = Some("snapshot-only".to_string());
+    }
+    record.saved = true;
+    if record.saved_at.is_none() {
+        record.saved_at = Some(chrono::Utc::now().to_rfc3339());
+    }
+    web_archive::merge_annotations(&mut record.annotations, &imported.annotations);
+    web_page::save_record(&session.record_path, &record)?;
+
+    let (title, page_count, last_page) = web_page::document_info(&record);
+    let info = DocumentInfo {
+        kind: "web".to_string(),
+        pdf_path: session.url.clone(),
+        title,
+        page_count,
+        last_page,
+    };
+
+    let mut sessions = state.sessions.lock().map_err(|e| e.to_string())?;
+    if let Some(prev) = sessions.remove(&session_id) {
+        close_session(&prev)?;
+    }
+    sessions.insert(session_id, Session::Web(session));
+
+    Ok(info)
 }
 
 #[derive(Debug, Deserialize)]
@@ -336,9 +696,18 @@ fn codex_output_schema() -> serde_json::Value {
     })
 }
 
-/// Response for open_file
+fn default_document_kind() -> String {
+    "pdf".to_string()
+}
+
+/// Response for open_file / open_web_document.
+/// `pdf_path` doubles as the generic document URI: a filesystem path for PDFs,
+/// a normalized URL for webpages (the field name is kept for compatibility
+/// with stored conversations and recents keyed on it).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DocumentInfo {
+    #[serde(default = "default_document_kind")]
+    pub kind: String,
     pub pdf_path: String,
     pub title: Option<String>,
     pub page_count: Option<u32>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,10 +2,257 @@ mod commands;
 mod models;
 mod pdf_annotations;
 mod pdf_session;
+mod web_archive;
+mod web_page;
 
 use commands::AppState;
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::Mutex;
+use tauri::Manager;
+
+/// Serve a captured subresource from an installed archive dir:
+/// `/asset/<key>/<name>` -> `<app_data>/web/archives/<key>/assets/<name>`.
+fn serve_archive_asset(data_dir: Option<&Path>, rest: &str) -> tauri::http::Response<Vec<u8>> {
+    let not_found = || html_response(404, "<h1>Asset not found</h1>".to_string());
+
+    let Some(data_dir) = data_dir else {
+        return not_found();
+    };
+    let Some((key, name)) = rest.split_once('/') else {
+        return not_found();
+    };
+    // Keys are sha256 hex; names are flat generated file names. Anything else
+    // is rejected (path traversal guard).
+    if key.is_empty()
+        || !key.chars().all(|c| c.is_ascii_hexdigit())
+        || name.is_empty()
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.starts_with('.')
+    {
+        return not_found();
+    }
+
+    let path = web_archive::archive_dir(data_dir, key).join("assets").join(name);
+    match std::fs::read(&path) {
+        Ok(bytes) => tauri::http::Response::builder()
+            .status(200)
+            .header("Content-Type", web_archive::content_type_for_name(name))
+            .header("Cache-Control", "public, max-age=604800")
+            .body(bytes)
+            .unwrap_or_else(|_| tauri::http::Response::new(Vec::new())),
+        Err(_) => not_found(),
+    }
+}
+
+/// Serve the installed self-contained snapshot (from a .vellumweb import or
+/// export), with asset placeholders resolved to proxy asset URLs.
+fn serve_installed_snapshot(
+    data_dir: Option<&Path>,
+    key: &str,
+    page_url: &str,
+    asset_base: &str,
+) -> Option<tauri::http::Response<Vec<u8>>> {
+    let data_dir = data_dir?;
+    let html =
+        std::fs::read_to_string(web_archive::archive_dir(data_dir, key).join("snapshot.html"))
+            .ok()?;
+    let resolved = web_archive::resolve_asset_placeholders(
+        &html,
+        &format!("{}/asset/{}", asset_base, key),
+    );
+    Some(html_response(
+        200,
+        web_page::prepare_html(&resolved, page_url, true),
+    ))
+}
+
+/// Serve a proxied webpage for the `vellum-web://` iframe protocol.
+/// Routes: `/?url=<encoded-url>` (page loads) and `/asset/<key>/<name>`
+/// (subresources of installed .vellumweb snapshots).
+async fn handle_vellum_web_request(
+    app: tauri::AppHandle,
+    uri: tauri::http::Uri,
+) -> tauri::http::Response<Vec<u8>> {
+    let data_dir = app.path().app_data_dir().ok();
+
+    if let Some(rest) = uri.path().strip_prefix("/asset/") {
+        return serve_archive_asset(data_dir.as_deref(), rest);
+    }
+
+    let raw_url = uri.query().and_then(|query| {
+        url::form_urlencoded::parse(query.as_bytes())
+            .find(|(key, _)| key == "url")
+            .map(|(_, value)| value.into_owned())
+    });
+
+    let Some(raw_url) = raw_url else {
+        return html_response(404, "<h1>Missing url parameter</h1>".to_string());
+    };
+
+    let page_url = match web_page::normalize_url(&raw_url) {
+        Ok(url) => url,
+        Err(e) => {
+            return html_response(
+                400,
+                web_page::prepare_html(&web_page::error_page(&raw_url, &e), &raw_url, false),
+            )
+        }
+    };
+
+    // Base for absolute asset URLs inside served snapshots, matching however
+    // this webview addresses the protocol on the current platform.
+    let asset_base = match (uri.scheme_str(), uri.authority()) {
+        (Some(scheme), Some(authority)) => format!("{}://{}", scheme, authority),
+        _ => "vellum-web://localhost".to_string(),
+    };
+
+    // Sidecar state drives snapshot refresh and the loading policy.
+    let key = web_page::page_key(&page_url);
+    let snapshot_file = data_dir
+        .as_deref()
+        .map(|dir| web_page::store_dir(dir).join(format!("{}.snapshot.html", key)));
+    let record = data_dir
+        .as_deref()
+        .and_then(|dir| web_page::load_record(&web_page::store_dir(dir).join(format!("{}.json", key))));
+    let record_saved = record.as_ref().map(|r| r.saved).unwrap_or(false);
+    let snapshot_only = record
+        .as_ref()
+        .and_then(|r| r.loading_policy.as_deref())
+        == Some("snapshot-only");
+
+    // Pinned-snapshot policy (from an imported archive): don't hit the
+    // network at all when the installed snapshot is available.
+    if snapshot_only {
+        if let Some(response) =
+            serve_installed_snapshot(data_dir.as_deref(), &key, &page_url, &asset_base)
+        {
+            return response;
+        }
+    }
+
+    match web_page::fetch_page(&page_url).await {
+        Ok(web_page::FetchedPage::Html { html, final_url }) => {
+            // Redirects change the page's effective identity (http -> https,
+            // moved articles): serve under the final URL so relative
+            // subresources resolve correctly and the app shell can rebind
+            // the tab to the canonical address.
+            let effective_url = web_page::normalize_url(&final_url)
+                .unwrap_or_else(|_| page_url.clone());
+
+            // Keep the offline snapshot of saved pages fresh on every
+            // successful visit, under the effective identity.
+            if effective_url == page_url {
+                if record_saved {
+                    if let Some(snapshot_file) = &snapshot_file {
+                        web_page::write_snapshot_atomic(snapshot_file, &html);
+                    }
+                }
+            } else if let Some(dir) = data_dir.as_deref() {
+                let effective_key = web_page::page_key(&effective_url);
+                let effective_record = web_page::load_record(
+                    &web_page::store_dir(dir).join(format!("{}.json", effective_key)),
+                );
+                if effective_record.map(|r| r.saved).unwrap_or(false) {
+                    web_page::write_snapshot_atomic(
+                        &web_page::store_dir(dir)
+                            .join(format!("{}.snapshot.html", effective_key)),
+                        &html,
+                    );
+                }
+            }
+
+            html_response(200, web_page::prepare_html(&html, &effective_url, false))
+        }
+        Ok(web_page::FetchedPage::Other { content_type, body }) => {
+            tauri::http::Response::builder()
+                .status(200)
+                .header("Content-Type", content_type)
+                .header("Cache-Control", "no-store")
+                .body(body)
+                .unwrap_or_else(|_| tauri::http::Response::new(Vec::new()))
+        }
+        Err(fetch_error) => {
+            // Offline / link-rot fallback: prefer the self-contained
+            // .vellumweb snapshot, then the plain saved snapshot.
+            if let Some(response) =
+                serve_installed_snapshot(data_dir.as_deref(), &key, &page_url, &asset_base)
+            {
+                return response;
+            }
+            let snapshot = snapshot_file
+                .as_deref()
+                .and_then(|path| std::fs::read_to_string(path).ok());
+            match snapshot {
+                Some(html) => html_response(200, web_page::prepare_html(&html, &page_url, true)),
+                None => html_response(
+                    502,
+                    web_page::prepare_html(
+                        &web_page::error_page(&page_url, &fetch_error),
+                        &page_url,
+                        false,
+                    ),
+                ),
+            }
+        }
+    }
+}
+
+fn html_response(status: u16, body: String) -> tauri::http::Response<Vec<u8>> {
+    tauri::http::Response::builder()
+        .status(status)
+        .header("Content-Type", "text/html; charset=utf-8")
+        .header("Cache-Control", "no-store")
+        .body(body.into_bytes())
+        .unwrap_or_else(|_| tauri::http::Response::new(Vec::new()))
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+
+    fn install_asset(data_dir: &std::path::Path, key: &str, name: &str, bytes: &[u8]) {
+        let dir = web_archive::archive_dir(data_dir, key).join("assets");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(name), bytes).unwrap();
+    }
+
+    #[test]
+    fn archive_assets_are_served_with_content_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key = "abc123def456";
+        install_asset(tmp.path(), key, "a0.css", b"body{}");
+
+        let response = serve_archive_asset(Some(tmp.path()), &format!("{}/a0.css", key));
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response.headers().get("Content-Type").unwrap(),
+            "text/css"
+        );
+        assert_eq!(response.body(), b"body{}");
+    }
+
+    #[test]
+    fn asset_route_rejects_traversal_and_bad_keys() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key = "abc123def456";
+        install_asset(tmp.path(), key, "a0.css", b"body{}");
+
+        for rest in [
+            format!("{}/../{}/a0.css", key, key),
+            format!("{}/..%2Fa0.css", key),
+            format!("{}/.hidden", key),
+            "not-hex-key!/a0.css".to_string(),
+            format!("{}/", key),
+            key.to_string(), // no name at all
+        ] {
+            let response = serve_archive_asset(Some(tmp.path()), &rest);
+            assert_eq!(response.status(), 404, "should reject {:?}", rest);
+        }
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -14,6 +261,13 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .manage(AppState {
             sessions: Mutex::new(HashMap::new()),
+        })
+        .register_asynchronous_uri_scheme_protocol("vellum-web", |ctx, request, responder| {
+            let app = ctx.app_handle().clone();
+            let uri = request.uri().clone();
+            tauri::async_runtime::spawn(async move {
+                responder.respond(handle_vellum_web_request(app, uri).await);
+            });
         });
 
     #[cfg(desktop)]
@@ -37,6 +291,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::open_file,
+            commands::open_web_document,
             commands::save_file,
             commands::close_file,
             commands::read_pdf_bytes,
@@ -45,6 +300,13 @@ pub fn run() {
             commands::update_annotation,
             commands::delete_annotation,
             commands::set_document_metadata,
+            commands::set_webpage_saved,
+            commands::get_webpage_saved,
+            commands::list_saved_webpages,
+            commands::remove_saved_webpage,
+            commands::export_vellumweb,
+            commands::open_vellumweb_file,
+            commands::archive_webpage_default,
             commands::run_codex_ai,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -32,6 +32,17 @@ pub struct PositionData {
     pub selected_text: Option<String>,
     pub start_offset: Option<u32>,
     pub end_offset: Option<u32>,
+    /// Text-quote anchor context for webpage annotations (normalized text,
+    /// ~32 chars each side). None for PDF annotations.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub suffix: Option<String>,
+    /// How far below the viewport top (CSS px) the anchor text sat when a
+    /// webpage point bookmark was captured; restoring scrolls the anchor back
+    /// to that offset. None for PDF annotations and text selections.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub viewport_offset: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/pdf_annotations.rs
+++ b/src-tauri/src/pdf_annotations.rs
@@ -801,6 +801,9 @@ fn default_position(input: &CreateAnnotationInput, geometry: &PageGeometry) -> P
         selected_text: None,
         start_offset: None,
         end_offset: None,
+        prefix: None,
+        suffix: None,
+        viewport_offset: None,
     }
 }
 
@@ -1011,6 +1014,9 @@ fn read_position(
         selected_text,
         start_offset: None,
         end_offset: None,
+        prefix: None,
+        suffix: None,
+        viewport_offset: None,
     })
 }
 
@@ -1403,6 +1409,9 @@ mod tests {
             selected_text: Some("selected text".to_string()),
             start_offset: None,
             end_offset: None,
+            prefix: None,
+            suffix: None,
+            viewport_offset: None,
         }
     }
 

--- a/src-tauri/src/web_archive.rs
+++ b/src-tauri/src/web_archive.rs
@@ -1,0 +1,1168 @@
+//! `.vellumweb` — portable, versioned ZIP archive for annotated webpages.
+//!
+//! Layout (all paths inside the ZIP):
+//!   manifest.json           format marker, URLs, capture time, hashes, policy
+//!   snapshot/index.html     sanitized, self-contained snapshot (scripts
+//!                           stripped, asset refs rewritten to
+//!                           `__VELLUM_ASSET__/<name>` placeholders)
+//!   snapshot/assets/<name>  captured subresources (images, stylesheets)
+//!   text/pages.json         extracted normalized text per virtual page
+//!   annotations.json        highlights/notes/bookmarks with text-quote anchors
+//!
+//! This is an import/export & archival format. The live source of truth stays
+//! the per-URL JSON sidecar; importing merges into it, exporting reads from it.
+//!
+//! Size strategy: text entries use Zopfli deflate when small enough (levels
+//! 10+ with the `deflate-zopfli` feature), flate2 level 9 otherwise;
+//! already-compressed media (jpg/png/webp/woff2/...) is Stored rather than
+//! recompressed; scripts, srcset variants, and preload hints are stripped
+//! from the snapshot before packing.
+
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use regex::{Regex, RegexBuilder};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+use uuid::Uuid;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+use crate::models::Annotation;
+use crate::web_page;
+
+pub const FORMAT_NAME: &str = "vellumweb";
+pub const FORMAT_VERSION: u32 = 1;
+
+const MAX_ASSETS: usize = 80;
+const MAX_ASSET_BYTES: usize = 8 * 1024 * 1024;
+const MAX_TOTAL_ASSET_BYTES: usize = 64 * 1024 * 1024;
+/// Deflate levels 10-264 select Zopfli (iteration count) in the zip crate;
+/// worth it for small text entries, too slow for megabyte-scale HTML.
+const ZOPFLI_LEVEL: i64 = 15;
+const ZOPFLI_MAX_BYTES: usize = 384 * 1024;
+const FLATE_LEVEL: i64 = 9;
+
+const ASSET_PLACEHOLDER: &str = "__VELLUM_ASSET__";
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestHashes {
+    /// "sha256:<hex>" of snapshot/index.html bytes.
+    pub snapshot_html: String,
+    /// "sha256:<hex>" of text/pages.json bytes.
+    pub page_text: String,
+    /// "sha256:<hex>" of annotations.json bytes (added in later exports;
+    /// verified on import when present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ManifestAsset {
+    pub path: String,
+    pub url: String,
+    pub content_type: String,
+    pub bytes: u64,
+    /// "sha256:<hex>" of the asset bytes (verified on import when present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArchiveManifest {
+    pub format: String,
+    pub version: u32,
+    pub url: String,
+    pub canonical_url: String,
+    pub title: Option<String>,
+    pub captured_at: String,
+    pub generator: String,
+    /// "live-first" (default) or "snapshot-only".
+    pub loading_policy: String,
+    pub page_count: Option<u32>,
+    pub last_page: Option<u32>,
+    pub hashes: ManifestHashes,
+    #[serde(default)]
+    pub assets: Vec<ManifestAsset>,
+    #[serde(default)]
+    pub assets_skipped: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageText {
+    pub number: u32,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExportSummary {
+    pub path: String,
+    pub bytes: u64,
+    pub asset_count: u32,
+    pub assets_skipped: u32,
+}
+
+pub struct CapturedAsset {
+    pub name: String,
+    pub url: String,
+    pub content_type: String,
+    pub bytes: Vec<u8>,
+}
+
+pub struct CapturedSnapshot {
+    pub html: String,
+    pub assets: Vec<CapturedAsset>,
+    pub skipped: u32,
+}
+
+pub struct ImportedArchive {
+    pub manifest: ArchiveManifest,
+    pub snapshot_html: String,
+    pub assets: Vec<(String, Vec<u8>)>,
+    pub annotations: Vec<Annotation>,
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|b| format!("{:02x}", b)).collect();
+    format!("sha256:{}", hex)
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot sanitizing & asset capture
+// ---------------------------------------------------------------------------
+
+fn re(pattern: &str, cell: &'static OnceLock<Regex>) -> &'static Regex {
+    cell.get_or_init(|| {
+        RegexBuilder::new(pattern)
+            .case_insensitive(true)
+            .dot_matches_new_line(true)
+            .build()
+            .expect("valid archive regex")
+    })
+}
+
+fn script_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(r"<script\b[^>]*>.*?</script\s*>|<script\b[^>]*/>", &RE)
+}
+
+fn preload_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(
+        r#"<link\b[^>]*rel\s*=\s*["']?(?:preload|prefetch|modulepreload|dns-prefetch|preconnect)["']?[^>]*>"#,
+        &RE,
+    )
+}
+
+fn attr_strip_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(
+        r#"\s(?:srcset|sizes|integrity|crossorigin)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)"#,
+        &RE,
+    )
+}
+
+fn img_src_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(r#"<img\b[^>]*?\ssrc\s*=\s*["']([^"']+)["']"#, &RE)
+}
+
+fn link_tag_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(r"<link\b[^>]*>", &RE)
+}
+
+fn href_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(r#"\bhref\s*=\s*["']([^"']+)["']"#, &RE)
+}
+
+fn stylesheet_rel_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(r#"\brel\s*=\s*["']?stylesheet["']?"#, &RE)
+}
+
+fn css_url_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    re(r#"url\(\s*['"]?([^'")]+)['"]?\s*\)|@import\s+['"]([^'"]+)['"]"#, &RE)
+}
+
+/// Strip scripts, preload hints, and per-response attributes (srcset/sizes/
+/// integrity/crossorigin) that either bloat the archive or break once assets
+/// are served locally.
+pub fn sanitize_snapshot_html(html: &str) -> String {
+    let out = script_re().replace_all(html, "");
+    let out = preload_re().replace_all(&out, "");
+    let out = attr_strip_re().replace_all(&out, "");
+    out.into_owned()
+}
+
+/// Collect capturable asset URLs (img src + stylesheet href), in document
+/// order, deduplicated, resolved against the page URL.
+fn collect_asset_urls(html: &str, page_url: &str) -> Vec<(String, String)> {
+    let base = match Url::parse(page_url) {
+        Ok(u) => u,
+        Err(_) => return Vec::new(),
+    };
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<(String, String)> = Vec::new(); // (raw attr value, absolute url)
+
+    let mut push = |raw: &str| {
+        let raw = raw.trim();
+        if raw.is_empty() || raw.starts_with("data:") || raw.starts_with('#') {
+            return;
+        }
+        let Ok(abs) = base.join(raw) else { return };
+        match abs.scheme() {
+            "http" | "https" => {}
+            _ => return,
+        }
+        if seen.insert(raw.to_string()) {
+            out.push((raw.to_string(), abs.to_string()));
+        }
+    };
+
+    for cap in img_src_re().captures_iter(html) {
+        if let Some(m) = cap.get(1) {
+            push(m.as_str());
+        }
+    }
+    for tag in link_tag_re().find_iter(html) {
+        let tag_str = tag.as_str();
+        if !stylesheet_rel_re().is_match(tag_str) {
+            continue;
+        }
+        if let Some(cap) = href_re().captures(tag_str) {
+            if let Some(m) = cap.get(1) {
+                push(m.as_str());
+            }
+        }
+    }
+    out
+}
+
+/// Rewrite `url(...)` / `@import` references inside captured CSS to absolute
+/// URLs so they still resolve when the stylesheet is served from the archive.
+/// (Nested CSS assets are not embedded; see format limitations.)
+fn absolutize_css(css: &str, css_url: &str) -> String {
+    let Ok(base) = Url::parse(css_url) else {
+        return css.to_string();
+    };
+    css_url_re()
+        .replace_all(css, |caps: &regex::Captures| {
+            let whole = caps.get(0).map(|m| m.as_str()).unwrap_or("");
+            let reference = caps
+                .get(1)
+                .or_else(|| caps.get(2))
+                .map(|m| m.as_str().trim())
+                .unwrap_or("");
+            if reference.is_empty()
+                || reference.starts_with("data:")
+                || reference.starts_with('#')
+            {
+                return whole.to_string();
+            }
+            match base.join(reference) {
+                Ok(abs) if matches!(abs.scheme(), "http" | "https") => {
+                    if whole.to_ascii_lowercase().starts_with("@import") {
+                        format!("@import \"{}\"", abs)
+                    } else {
+                        format!("url(\"{}\")", abs)
+                    }
+                }
+                _ => whole.to_string(),
+            }
+        })
+        .into_owned()
+}
+
+fn extension_for(content_type: &str, url: &str) -> &'static str {
+    let ct = content_type
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+    match ct.as_str() {
+        "text/css" => return "css",
+        "image/png" => return "png",
+        "image/jpeg" | "image/jpg" => return "jpg",
+        "image/gif" => return "gif",
+        "image/webp" => return "webp",
+        "image/avif" => return "avif",
+        "image/svg+xml" => return "svg",
+        "image/x-icon" | "image/vnd.microsoft.icon" => return "ico",
+        "font/woff2" => return "woff2",
+        "font/woff" | "application/font-woff" => return "woff",
+        "font/ttf" => return "ttf",
+        "font/otf" => return "otf",
+        _ => {}
+    }
+    let path_ext = Url::parse(url)
+        .ok()
+        .and_then(|u| {
+            Path::new(u.path())
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_ascii_lowercase())
+        })
+        .unwrap_or_default();
+    match path_ext.as_str() {
+        "css" => "css",
+        "png" => "png",
+        "jpg" | "jpeg" => "jpg",
+        "gif" => "gif",
+        "webp" => "webp",
+        "avif" => "avif",
+        "svg" => "svg",
+        "ico" => "ico",
+        "woff2" => "woff2",
+        "woff" => "woff",
+        "ttf" => "ttf",
+        "otf" => "otf",
+        _ => "bin",
+    }
+}
+
+pub fn content_type_for_name(name: &str) -> &'static str {
+    let ext = Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match ext.as_str() {
+        "css" => "text/css",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "avif" => "image/avif",
+        "svg" => "image/svg+xml",
+        "ico" => "image/x-icon",
+        "woff2" => "font/woff2",
+        "woff" => "font/woff",
+        "ttf" => "font/ttf",
+        "otf" => "font/otf",
+        "html" => "text/html; charset=utf-8",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Media whose container is already compressed: recompressing wastes CPU and
+/// can slightly grow the archive, so these are Stored.
+fn is_precompressed(name: &str) -> bool {
+    matches!(
+        Path::new(name)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .as_str(),
+        "png" | "jpg" | "jpeg" | "gif" | "webp" | "avif" | "woff" | "woff2"
+    )
+}
+
+/// Sanitize + capture subresources for a fetched page. Asset references in
+/// the returned HTML point at `__VELLUM_ASSET__/<name>` placeholders.
+pub async fn capture_snapshot(page_url: &str, raw_html: &str) -> Result<CapturedSnapshot, String> {
+    let mut html = sanitize_snapshot_html(raw_html);
+    let targets = collect_asset_urls(&html, page_url);
+
+    let client = web_page::http_client()?;
+    let mut assets: Vec<CapturedAsset> = Vec::new();
+    let mut skipped: u32 = 0;
+    let mut total_bytes: usize = 0;
+
+    for (raw_ref, abs_url) in targets {
+        if assets.len() >= MAX_ASSETS || total_bytes >= MAX_TOTAL_ASSET_BYTES {
+            skipped += 1;
+            continue;
+        }
+
+        let fetched = async {
+            let resp = client.get(&abs_url).send().await.ok()?;
+            if !resp.status().is_success() {
+                return None;
+            }
+            let content_type = resp
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("application/octet-stream")
+                .to_string();
+            // Cap enforced while streaming so an unbounded or lying origin
+            // can't exhaust memory before a post-hoc check.
+            let bytes = web_page::read_body_capped(resp, MAX_ASSET_BYTES).await.ok()?;
+            Some((content_type, bytes))
+        }
+        .await;
+
+        let Some((content_type, mut bytes)) = fetched else {
+            skipped += 1;
+            continue;
+        };
+
+        let ext = extension_for(&content_type, &abs_url);
+        if ext == "css" {
+            let css = String::from_utf8_lossy(&bytes);
+            bytes = absolutize_css(&css, &abs_url).into_bytes();
+        }
+
+        let name = format!("a{}.{}", assets.len(), ext);
+        let placeholder = format!("{}/{}", ASSET_PLACEHOLDER, name);
+        html = html
+            .replace(&format!("\"{}\"", raw_ref), &format!("\"{}\"", placeholder))
+            .replace(&format!("'{}'", raw_ref), &format!("'{}'", placeholder));
+
+        total_bytes += bytes.len();
+        assets.push(CapturedAsset {
+            name,
+            url: abs_url,
+            content_type,
+            bytes,
+        });
+    }
+
+    Ok(CapturedSnapshot {
+        html,
+        assets,
+        skipped,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Archive write / read
+// ---------------------------------------------------------------------------
+
+fn text_options(len: usize) -> SimpleFileOptions {
+    let level = if len <= ZOPFLI_MAX_BYTES {
+        ZOPFLI_LEVEL
+    } else {
+        FLATE_LEVEL
+    };
+    SimpleFileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        .compression_level(Some(level))
+}
+
+fn asset_options(name: &str) -> SimpleFileOptions {
+    if is_precompressed(name) {
+        SimpleFileOptions::default().compression_method(CompressionMethod::Stored)
+    } else {
+        SimpleFileOptions::default()
+            .compression_method(CompressionMethod::Deflated)
+            .compression_level(Some(FLATE_LEVEL))
+    }
+}
+
+pub fn build_manifest(
+    url: &str,
+    title: Option<String>,
+    page_count: Option<u32>,
+    last_page: Option<u32>,
+    loading_policy: &str,
+    snapshot_html: &str,
+    pages_json: &[u8],
+    assets: &[CapturedAsset],
+    assets_skipped: u32,
+) -> ArchiveManifest {
+    ArchiveManifest {
+        format: FORMAT_NAME.to_string(),
+        version: FORMAT_VERSION,
+        url: url.to_string(),
+        canonical_url: url.to_string(),
+        title,
+        captured_at: chrono::Utc::now().to_rfc3339(),
+        generator: format!("Vellum {}", env!("CARGO_PKG_VERSION")),
+        loading_policy: loading_policy.to_string(),
+        page_count,
+        last_page,
+        hashes: ManifestHashes {
+            snapshot_html: sha256_hex(snapshot_html.as_bytes()),
+            page_text: sha256_hex(pages_json),
+            annotations: None, // filled in by write_archive
+        },
+        assets: assets
+            .iter()
+            .map(|a| ManifestAsset {
+                path: format!("snapshot/assets/{}", a.name),
+                url: a.url.clone(),
+                content_type: a.content_type.clone(),
+                bytes: a.bytes.len() as u64,
+                sha256: Some(sha256_hex(&a.bytes)),
+            })
+            .collect(),
+        assets_skipped,
+    }
+}
+
+/// Write the archive atomically: pack into a temp file next to `dest`, fsync,
+/// then rename over the destination.
+pub fn write_archive(
+    dest: &Path,
+    manifest: &ArchiveManifest,
+    snapshot_html: &str,
+    assets: &[CapturedAsset],
+    pages_json: &[u8],
+    annotations: &[Annotation],
+) -> Result<u64, String> {
+    let parent = dest
+        .parent()
+        .ok_or_else(|| "Destination has no parent directory".to_string())?;
+    fs::create_dir_all(parent).map_err(|e| format!("Failed to create destination dir: {}", e))?;
+
+    let file_name = dest
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("archive.vellumweb");
+    // Unique per operation: concurrent writers to the same destination (e.g.
+    // auto-archive racing an explicit export) must not share a temp file.
+    let tmp = parent.join(format!(
+        ".{}.tmp-{}-{}",
+        file_name,
+        std::process::id(),
+        Uuid::new_v4()
+    ));
+
+    let result = (|| -> Result<u64, String> {
+        let file = File::create(&tmp).map_err(|e| format!("Failed to create archive: {}", e))?;
+        let mut zip = ZipWriter::new(file);
+        let err = |e: zip::result::ZipError| format!("Failed to write archive: {}", e);
+        let ioerr = |e: std::io::Error| format!("Failed to write archive: {}", e);
+
+        let annotations_json = serde_json::to_vec(annotations)
+            .map_err(|e| format!("Failed to serialize annotations: {}", e))?;
+        let mut manifest = manifest.clone();
+        manifest.hashes.annotations = Some(sha256_hex(&annotations_json));
+
+        let manifest_json = serde_json::to_vec_pretty(&manifest)
+            .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
+        zip.start_file("manifest.json", text_options(manifest_json.len()))
+            .map_err(err)?;
+        zip.write_all(&manifest_json).map_err(ioerr)?;
+
+        let html_bytes = snapshot_html.as_bytes();
+        zip.start_file("snapshot/index.html", text_options(html_bytes.len()))
+            .map_err(err)?;
+        zip.write_all(html_bytes).map_err(ioerr)?;
+
+        for asset in assets {
+            zip.start_file(
+                format!("snapshot/assets/{}", asset.name),
+                asset_options(&asset.name),
+            )
+            .map_err(err)?;
+            zip.write_all(&asset.bytes).map_err(ioerr)?;
+        }
+
+        zip.start_file("text/pages.json", text_options(pages_json.len()))
+            .map_err(err)?;
+        zip.write_all(pages_json).map_err(ioerr)?;
+
+        zip.start_file("annotations.json", text_options(annotations_json.len()))
+            .map_err(err)?;
+        zip.write_all(&annotations_json).map_err(ioerr)?;
+
+        let file = zip.finish().map_err(err)?;
+        file.sync_all()
+            .map_err(|e| format!("Failed to sync archive: {}", e))?;
+        let bytes = file
+            .metadata()
+            .map_err(|e| format!("Failed to stat archive: {}", e))?
+            .len();
+        drop(file);
+
+        fs::rename(&tmp, dest).map_err(|e| format!("Failed to move archive into place: {}", e))?;
+        Ok(bytes)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+    result
+}
+
+/// Read one zip entry with a hard decompressed-size cap. `entry.size()` is an
+/// attacker-controlled header field in a shared archive, so it must never be
+/// trusted for allocation, and decompression must stop at the cap rather than
+/// inflate a bomb.
+fn read_zip_entry_capped<R: Read + std::io::Seek>(
+    zip: &mut ZipArchive<R>,
+    name: &str,
+    cap: u64,
+) -> Result<Vec<u8>, String> {
+    let entry = zip
+        .by_name(name)
+        .map_err(|_| format!("Archive is missing {}", name))?;
+    if entry.size() > cap {
+        return Err(format!("Archive entry {} exceeds its size limit", name));
+    }
+    let mut buf = Vec::with_capacity(entry.size().min(cap) as usize);
+    let mut limited = entry.take(cap + 1);
+    limited
+        .read_to_end(&mut buf)
+        .map_err(|e| format!("Failed to read {}: {}", name, e))?;
+    if buf.len() as u64 > cap {
+        return Err(format!("Archive entry {} exceeds its size limit", name));
+    }
+    Ok(buf)
+}
+
+/// Only bare file names are allowed for assets (zip-slip guard).
+fn safe_asset_name(name: &str) -> Option<String> {
+    if name.is_empty()
+        || name.contains("..")
+        || name.contains('/')
+        || name.contains('\\')
+        || name.starts_with('.')
+    {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+const MAX_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_ANNOTATIONS_BYTES: u64 = 32 * 1024 * 1024;
+
+pub fn read_archive(path: &Path) -> Result<ImportedArchive, String> {
+    let file = File::open(path).map_err(|e| format!("Failed to open archive: {}", e))?;
+    let mut zip =
+        ZipArchive::new(file).map_err(|e| format!("Not a valid .vellumweb archive: {}", e))?;
+
+    let manifest_bytes = read_zip_entry_capped(&mut zip, "manifest.json", MAX_MANIFEST_BYTES)?;
+    let manifest: ArchiveManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| format!("Invalid archive manifest: {}", e))?;
+    if manifest.format != FORMAT_NAME {
+        return Err("Not a .vellumweb archive (wrong format marker)".to_string());
+    }
+    if manifest.version > FORMAT_VERSION {
+        return Err(format!(
+            "This archive uses format version {} — please update Vellum",
+            manifest.version
+        ));
+    }
+
+    let snapshot_bytes = read_zip_entry_capped(
+        &mut zip,
+        "snapshot/index.html",
+        web_page::MAX_RESPONSE_BYTES as u64,
+    )?;
+    if sha256_hex(&snapshot_bytes) != manifest.hashes.snapshot_html {
+        return Err("Archive snapshot failed its integrity check (corrupted file?)".to_string());
+    }
+    let snapshot_html = String::from_utf8_lossy(&snapshot_bytes).into_owned();
+
+    let annotations: Vec<Annotation> = if zip.by_name("annotations.json").is_ok() {
+        let buf = read_zip_entry_capped(&mut zip, "annotations.json", MAX_ANNOTATIONS_BYTES)?;
+        let parsed: Vec<Annotation> = serde_json::from_slice(&buf)
+            .map_err(|e| format!("Invalid annotations in archive: {}", e))?;
+        if let Some(expected) = &manifest.hashes.annotations {
+            if &sha256_hex(&buf) != expected {
+                return Err(
+                    "Archive annotations failed their integrity check (corrupted file?)"
+                        .to_string(),
+                );
+            }
+        }
+        parsed
+    } else {
+        Vec::new()
+    };
+
+    let mut asset_names: Vec<String> = Vec::new();
+    for i in 0..zip.len() {
+        let entry = zip
+            .by_index(i)
+            .map_err(|e| format!("Failed to scan archive: {}", e))?;
+        if let Some(rest) = entry.name().strip_prefix("snapshot/assets/") {
+            if let Some(safe) = safe_asset_name(rest) {
+                asset_names.push(safe);
+            }
+        }
+    }
+    let mut assets = Vec::with_capacity(asset_names.len());
+    let mut total_asset_bytes: u64 = 0;
+    for name in asset_names {
+        let entry_path = format!("snapshot/assets/{}", name);
+        let bytes = read_zip_entry_capped(&mut zip, &entry_path, MAX_ASSET_BYTES as u64)?;
+        total_asset_bytes += bytes.len() as u64;
+        if total_asset_bytes > MAX_TOTAL_ASSET_BYTES as u64 {
+            return Err("Archive assets exceed the total size limit".to_string());
+        }
+        if let Some(expected) = manifest
+            .assets
+            .iter()
+            .find(|a| a.path == entry_path)
+            .and_then(|a| a.sha256.as_ref())
+        {
+            if &sha256_hex(&bytes) != expected {
+                return Err(format!(
+                    "Archive asset {} failed its integrity check",
+                    name
+                ));
+            }
+        }
+        assets.push((name, bytes));
+    }
+
+    Ok(ImportedArchive {
+        manifest,
+        snapshot_html,
+        assets,
+        annotations,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Local self-contained snapshot dir (archives/<key>/)
+// ---------------------------------------------------------------------------
+
+pub fn archive_dir(app_data_dir: &Path, key: &str) -> PathBuf {
+    web_page::store_dir(app_data_dir).join("archives").join(key)
+}
+
+/// Install snapshot + assets into `archives/<key>/`: staged into a unique
+/// sibling dir, then swapped in with rename-aside so a concurrent reader
+/// never sees a missing dir for more than the instant between two renames,
+/// and a failed install leaves the previous snapshot intact.
+pub fn install_archive_dir(
+    app_data_dir: &Path,
+    key: &str,
+    snapshot_html: &str,
+    assets: &[(String, Vec<u8>)],
+    manifest: Option<&ArchiveManifest>,
+) -> Result<(), String> {
+    let final_dir = archive_dir(app_data_dir, key);
+    let op_id = Uuid::new_v4();
+    let staging = final_dir.with_extension(format!("staging-{}", op_id));
+    let aside = final_dir.with_extension(format!("old-{}", op_id));
+
+    fs::create_dir_all(staging.join("assets"))
+        .map_err(|e| format!("Failed to stage snapshot dir: {}", e))?;
+    let staged = (|| -> Result<(), String> {
+        fs::write(staging.join("snapshot.html"), snapshot_html)
+            .map_err(|e| format!("Failed to write snapshot: {}", e))?;
+        for (name, bytes) in assets {
+            let Some(safe) = safe_asset_name(name) else {
+                continue;
+            };
+            fs::write(staging.join("assets").join(safe), bytes)
+                .map_err(|e| format!("Failed to write asset: {}", e))?;
+        }
+        if let Some(manifest) = manifest {
+            let json = serde_json::to_vec_pretty(manifest)
+                .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
+            fs::write(staging.join("manifest.json"), json)
+                .map_err(|e| format!("Failed to write manifest: {}", e))?;
+        }
+        Ok(())
+    })();
+    if let Err(e) = staged {
+        let _ = fs::remove_dir_all(&staging);
+        return Err(e);
+    }
+
+    // Swap: move the current dir aside (not delete), move staging in, then
+    // clean up. On failure, restore the previous dir.
+    let had_previous = final_dir.exists() && fs::rename(&final_dir, &aside).is_ok();
+    match fs::rename(&staging, &final_dir) {
+        Ok(()) => {
+            if had_previous {
+                let _ = fs::remove_dir_all(&aside);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if had_previous {
+                let _ = fs::rename(&aside, &final_dir);
+            }
+            let _ = fs::remove_dir_all(&staging);
+            Err(format!("Failed to install snapshot dir: {}", e))
+        }
+    }
+}
+
+/// Load a previously installed self-contained snapshot, if present.
+pub fn load_archive_dir(
+    app_data_dir: &Path,
+    key: &str,
+) -> Option<(String, Vec<(String, Vec<u8>)>)> {
+    let dir = archive_dir(app_data_dir, key);
+    let html = fs::read_to_string(dir.join("snapshot.html")).ok()?;
+    let mut assets = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir.join("assets")) {
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if let Ok(bytes) = fs::read(entry.path()) {
+                assets.push((name, bytes));
+            }
+        }
+    }
+    Some((html, assets))
+}
+
+/// Rewrite asset placeholders for serving: `__VELLUM_ASSET__/<name>` becomes
+/// an absolute proxy URL under the given base (e.g.
+/// `vellum-web://localhost/asset/<key>`).
+pub fn resolve_asset_placeholders(html: &str, asset_base: &str) -> String {
+    html.replace(
+        &format!("{}/", ASSET_PLACEHOLDER),
+        &format!("{}/", asset_base.trim_end_matches('/')),
+    )
+}
+
+/// Merge imported annotations into the sidecar's list. Same-id conflicts keep
+/// the newer `updated_at`. Returns how many entries were added or replaced.
+pub fn merge_annotations(existing: &mut Vec<Annotation>, incoming: &[Annotation]) -> u32 {
+    let mut changed = 0;
+    for annotation in incoming {
+        match existing.iter_mut().find(|a| a.id == annotation.id) {
+            None => {
+                existing.push(annotation.clone());
+                changed += 1;
+            }
+            Some(current) => {
+                if newer_than(&annotation.updated_at, &current.updated_at) {
+                    *current = annotation.clone();
+                    changed += 1;
+                }
+            }
+        }
+    }
+    changed
+}
+
+fn newer_than(a: &str, b: &str) -> bool {
+    use chrono::DateTime;
+    match (
+        DateTime::parse_from_rfc3339(a),
+        DateTime::parse_from_rfc3339(b),
+    ) {
+        (Ok(a), Ok(b)) => a > b,
+        _ => a > b, // fall back to lexical compare (same generator format)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{AnnotationType, PositionData};
+
+    fn sample_annotation(id: &str, updated_at: &str) -> Annotation {
+        Annotation {
+            id: id.to_string(),
+            annotation_type: AnnotationType::Highlight,
+            page_number: 1,
+            color: Some("#fef08a".to_string()),
+            content: None,
+            position_data: Some(PositionData {
+                rects: vec![],
+                page_width: 1.0,
+                page_height: 1.0,
+                selected_text: Some("hello world".to_string()),
+                start_offset: Some(10),
+                end_offset: Some(21),
+                prefix: Some("before ".to_string()),
+                suffix: Some(" after".to_string()),
+                viewport_offset: None,
+            }),
+            created_at: "2026-07-01T00:00:00Z".to_string(),
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn sanitize_strips_scripts_srcset_and_preloads() {
+        let html = r#"<html><head>
+            <link rel="preload" href="/x.woff2" as="font">
+            <script src="/app.js"></script>
+        </head><body>
+            <script>alert(1)</script>
+            <img src="/a.png" srcset="/a2x.png 2x" sizes="100vw" crossorigin="anonymous">
+            <p>keep me</p>
+        </body></html>"#;
+        let out = sanitize_snapshot_html(html);
+        assert!(!out.contains("<script"));
+        assert!(!out.contains("alert(1)"));
+        assert!(!out.contains("srcset"));
+        assert!(!out.contains("preload"));
+        assert!(!out.contains("crossorigin"));
+        assert!(out.contains("keep me"));
+        assert!(out.contains(r#"src="/a.png""#));
+    }
+
+    #[test]
+    fn collects_img_and_stylesheet_urls() {
+        let html = r#"<img src="/pic.png"><link rel="stylesheet" href="style.css">
+            <link href="/other.css" rel="stylesheet"><link rel="icon" href="/fav.ico">
+            <img src="data:image/png;base64,xxx">"#;
+        let urls = collect_asset_urls(html, "https://example.com/post/index.html");
+        let absolute: Vec<&str> = urls.iter().map(|(_, abs)| abs.as_str()).collect();
+        assert_eq!(
+            absolute,
+            vec![
+                "https://example.com/pic.png",
+                "https://example.com/post/style.css",
+                "https://example.com/other.css",
+            ]
+        );
+    }
+
+    #[test]
+    fn css_urls_are_absolutized() {
+        let css = r#"body { background: url("../img/bg.png"); } @import "extra.css";"#;
+        let out = absolutize_css(css, "https://example.com/styles/main.css");
+        assert!(out.contains(r#"url("https://example.com/img/bg.png")"#));
+        assert!(out.contains(r#"@import "https://example.com/styles/extra.css""#));
+    }
+
+    #[test]
+    fn archive_round_trip_preserves_content_and_verifies_hashes() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("article.vellumweb");
+
+        let html = "<html><head></head><body><p>hello world</p>\
+             <img src=\"__VELLUM_ASSET__/a0.png\"></body></html>";
+        let assets = vec![CapturedAsset {
+            name: "a0.png".to_string(),
+            url: "https://example.com/pic.png".to_string(),
+            content_type: "image/png".to_string(),
+            bytes: vec![0x89, 0x50, 0x4e, 0x47, 1, 2, 3],
+        }];
+        let pages = vec![PageText {
+            number: 1,
+            text: "hello world".to_string(),
+        }];
+        let pages_json = serde_json::to_vec(&pages).unwrap();
+        let annotations = vec![sample_annotation("ann-1", "2026-07-02T00:00:00Z")];
+
+        let manifest = build_manifest(
+            "https://example.com/post",
+            Some("Post".to_string()),
+            Some(1),
+            Some(1),
+            "live-first",
+            html,
+            &pages_json,
+            &assets,
+            0,
+        );
+
+        let bytes = write_archive(&dest, &manifest, html, &assets, &pages_json, &annotations)
+            .expect("write archive");
+        assert!(bytes > 0);
+        assert!(dest.is_file());
+
+        let imported = read_archive(&dest).expect("read archive");
+        assert_eq!(imported.manifest.url, "https://example.com/post");
+        assert_eq!(imported.manifest.version, FORMAT_VERSION);
+        assert_eq!(imported.snapshot_html, html);
+        assert_eq!(imported.assets.len(), 1);
+        assert_eq!(imported.assets[0].0, "a0.png");
+        assert_eq!(imported.annotations.len(), 1);
+        assert_eq!(
+            imported.annotations[0]
+                .position_data
+                .as_ref()
+                .unwrap()
+                .prefix
+                .as_deref(),
+            Some("before ")
+        );
+    }
+
+    #[test]
+    fn corrupted_snapshot_fails_integrity_check() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("bad.vellumweb");
+        let pages_json = b"[]".to_vec();
+        let mut manifest = build_manifest(
+            "https://example.com",
+            None,
+            None,
+            None,
+            "live-first",
+            "<html>real</html>",
+            &pages_json,
+            &[],
+            0,
+        );
+        manifest.hashes.snapshot_html = "sha256:deadbeef".to_string();
+        write_archive(&dest, &manifest, "<html>real</html>", &[], &pages_json, &[]).unwrap();
+        let err = match read_archive(&dest) {
+            Ok(_) => panic!("corrupted archive was accepted"),
+            Err(e) => e,
+        };
+        assert!(err.contains("integrity"));
+    }
+
+    #[test]
+    fn merge_prefers_newer_annotations_and_adds_missing() {
+        let mut existing = vec![sample_annotation("a", "2026-07-01T00:00:00Z")];
+        let incoming = vec![
+            sample_annotation("a", "2026-07-02T00:00:00Z"),
+            sample_annotation("b", "2026-07-01T00:00:00Z"),
+        ];
+        let changed = merge_annotations(&mut existing, &incoming);
+        assert_eq!(changed, 2);
+        assert_eq!(existing.len(), 2);
+        assert_eq!(existing[0].updated_at, "2026-07-02T00:00:00Z");
+
+        // Older incoming copy does not clobber the newer local one.
+        let changed = merge_annotations(
+            &mut existing,
+            &[sample_annotation("a", "2026-06-30T00:00:00Z")],
+        );
+        assert_eq!(changed, 0);
+        assert_eq!(existing[0].updated_at, "2026-07-02T00:00:00Z");
+    }
+
+    #[test]
+    fn asset_placeholders_resolve_to_proxy_urls() {
+        let html = r#"<img src="__VELLUM_ASSET__/a0.png">"#;
+        let out = resolve_asset_placeholders(html, "vellum-web://localhost/asset/abc123");
+        assert_eq!(out, r#"<img src="vellum-web://localhost/asset/abc123/a0.png">"#);
+    }
+
+    #[test]
+    fn zip_slip_names_are_rejected() {
+        assert!(safe_asset_name("../evil.css").is_none());
+        assert!(safe_asset_name("a/b.css").is_none());
+        assert!(safe_asset_name(".hidden").is_none());
+        assert!(safe_asset_name("a0.css").is_some());
+    }
+
+    /// Spin up a throwaway local HTTP server for fetch/capture integration
+    /// tests. Returns the base URL; the server dies with the thread when the
+    /// returned handle is dropped at test end.
+    fn spawn_test_server(
+        routes: Vec<(&'static str, &'static str, &'static [u8])>,
+    ) -> (String, std::sync::Arc<tiny_http::Server>) {
+        let server =
+            std::sync::Arc::new(tiny_http::Server::http("127.0.0.1:0").expect("bind test server"));
+        let base = format!("http://{}", server.server_addr());
+        let routes: Vec<(String, String, Vec<u8>)> = routes
+            .into_iter()
+            .map(|(p, ct, b)| (p.to_string(), ct.to_string(), b.to_vec()))
+            .collect();
+
+        let server_thread = server.clone();
+        std::thread::spawn(move || {
+            while let Ok(request) = server_thread.recv() {
+                let url = request.url().to_string();
+                if let Some(target) = url.strip_prefix("/redirect-to") {
+                    let location = target.trim_start_matches('/').to_string();
+                    let response = tiny_http::Response::empty(302).with_header(
+                        tiny_http::Header::from_bytes(&b"Location"[..], format!("/{}", location))
+                            .unwrap(),
+                    );
+                    let _ = request.respond(response);
+                    continue;
+                }
+                match routes.iter().find(|(path, _, _)| *path == url) {
+                    Some((_, content_type, body)) => {
+                        let response = tiny_http::Response::from_data(body.clone()).with_header(
+                            tiny_http::Header::from_bytes(
+                                &b"Content-Type"[..],
+                                content_type.as_bytes(),
+                            )
+                            .unwrap(),
+                        );
+                        let _ = request.respond(response);
+                    }
+                    None => {
+                        let _ = request.respond(tiny_http::Response::empty(404));
+                    }
+                }
+            }
+        });
+
+        (base, server)
+    }
+
+    #[tokio::test]
+    async fn fetch_page_reports_final_url_after_redirect() {
+        let (base, _server) = spawn_test_server(vec![(
+            "/article",
+            "text/html; charset=utf-8",
+            b"<html><head></head><body>landed</body></html>",
+        )]);
+
+        let fetched = crate::web_page::fetch_page(&format!("{}/redirect-to/article", base))
+            .await
+            .expect("fetch through redirect");
+        match fetched {
+            crate::web_page::FetchedPage::Html { html, final_url } => {
+                assert!(html.contains("landed"));
+                assert!(
+                    final_url.ends_with("/article"),
+                    "final_url should be the redirect target, got {}",
+                    final_url
+                );
+            }
+            _ => panic!("expected HTML"),
+        }
+    }
+
+    #[tokio::test]
+    async fn capture_snapshot_embeds_assets_and_rewrites_refs() {
+        let (base, _server) = spawn_test_server(vec![
+            ("/style.css", "text/css", b"body { background: url('bg.png'); }".as_slice()),
+            ("/pic.png", "image/png", b"\x89PNGfake".as_slice()),
+        ]);
+
+        let html = format!(
+            r#"<html><head><link rel="stylesheet" href="style.css"><script>tracker()</script></head>
+            <body><img src="{}/pic.png" srcset="pic2x.png 2x"><p>content</p></body></html>"#,
+            base
+        );
+        let page_url = format!("{}/post", base);
+
+        let captured = capture_snapshot(&page_url, &html).await.expect("capture");
+
+        assert_eq!(captured.assets.len(), 2);
+        assert_eq!(captured.skipped, 0);
+        assert!(!captured.html.contains("<script"));
+        assert!(!captured.html.contains("srcset"));
+        // Both refs rewritten to placeholders (img srcs are collected before
+        // stylesheet hrefs, so the png gets a0).
+        assert!(captured.html.contains("__VELLUM_ASSET__/a0.png"));
+        assert!(captured.html.contains("__VELLUM_ASSET__/a1.css"));
+        // Image bytes stored verbatim.
+        assert_eq!(captured.assets[0].bytes, b"\x89PNGfake");
+        // CSS url() refs absolutized against the stylesheet's own URL.
+        let css = String::from_utf8_lossy(&captured.assets[1].bytes).into_owned();
+        assert!(
+            css.contains(&format!("url(\"{}/bg.png\")", base)),
+            "css was: {}",
+            css
+        );
+    }
+
+    #[tokio::test]
+    async fn capture_snapshot_skips_unreachable_assets() {
+        let (base, _server) = spawn_test_server(vec![]);
+        let html = r#"<img src="/missing.png"><p>text</p>"#;
+        let captured = capture_snapshot(&format!("{}/post", base), html)
+            .await
+            .expect("capture");
+        assert_eq!(captured.assets.len(), 0);
+        assert_eq!(captured.skipped, 1);
+        // Unfetched refs keep their original URL (resolved by <base> live).
+        assert!(captured.html.contains("/missing.png"));
+    }
+}

--- a/src-tauri/src/web_page.rs
+++ b/src-tauri/src/web_page.rs
@@ -1,0 +1,684 @@
+//! Webpage sessions: proxy fetching, sidecar annotation storage, and the
+//! saved-pages library.
+//!
+//! Unlike PDFs (where annotations are embedded in the file itself), webpage
+//! annotations live in a JSON sidecar in the app data dir, keyed by the
+//! normalized page URL. The page itself is served to the frontend through the
+//! `vellum-web` custom protocol, which strips framing protections and injects
+//! the Vellum content script.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use chrono::Utc;
+use regex::{Regex, RegexBuilder};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+use uuid::Uuid;
+
+use crate::models::{Annotation, AnnotationType, CreateAnnotationInput, UpdateAnnotationInput};
+
+const DEFAULT_HIGHLIGHT_COLOR: &str = "#fef08a";
+const DEFAULT_NOTE_COLOR: &str = "#fde68a";
+pub(crate) const MAX_RESPONSE_BYTES: usize = 25 * 1024 * 1024;
+const FETCH_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+     AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15 Vellum/0.1";
+
+/// The content script injected into every proxied page.
+pub const CONTENT_SCRIPT: &str = include_str!("../assets/vellum-content-script.js");
+
+/// Session state for an open webpage tab.
+pub struct WebSession {
+    /// Normalized page URL (this is the document identity).
+    pub url: String,
+    /// Path to the JSON sidecar holding metadata + annotations.
+    pub record_path: PathBuf,
+    /// Path to the offline HTML snapshot (may not exist).
+    pub snapshot_path: PathBuf,
+}
+
+/// Sidecar record persisted per webpage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebPageRecord {
+    pub url: String,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub page_count: Option<u32>,
+    #[serde(default)]
+    pub last_page: Option<u32>,
+    #[serde(default)]
+    pub saved: bool,
+    #[serde(default)]
+    pub saved_at: Option<String>,
+    #[serde(default)]
+    pub opened_at: Option<String>,
+    /// "live-first" (default when None) or "snapshot-only" (pinned snapshot,
+    /// set when importing a .vellumweb archive that requests it).
+    #[serde(default)]
+    pub loading_policy: Option<String>,
+    #[serde(default)]
+    pub annotations: Vec<Annotation>,
+}
+
+impl WebPageRecord {
+    fn new(url: &str) -> Self {
+        WebPageRecord {
+            url: url.to_string(),
+            title: None,
+            page_count: None,
+            last_page: None,
+            saved: false,
+            saved_at: None,
+            opened_at: None,
+            loading_policy: None,
+            annotations: Vec::new(),
+        }
+    }
+}
+
+/// Entry returned for the saved-pages library.
+#[derive(Debug, Serialize)]
+pub struct WebLibraryEntry {
+    pub url: String,
+    pub title: Option<String>,
+    pub page_count: Option<u32>,
+    pub saved_at: Option<String>,
+    pub has_snapshot: bool,
+}
+
+// ---------------------------------------------------------------------------
+// URL normalization & storage paths
+// ---------------------------------------------------------------------------
+
+fn is_tracking_param(key: &str) -> bool {
+    key.starts_with("utm_")
+        || matches!(
+            key,
+            "fbclid" | "gclid" | "igshid" | "mc_cid" | "mc_eid" | "ref_src" | "twclid"
+        )
+}
+
+/// Normalize a user-supplied URL: default to https, strip fragments and
+/// tracking params so the same article always maps to one record.
+pub fn normalize_url(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err("Empty URL".to_string());
+    }
+    let candidate = if trimmed.contains("://") {
+        trimmed.to_string()
+    } else {
+        format!("https://{}", trimmed)
+    };
+
+    let mut url = Url::parse(&candidate).map_err(|e| format!("Invalid URL: {}", e))?;
+    match url.scheme() {
+        "http" | "https" => {}
+        other => return Err(format!("Unsupported URL scheme: {}", other)),
+    }
+    if url.host_str().is_none() {
+        return Err("URL has no host".to_string());
+    }
+
+    url.set_fragment(None);
+    let kept: Vec<(String, String)> = url
+        .query_pairs()
+        .filter(|(k, _)| !is_tracking_param(k))
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+    if kept.is_empty() {
+        url.set_query(None);
+    } else {
+        url.query_pairs_mut().clear().extend_pairs(kept);
+    }
+
+    Ok(url.to_string())
+}
+
+/// Stable storage key for a normalized URL.
+pub fn page_key(normalized_url: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(normalized_url.as_bytes());
+    let digest = hasher.finalize();
+    digest.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+pub fn store_dir(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("web")
+}
+
+fn record_path(app_data_dir: &Path, key: &str) -> PathBuf {
+    store_dir(app_data_dir).join(format!("{}.json", key))
+}
+
+fn snapshot_path(app_data_dir: &Path, key: &str) -> PathBuf {
+    store_dir(app_data_dir).join(format!("{}.snapshot.html", key))
+}
+
+/// Managed library path for a page's `.vellumweb` archive. Opening a page
+/// writes here by default, so the library is a collection of portable
+/// archives rather than loose snapshot files.
+pub fn managed_archive_path(app_data_dir: &Path, key: &str) -> PathBuf {
+    store_dir(app_data_dir).join(format!("{}.vellumweb", key))
+}
+
+// ---------------------------------------------------------------------------
+// Record persistence
+// ---------------------------------------------------------------------------
+
+pub fn load_record(path: &Path) -> Option<WebPageRecord> {
+    let raw = fs::read_to_string(path).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+pub fn save_record(path: &Path, record: &WebPageRecord) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create web store dir: {}", e))?;
+    }
+    let json = serde_json::to_string_pretty(record)
+        .map_err(|e| format!("Failed to serialize webpage record: {}", e))?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, json).map_err(|e| format!("Failed to write webpage record: {}", e))?;
+    fs::rename(&tmp, path).map_err(|e| format!("Failed to commit webpage record: {}", e))?;
+    Ok(())
+}
+
+/// Open (or create) a webpage session for a raw URL.
+pub fn open_session(app_data_dir: &Path, raw_url: &str) -> Result<(WebSession, WebPageRecord), String> {
+    let url = normalize_url(raw_url)?;
+    let key = page_key(&url);
+    let session = WebSession {
+        url: url.clone(),
+        record_path: record_path(app_data_dir, &key),
+        snapshot_path: snapshot_path(app_data_dir, &key),
+    };
+
+    let mut record = load_record(&session.record_path).unwrap_or_else(|| WebPageRecord::new(&url));
+    record.url = url;
+    record.opened_at = Some(Utc::now().to_rfc3339());
+    save_record(&session.record_path, &record)?;
+    Ok((session, record))
+}
+
+fn with_record<T>(
+    session: &WebSession,
+    f: impl FnOnce(&mut WebPageRecord) -> T,
+) -> Result<T, String> {
+    let mut record =
+        load_record(&session.record_path).unwrap_or_else(|| WebPageRecord::new(&session.url));
+    let out = f(&mut record);
+    save_record(&session.record_path, &record)?;
+    Ok(out)
+}
+
+// ---------------------------------------------------------------------------
+// Annotation CRUD (mirrors the pdf_annotations command surface)
+// ---------------------------------------------------------------------------
+
+pub fn get_annotations(
+    session: &WebSession,
+    page_number: Option<u32>,
+) -> Result<Vec<Annotation>, String> {
+    let record =
+        load_record(&session.record_path).unwrap_or_else(|| WebPageRecord::new(&session.url));
+    Ok(record
+        .annotations
+        .into_iter()
+        .filter(|a| page_number.map(|p| a.page_number == p).unwrap_or(true))
+        .collect())
+}
+
+pub fn create_annotation(
+    session: &WebSession,
+    input: &CreateAnnotationInput,
+) -> Result<Annotation, String> {
+    let now = Utc::now().to_rfc3339();
+    let default_color = match input.annotation_type {
+        AnnotationType::Highlight => Some(DEFAULT_HIGHLIGHT_COLOR.to_string()),
+        AnnotationType::Note => Some(DEFAULT_NOTE_COLOR.to_string()),
+        AnnotationType::Bookmark => None,
+    };
+    let annotation = Annotation {
+        id: Uuid::new_v4().to_string(),
+        annotation_type: input.annotation_type.clone(),
+        page_number: input.page_number,
+        color: input.color.clone().or(default_color),
+        content: input.content.clone(),
+        position_data: input.position_data.clone(),
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    let stored = annotation.clone();
+    with_record(session, move |record| record.annotations.push(stored))?;
+    Ok(annotation)
+}
+
+pub fn update_annotation(
+    session: &WebSession,
+    input: &UpdateAnnotationInput,
+) -> Result<bool, String> {
+    with_record(session, |record| {
+        let Some(annotation) = record.annotations.iter_mut().find(|a| a.id == input.id) else {
+            return false;
+        };
+        if let Some(color) = &input.color {
+            annotation.color = Some(color.clone());
+        }
+        if let Some(content) = &input.content {
+            annotation.content = Some(content.clone());
+        }
+        if let Some(position_data) = &input.position_data {
+            annotation.position_data = Some(position_data.clone());
+        }
+        annotation.updated_at = Utc::now().to_rfc3339();
+        true
+    })
+}
+
+pub fn delete_annotation(session: &WebSession, id: &str) -> Result<bool, String> {
+    with_record(session, |record| {
+        let before = record.annotations.len();
+        record.annotations.retain(|a| a.id != id);
+        record.annotations.len() != before
+    })
+}
+
+pub fn set_metadata(session: &WebSession, key: &str, value: &str) -> Result<(), String> {
+    with_record(session, |record| match key {
+        "title" => {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                record.title = Some(trimmed.to_string());
+            }
+        }
+        "page_count" => record.page_count = value.parse().ok(),
+        "last_page" => record.last_page = value.parse().ok(),
+        _ => {}
+    })
+}
+
+pub fn document_info(record: &WebPageRecord) -> (Option<String>, Option<u32>, Option<u32>) {
+    (record.title.clone(), record.page_count, record.last_page)
+}
+
+// ---------------------------------------------------------------------------
+// Saved-pages library
+// ---------------------------------------------------------------------------
+
+pub fn set_saved(session: &WebSession, saved: bool) -> Result<(), String> {
+    with_record(session, |record| {
+        record.saved = saved;
+        record.saved_at = if saved {
+            Some(Utc::now().to_rfc3339())
+        } else {
+            None
+        };
+    })?;
+    if !saved {
+        remove_local_snapshots(app_data_dir_of(&session.record_path), &page_key(&session.url));
+        let _ = fs::remove_file(&session.snapshot_path);
+    }
+    Ok(())
+}
+
+/// Recover the app data dir from a record path (`<app_data>/web/<key>.json`).
+fn app_data_dir_of(record_path: &Path) -> PathBuf {
+    record_path
+        .parent()
+        .and_then(|web_dir| web_dir.parent())
+        .map(|dir| dir.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Delete all locally cached snapshot artifacts for a page.
+fn remove_local_snapshots(app_data_dir: PathBuf, key: &str) {
+    let _ = fs::remove_file(snapshot_path(&app_data_dir, key));
+    let _ = fs::remove_file(managed_archive_path(&app_data_dir, key));
+    let _ = fs::remove_dir_all(store_dir(&app_data_dir).join("archives").join(key));
+}
+
+pub fn is_saved(session: &WebSession) -> bool {
+    load_record(&session.record_path)
+        .map(|r| r.saved)
+        .unwrap_or(false)
+}
+
+/// Mark a page saved without disturbing an existing `saved_at`. Used by the
+/// automatic on-open archiver so opened pages land in the library.
+pub fn mark_saved_if_absent(record_path: &Path, url: &str) -> Result<(), String> {
+    let mut record = load_record(record_path).unwrap_or_else(|| WebPageRecord::new(url));
+    record.url = url.to_string();
+    record.saved = true;
+    if record.saved_at.is_none() {
+        record.saved_at = Some(Utc::now().to_rfc3339());
+    }
+    save_record(record_path, &record)
+}
+
+fn has_local_snapshot(app_data_dir: &Path, key: &str) -> bool {
+    snapshot_path(app_data_dir, key).is_file()
+        || managed_archive_path(app_data_dir, key).is_file()
+        || store_dir(app_data_dir)
+            .join("archives")
+            .join(key)
+            .join("snapshot.html")
+            .is_file()
+}
+
+pub fn list_saved(app_data_dir: &Path) -> Vec<WebLibraryEntry> {
+    let dir = store_dir(app_data_dir);
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+
+    let mut out: Vec<WebLibraryEntry> = entries
+        .filter_map(|entry| {
+            let path = entry.ok()?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                return None;
+            }
+            let record = load_record(&path)?;
+            if !record.saved {
+                return None;
+            }
+            let key = page_key(&record.url);
+            Some(WebLibraryEntry {
+                has_snapshot: has_local_snapshot(app_data_dir, &key),
+                url: record.url,
+                title: record.title,
+                page_count: record.page_count,
+                saved_at: record.saved_at,
+            })
+        })
+        .collect();
+
+    out.sort_by(|a, b| b.saved_at.cmp(&a.saved_at));
+    out
+}
+
+pub fn remove_saved(app_data_dir: &Path, raw_url: &str) -> Result<(), String> {
+    let url = normalize_url(raw_url)?;
+    let key = page_key(&url);
+    let path = record_path(app_data_dir, &key);
+    // Un-save (keep annotations in case the page is reopened later).
+    if let Some(mut record) = load_record(&path) {
+        record.saved = false;
+        record.saved_at = None;
+        save_record(&path, &record)?;
+    }
+    remove_local_snapshots(app_data_dir.to_path_buf(), &key);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Proxy: fetch + rewrite
+// ---------------------------------------------------------------------------
+
+pub enum FetchedPage {
+    Html {
+        html: String,
+        /// URL after redirects — may differ from the requested URL (http →
+        /// https, moved articles). Callers should treat this as the page's
+        /// effective identity.
+        final_url: String,
+    },
+    Other {
+        content_type: String,
+        body: Vec<u8>,
+    },
+}
+
+/// Shared HTTP client configuration for page and asset fetches.
+pub fn http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .user_agent(FETCH_USER_AGENT)
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {}", e))
+}
+
+/// Read a response body with the size cap enforced *while* streaming, so a
+/// missing/false Content-Length or a decompression bomb can't exhaust memory
+/// before a post-hoc check.
+pub async fn read_body_capped(
+    mut response: reqwest::Response,
+    cap: usize,
+) -> Result<Vec<u8>, String> {
+    if let Some(len) = response.content_length() {
+        if len > cap as u64 {
+            return Err("Response is too large to load".to_string());
+        }
+    }
+    let mut body: Vec<u8> = Vec::new();
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|e| format!("Failed to read response body: {}", e))?
+    {
+        if body.len() + chunk.len() > cap {
+            return Err("Response is too large to load".to_string());
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// Decode HTML bytes honoring the charset from the Content-Type header
+/// (falling back to UTF-8), mirroring what `Response::text()` would do.
+fn decode_html(body: &[u8], content_type: &str) -> String {
+    let charset = content_type
+        .split(';')
+        .filter_map(|part| part.trim().strip_prefix("charset="))
+        .next()
+        .map(|c| c.trim_matches('"').trim())
+        .unwrap_or("utf-8");
+    let encoding =
+        encoding_rs::Encoding::for_label(charset.as_bytes()).unwrap_or(encoding_rs::UTF_8);
+    let (text, _, _) = encoding.decode(body);
+    text.into_owned()
+}
+
+/// Write a snapshot file atomically (temp + rename) so concurrent readers
+/// never observe a torn file.
+pub fn write_snapshot_atomic(path: &Path, html: &str) {
+    let tmp = path.with_extension(format!("tmp-{}", Uuid::new_v4()));
+    if fs::write(&tmp, html).is_ok() && fs::rename(&tmp, path).is_err() {
+        let _ = fs::remove_file(&tmp);
+    }
+}
+
+pub async fn fetch_page(url: &str) -> Result<FetchedPage, String> {
+    let client = http_client()?;
+
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to fetch page: {}", e))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(format!("The server responded with HTTP {}", status.as_u16()));
+    }
+
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("text/html")
+        .to_string();
+
+    if content_type.contains("text/html") || content_type.contains("application/xhtml") {
+        let final_url = response.url().to_string();
+        let body = read_body_capped(response, MAX_RESPONSE_BYTES).await?;
+        Ok(FetchedPage::Html {
+            html: decode_html(&body, &content_type),
+            final_url,
+        })
+    } else {
+        let body = read_body_capped(response, MAX_RESPONSE_BYTES).await?;
+        Ok(FetchedPage::Other { content_type, body })
+    }
+}
+
+fn csp_meta_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        RegexBuilder::new(r#"<meta[^>]+http-equiv\s*=\s*["']?content-security-policy["']?[^>]*>"#)
+            .case_insensitive(true)
+            .build()
+            .expect("valid CSP meta regex")
+    })
+}
+
+fn refresh_meta_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        RegexBuilder::new(r#"<meta[^>]+http-equiv\s*=\s*["']?refresh["']?[^>]*>"#)
+            .case_insensitive(true)
+            .build()
+            .expect("valid refresh meta regex")
+    })
+}
+
+fn head_open_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        RegexBuilder::new(r"<head[^>]*>")
+            .case_insensitive(true)
+            .build()
+            .expect("valid head regex")
+    })
+}
+
+fn html_open_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        RegexBuilder::new(r"<html[^>]*>")
+            .case_insensitive(true)
+            .build()
+            .expect("valid html regex")
+    })
+}
+
+/// Rewrite fetched HTML for serving inside the Vellum iframe:
+/// - strip `<meta http-equiv="Content-Security-Policy">` tags (headers are
+///   already dropped because we build a fresh response),
+/// - inject `<base href>` so relative subresources resolve against the real
+///   origin,
+/// - inject the Vellum content script with the normalized page URL.
+pub fn prepare_html(html: &str, page_url: &str, offline_snapshot: bool) -> String {
+    let stripped = csp_meta_regex().replace_all(html, "");
+    // Meta refresh would navigate the iframe straight to the target site,
+    // escaping the proxy (no content script, likely frame-blocked).
+    let stripped = refresh_meta_regex().replace_all(&stripped, "");
+
+    let safe_url_attr = page_url.replace('"', "%22");
+    let url_json = serde_json::to_string(page_url).unwrap_or_else(|_| "\"\"".to_string());
+    let injection = format!(
+        "<base href=\"{}\"><script>window.__VELLUM_PAGE_URL__={};window.__VELLUM_OFFLINE__={};\n{}</script>",
+        safe_url_attr, url_json, offline_snapshot, CONTENT_SCRIPT
+    );
+
+    if let Some(m) = head_open_regex().find(&stripped) {
+        let mut out = String::with_capacity(stripped.len() + injection.len());
+        out.push_str(&stripped[..m.end()]);
+        out.push_str(&injection);
+        out.push_str(&stripped[m.end()..]);
+        return out;
+    }
+    if let Some(m) = html_open_regex().find(&stripped) {
+        let mut out = String::with_capacity(stripped.len() + injection.len());
+        out.push_str(&stripped[..m.end()]);
+        out.push_str("<head>");
+        out.push_str(&injection);
+        out.push_str("</head>");
+        out.push_str(&stripped[m.end()..]);
+        return out;
+    }
+    format!("{}{}", injection, stripped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_url_defaults_to_https_and_strips_tracking() {
+        let url = normalize_url("example.com/post?utm_source=x&id=7#section").unwrap();
+        assert_eq!(url, "https://example.com/post?id=7");
+    }
+
+    #[test]
+    fn normalize_url_rejects_non_http_schemes() {
+        assert!(normalize_url("file:///etc/passwd").is_err());
+        assert!(normalize_url("javascript:alert(1)").is_err());
+    }
+
+    #[test]
+    fn same_article_maps_to_one_key() {
+        let a = normalize_url("https://example.com/post?utm_campaign=a").unwrap();
+        let b = normalize_url("example.com/post").unwrap();
+        assert_eq!(page_key(&a), page_key(&b));
+    }
+
+    #[test]
+    fn prepare_html_injects_base_and_script_after_head() {
+        let html = "<!doctype html><html><head><title>T</title></head><body>hi</body></html>";
+        let out = prepare_html(html, "https://example.com/post", false);
+        let head_pos = out.find("<head>").unwrap();
+        let base_pos = out.find("<base href=\"https://example.com/post\">").unwrap();
+        let title_pos = out.find("<title>").unwrap();
+        assert!(head_pos < base_pos && base_pos < title_pos);
+        assert!(out.contains("__VELLUM_PAGE_URL__"));
+        assert!(out.contains("vellumCmd"));
+    }
+
+    #[test]
+    fn prepare_html_strips_meta_csp() {
+        let html = r#"<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'none'"></head><body></body></html>"#;
+        let out = prepare_html(html, "https://example.com", false);
+        assert!(!out.to_lowercase().contains("content-security-policy"));
+    }
+
+    #[test]
+    fn prepare_html_strips_meta_refresh() {
+        let html = r#"<html><head><META HTTP-EQUIV="Refresh" content="0; url=https://evil.example/out"></head><body>stay</body></html>"#;
+        let out = prepare_html(html, "https://example.com", false);
+        assert!(!out.to_lowercase().contains("http-equiv=\"refresh\""));
+        assert!(!out.contains("evil.example"));
+        assert!(out.contains("stay"));
+    }
+
+    #[test]
+    fn prepare_html_handles_headless_documents() {
+        let out = prepare_html("<p>bare fragment</p>", "https://example.com", false);
+        assert!(out.contains("__VELLUM_PAGE_URL__"));
+        assert!(out.contains("bare fragment"));
+    }
+}
+
+/// Simple error page, also run through `prepare_html` so the content script
+/// still reports to the app shell.
+pub fn error_page(url: &str, message: &str) -> String {
+    let esc = |s: &str| {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+    };
+    format!(
+        r#"<!doctype html><html><head><meta charset="utf-8"><title>Couldn't load page</title></head>
+<body style="font-family: -apple-system, system-ui, sans-serif; max-width: 34rem; margin: 4rem auto; padding: 0 1.5rem; color: #333;">
+<h1 style="font-size: 1.25rem;">Couldn't load this page</h1>
+<p style="color:#666; word-break: break-all;">{}</p>
+<p>{}</p>
+<p style="color:#666;">Check the URL and your network connection, then reload the tab.</p>
+</body></html>"#,
+        esc(url),
+        esc(message)
+    )
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,8 +135,7 @@ export default function App() {
       !(e.target instanceof HTMLTextAreaElement)
     ) {
       const { document: d, mode, setMode } = usePdfStore.getState();
-      // Click-to-place notes are PDF-only; web notes attach to selections.
-      if (d && d.kind !== "web") {
+      if (d) {
         e.preventDefault();
         setMode(mode === "note" ? "view" : "note");
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { usePdfStore } from "@/stores/pdf-store";
 import { useAnnotationStore } from "@/stores/annotation-store";
 import { useAiStore } from "@/stores/ai-store";
 import { PdfViewer } from "@/components/pdf/PdfViewer";
+import { WebViewer } from "@/components/web/WebViewer";
 import { Toolbar } from "@/components/pdf/Toolbar";
 import { TabBar } from "@/components/pdf/TabBar";
 import { AnnotationSidebar } from "@/components/annotations/AnnotationSidebar";
@@ -25,20 +26,23 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [sidebarTab, setSidebarTab] = useState<"annotations" | "ai">("annotations");
 
-  // Load annotations when document changes
+  // Load annotations when the document identity changes. Keyed on the path
+  // rather than the document object so metadata updates (e.g. a webpage
+  // reporting its title) don't wipe the AI context and annotations.
+  const docPath = doc?.pdf_path ?? null;
   useEffect(() => {
-    if (doc) {
+    if (docPath) {
       clearAnnotations();
       clearDocumentContext();
       loadAnnotations();
-      loadConversationForDocument(doc);
+      loadConversationForDocument(usePdfStore.getState().document);
     } else {
       clearAnnotations();
       clearDocumentContext();
     }
   }, [
     activeTabId,
-    doc,
+    docPath,
     loadAnnotations,
     clearAnnotations,
     clearDocumentContext,
@@ -63,13 +67,20 @@ export default function App() {
       const selected = await open({
         multiple: true,
         filters: [
+          { name: "Documents", extensions: ["pdf", "vellumweb"] },
           { name: "PDF", extensions: ["pdf"] },
+          { name: "Vellum Web Archive", extensions: ["vellumweb"] },
         ],
       });
       if (!selected) return;
       await usePdfStore
         .getState()
         .openFiles(Array.isArray(selected) ? selected : [selected]);
+    }
+
+    if (isCtrl && e.key === "l") {
+      e.preventDefault();
+      window.dispatchEvent(new CustomEvent("vellum:add-webpage"));
     }
 
     if (isCtrl && e.key === "s") {
@@ -106,18 +117,8 @@ export default function App() {
 
     if (isCtrl && e.key === "b") {
       e.preventDefault();
-      const { document: d, currentPage } = usePdfStore.getState();
-      if (d) {
-        const { annotations, addBookmark, deleteAnnotation } =
-          useAnnotationStore.getState();
-        const existing = annotations.find(
-          (a) => a.type === "bookmark" && a.page_number === currentPage,
-        );
-        if (existing) {
-          deleteAnnotation(existing.id);
-        } else {
-          addBookmark(currentPage);
-        }
+      if (usePdfStore.getState().document) {
+        void useAnnotationStore.getState().toggleBookmark();
       }
     }
 
@@ -134,7 +135,8 @@ export default function App() {
       !(e.target instanceof HTMLTextAreaElement)
     ) {
       const { document: d, mode, setMode } = usePdfStore.getState();
-      if (d) {
+      // Click-to-place notes are PDF-only; web notes attach to selections.
+      if (d && d.kind !== "web") {
         e.preventDefault();
         setMode(mode === "note" ? "view" : "note");
       }
@@ -145,6 +147,18 @@ export default function App() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
+
+  // Reload annotations when an external mutation (e.g. a .vellumweb import
+  // merging into the already-active tab) changes them outside the store.
+  useEffect(() => {
+    const reload = () => {
+      if (usePdfStore.getState().document) {
+        loadAnnotations();
+      }
+    };
+    window.addEventListener("vellum:annotations-updated", reload);
+    return () => window.removeEventListener("vellum:annotations-updated", reload);
+  }, [loadAnnotations]);
 
   if (!doc) {
     return (
@@ -164,8 +178,12 @@ export default function App() {
         onToggleSidebar={() => setSidebarOpen((v) => !v)}
       />
       <div className="flex min-h-0 flex-1 overflow-hidden">
-        {/* PDF Viewer (main area) */}
-        <PdfViewer key={activeTabId} />
+        {/* Document viewer (main area) */}
+        {doc.kind === "web" ? (
+          <WebViewer key={activeTabId} />
+        ) : (
+          <PdfViewer key={activeTabId} />
+        )}
 
         {/* Annotation / AI side panel */}
         {sidebarOpen && (

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,38 +1,77 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { Clock, FileText, FolderOpen, X } from "lucide-react";
+import { BookmarkCheck, Clock, FileText, FolderOpen, Globe, X } from "lucide-react";
 import {
   getPdfFileName,
   getRecentPdfs,
+  getWebpageDisplayName,
   removeRecentPdf,
   type RecentPdf,
 } from "@/lib/recent-pdfs";
+import * as commands from "@/lib/tauri-commands";
 import { shortcut } from "@/lib/utils";
 import { usePdfStore } from "@/stores/pdf-store";
 import { Button } from "@/components/ui/Button";
+import type { WebLibraryEntry } from "@/types";
 
 export function WelcomeScreen() {
   const openFile = usePdfStore((s) => s.openFile);
   const openFiles = usePdfStore((s) => s.openFiles);
+  const openUrl = usePdfStore((s) => s.openUrl);
   const isLoading = usePdfStore((s) => s.isLoading);
   const error = usePdfStore((s) => s.error);
   const [recentPdfs, setRecentPdfs] = useState(getRecentPdfs);
+  const [savedPages, setSavedPages] = useState<WebLibraryEntry[]>([]);
+  const [urlInput, setUrlInput] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    commands
+      .listSavedWebpages()
+      .then((pages) => {
+        if (!cancelled) setSavedPages(pages);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleOpen = async () => {
     const selected = await open({
       multiple: true,
-      filters: [{ name: "PDF", extensions: ["pdf"] }],
+      filters: [
+        { name: "Documents", extensions: ["pdf", "vellumweb"] },
+        { name: "PDF", extensions: ["pdf"] },
+        { name: "Vellum Web Archive", extensions: ["vellumweb"] },
+      ],
     });
     if (!selected) return;
     await openFiles(Array.isArray(selected) ? selected : [selected]);
   };
 
-  const handleRecentOpen = async (pdf: RecentPdf) => {
-    await openFile(pdf.pdf_path);
+  const handleOpenUrl = async () => {
+    const value = urlInput.trim();
+    if (!value) return;
+    setUrlInput("");
+    await openUrl(value);
+  };
+
+  const handleRecentOpen = async (entry: RecentPdf) => {
+    if (entry.kind === "web") {
+      await openUrl(entry.pdf_path);
+    } else {
+      await openFile(entry.pdf_path);
+    }
   };
 
   const handleRemoveRecent = (path: string) => {
     setRecentPdfs(removeRecentPdf(path));
+  };
+
+  const handleRemoveSavedPage = async (url: string) => {
+    setSavedPages((pages) => pages.filter((page) => page.url !== url));
+    await commands.removeSavedWebpage(url).catch(() => {});
   };
 
   return (
@@ -62,10 +101,82 @@ export function WelcomeScreen() {
           </span>
         </div>
 
+        {/* Add a webpage */}
+        <div className="mt-4 flex w-full max-w-md items-center gap-2">
+          <div className="flex h-10 flex-1 items-center gap-2 rounded-lg border border-border bg-surface px-3 shadow-soft">
+            <Globe size={15} className="flex-shrink-0 text-muted-foreground" />
+            <input
+              type="text"
+              className="h-full flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              placeholder="Or read a webpage — paste an article URL"
+              value={urlInput}
+              onChange={(e) => setUrlInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleOpenUrl();
+              }}
+              disabled={isLoading}
+            />
+          </div>
+          <Button onClick={() => void handleOpenUrl()} disabled={isLoading || !urlInput.trim()}>
+            Open
+          </Button>
+        </div>
+
         {error && (
           <p className="mt-5 max-w-md rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-center text-sm text-destructive">
             {error}
           </p>
+        )}
+
+        {/* Saved webpages */}
+        {savedPages.length > 0 && (
+          <section className="mt-12 w-full">
+            <h2 className="mb-2 flex items-center gap-1.5 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <BookmarkCheck size={13} />
+              Saved pages
+            </h2>
+            <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-soft">
+              {savedPages.map((page) => {
+                const displayName = getWebpageDisplayName(page.url);
+                const displayTitle = page.title?.trim() || displayName;
+
+                return (
+                  <div
+                    key={page.url}
+                    className="group flex items-center border-b border-border last:border-b-0 transition-colors hover:bg-accent"
+                  >
+                    <button
+                      className="focus-ring flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left disabled:opacity-50"
+                      onClick={() => void openUrl(page.url)}
+                      disabled={isLoading}
+                      title={page.url}
+                    >
+                      <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground transition-colors group-hover:border-border-strong group-hover:text-primary">
+                        <Globe size={17} strokeWidth={1.75} />
+                      </span>
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-foreground">
+                          {displayTitle}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {displayName}
+                          {page.has_snapshot ? " · available offline" : ""}
+                        </span>
+                      </span>
+                    </button>
+                    <button
+                      className="focus-ring mr-2 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition hover:bg-muted hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
+                      onClick={() => void handleRemoveSavedPage(page.url)}
+                      title="Remove from saved pages"
+                      aria-label={`Remove ${displayTitle} from saved pages`}
+                    >
+                      <X size={15} />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
         )}
 
         {/* Recently opened */}
@@ -76,23 +187,30 @@ export function WelcomeScreen() {
               Recently opened
             </h2>
             <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-soft">
-              {recentPdfs.map((pdf) => {
-                const fileName = getPdfFileName(pdf.pdf_path);
-                const displayTitle = pdf.title?.trim() || fileName;
+              {recentPdfs.map((entry) => {
+                const isWeb = entry.kind === "web";
+                const fileName = isWeb
+                  ? getWebpageDisplayName(entry.pdf_path)
+                  : getPdfFileName(entry.pdf_path);
+                const displayTitle = entry.title?.trim() || fileName;
 
                 return (
                   <div
-                    key={pdf.pdf_path}
+                    key={entry.pdf_path}
                     className="group flex items-center border-b border-border last:border-b-0 transition-colors hover:bg-accent"
                   >
                     <button
                       className="focus-ring flex min-w-0 flex-1 items-center gap-3 px-4 py-3 text-left disabled:opacity-50"
-                      onClick={() => handleRecentOpen(pdf)}
+                      onClick={() => void handleRecentOpen(entry)}
                       disabled={isLoading}
-                      title={pdf.pdf_path}
+                      title={entry.pdf_path}
                     >
                       <span className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground transition-colors group-hover:border-border-strong group-hover:text-primary">
-                        <FileText size={17} strokeWidth={1.75} />
+                        {isWeb ? (
+                          <Globe size={17} strokeWidth={1.75} />
+                        ) : (
+                          <FileText size={17} strokeWidth={1.75} />
+                        )}
                       </span>
                       <span className="min-w-0 flex-1">
                         <span className="block truncate text-sm font-medium text-foreground">
@@ -100,16 +218,16 @@ export function WelcomeScreen() {
                         </span>
                         <span className="block truncate text-xs text-muted-foreground">
                           {displayTitle !== fileName && `${fileName} · `}
-                          {pdf.page_count
-                            ? `${pdf.page_count} ${pdf.page_count === 1 ? "page" : "pages"} · `
+                          {!isWeb && entry.page_count
+                            ? `${entry.page_count} ${entry.page_count === 1 ? "page" : "pages"} · `
                             : ""}
-                          {formatOpenedDate(pdf.opened_at)}
+                          {formatOpenedDate(entry.opened_at)}
                         </span>
                       </span>
                     </button>
                     <button
                       className="focus-ring mr-2 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-0 transition hover:bg-muted hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
-                      onClick={() => handleRemoveRecent(pdf.pdf_path)}
+                      onClick={() => handleRemoveRecent(entry.pdf_path)}
                       title={`Remove ${fileName} from recent files`}
                       aria-label={`Remove ${fileName} from recent files`}
                     >

--- a/src/components/WelcomeScreen.tsx
+++ b/src/components/WelcomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { open } from "@tauri-apps/plugin-dialog";
-import { BookmarkCheck, Clock, FileText, FolderOpen, Globe, X } from "lucide-react";
+import { Archive, Clock, FileText, FolderOpen, Globe, X } from "lucide-react";
 import {
   getPdfFileName,
   getRecentPdfs,
@@ -132,7 +132,7 @@ export function WelcomeScreen() {
         {savedPages.length > 0 && (
           <section className="mt-12 w-full">
             <h2 className="mb-2 flex items-center gap-1.5 px-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              <BookmarkCheck size={13} />
+              <Archive size={13} />
               Saved pages
             </h2>
             <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-soft">

--- a/src/components/annotations/AnnotationSidebar.tsx
+++ b/src/components/annotations/AnnotationSidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useAnnotationStore } from "@/stores/annotation-store";
 import { usePdfStore } from "@/stores/pdf-store";
-import type { Annotation, AnnotationType } from "@/types";
+import type { Annotation, AnnotationType, PositionData } from "@/types";
 import { cn } from "@/lib/utils";
 import {
   Highlighter,
@@ -60,10 +60,24 @@ export function AnnotationSidebar() {
 
   const handleClick = (annotation: Annotation) => {
     selectAnnotation(annotation.id);
+    // Web annotations anchored to a text position scroll to that exact spot;
+    // everything else jumps to the page.
+    const globals = window as unknown as Record<string, unknown>;
+    const scrollToWebPosition = globals.__scrollToWebPosition as
+      | ((pd: PositionData, page?: number) => boolean)
+      | undefined;
+    if (
+      scrollToWebPosition &&
+      annotation.position_data?.start_offset != null &&
+      annotation.type !== "highlight" &&
+      scrollToWebPosition(annotation.position_data, annotation.page_number)
+    ) {
+      return;
+    }
     goToPage(annotation.page_number);
-    // Scroll to page
-    const scrollToPage = (window as unknown as Record<string, unknown>)
-      .__scrollToPage as ((page: number) => void) | undefined;
+    const scrollToPage = globals.__scrollToPage as
+      | ((page: number) => void)
+      | undefined;
     scrollToPage?.(annotation.page_number);
   };
 

--- a/src/components/pdf/Toolbar.tsx
+++ b/src/components/pdf/Toolbar.tsx
@@ -15,11 +15,11 @@ import {
   ChevronLeft,
   ChevronRight,
   Save,
+  Archive,
   Bookmark,
-  BookmarkPlus,
   StickyNote,
   Download,
-  FileDown,
+  Share,
   LoaderCircle,
   RefreshCw,
   PanelRight,
@@ -56,7 +56,7 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
   } = usePdfStore();
 
   const { annotations, toggleBookmark } = useAnnotationStore();
-  const webVisibleRange = usePdfStore((s) => s.webVisibleRange);
+  const webVisibleBookmarks = usePdfStore((s) => s.webVisibleBookmarks);
   const isWeb = doc?.kind === "web";
 
   // "Add webpage" URL prompt (also opened via Cmd/Ctrl+L)
@@ -173,7 +173,7 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
     annotations,
     doc?.kind,
     currentPage,
-    webVisibleRange,
+    webVisibleBookmarks,
   );
   const isBookmarked = !!currentBookmark;
 
@@ -526,22 +526,30 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
             <StickyNote size={16} />
           </IconButton>
 
-          {/* Save webpage to library */}
+          {/* Page actions (save/export) — separated from the annotation
+              tools so the cluster doesn't read as one row of lookalikes. */}
+          {isWeb && <Divider />}
+
+          {/* Save webpage to library. Deliberately NOT a bookmark glyph
+              (the spot-bookmark button owns that shape), and the saved
+              state tints the icon like the bookmark's gold — a filled
+              "active" background would swallow the glyph entirely. */}
           {isWeb && (
             <IconButton
               onClick={() => void handleToggleSavedPage()}
-              className={cn(pageSaved && "text-gold hover:text-gold")}
+              className={cn(pageSaved && "text-primary hover:text-primary")}
               title={
                 pageSaved
-                  ? "Remove from saved pages"
+                  ? "Saved to library — click to remove"
                   : "Save page to library (keeps an offline snapshot)"
               }
             >
-              <BookmarkPlus size={16} fill={pageSaved ? "currentColor" : "none"} />
+              <Archive size={16} />
             </IconButton>
           )}
 
-          {/* Export portable .vellumweb archive */}
+          {/* Export portable .vellumweb archive (share-style glyph so it
+              doesn't read as yet another file/page icon) */}
           {isWeb && (
             <IconButton
               onClick={() => void handleExportVellumweb()}
@@ -559,7 +567,7 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
               {exportState.status === "exporting" ? (
                 <LoaderCircle size={16} className="animate-spin" />
               ) : (
-                <FileDown size={16} />
+                <Share size={16} />
               )}
             </IconButton>
           )}

--- a/src/components/pdf/Toolbar.tsx
+++ b/src/components/pdf/Toolbar.tsx
@@ -513,16 +513,18 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
             <Bookmark size={16} fill={isBookmarked ? "currentColor" : "none"} />
           </IconButton>
 
-          {/* Sticky Note tool (PDF only — web notes attach to selections) */}
-          {!isWeb && (
-            <IconButton
-              variant={mode === "note" ? "active" : "ghost"}
-              onClick={() => setMode(mode === "note" ? "view" : "note")}
-              title="Sticky note tool (N) — click on the page to place a note"
-            >
-              <StickyNote size={16} />
-            </IconButton>
-          )}
+          {/* Sticky Note tool */}
+          <IconButton
+            variant={mode === "note" ? "active" : "ghost"}
+            onClick={() => setMode(mode === "note" ? "view" : "note")}
+            title={
+              isWeb
+                ? "Sticky note tool (N) — click in the page to attach a note to the text there"
+                : "Sticky note tool (N) — click on the page to place a note"
+            }
+          >
+            <StickyNote size={16} />
+          </IconButton>
 
           {/* Save webpage to library */}
           {isWeb && (

--- a/src/components/pdf/Toolbar.tsx
+++ b/src/components/pdf/Toolbar.tsx
@@ -1,24 +1,30 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { open } from "@tauri-apps/plugin-dialog";
+import { open, save } from "@tauri-apps/plugin-dialog";
 import { usePdfStore } from "@/stores/pdf-store";
+import { useAiStore } from "@/stores/ai-store";
 import type { AppUpdate, AppUpdateDownloadEvent } from "@/lib/app-updates";
 import { checkForAppUpdate, relaunchForUpdate } from "@/lib/app-updates";
 import * as commands from "@/lib/tauri-commands";
 import {
   FolderOpen,
+  Globe,
   ZoomIn,
   ZoomOut,
+  ArrowLeft,
+  ArrowRight,
   ChevronLeft,
   ChevronRight,
   Save,
   Bookmark,
+  BookmarkPlus,
   StickyNote,
   Download,
+  FileDown,
   LoaderCircle,
   RefreshCw,
   PanelRight,
 } from "lucide-react";
-import { useAnnotationStore } from "@/stores/annotation-store";
+import { useAnnotationStore, findCurrentBookmark } from "@/stores/annotation-store";
 import { IconButton } from "@/components/ui/IconButton";
 import { ThemeToggle } from "@/components/ui/ThemeToggle";
 import { cn, shortcut } from "@/lib/utils";
@@ -41,6 +47,7 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
     zoom,
     mode,
     openFiles,
+    openUrl,
     zoomIn,
     zoomOut,
     setZoom,
@@ -48,11 +55,125 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
     setMode,
   } = usePdfStore();
 
-  const { addBookmark, annotations, deleteAnnotation } = useAnnotationStore();
+  const { annotations, toggleBookmark } = useAnnotationStore();
+  const webVisibleRange = usePdfStore((s) => s.webVisibleRange);
+  const isWeb = doc?.kind === "web";
 
-  // Find existing bookmark for the current page
-  const currentBookmark = annotations.find(
-    (a) => a.type === "bookmark" && a.page_number === currentPage,
+  // "Add webpage" URL prompt (also opened via Cmd/Ctrl+L)
+  const [urlPromptOpen, setUrlPromptOpen] = useState(false);
+  const [urlInput, setUrlInput] = useState("");
+  const urlInputRef = useRef<HTMLInputElement>(null);
+
+  // Saved-to-library state for the active webpage tab
+  const [pageSaved, setPageSaved] = useState(false);
+
+  useEffect(() => {
+    const openPrompt = () => setUrlPromptOpen(true);
+    window.addEventListener("vellum:add-webpage", openPrompt);
+    return () => window.removeEventListener("vellum:add-webpage", openPrompt);
+  }, []);
+
+  useEffect(() => {
+    if (urlPromptOpen) {
+      setUrlInput("");
+      requestAnimationFrame(() => urlInputRef.current?.focus());
+    }
+  }, [urlPromptOpen]);
+
+  useEffect(() => {
+    setPageSaved(false);
+    if (!isWeb || !activeTabId) return;
+    let cancelled = false;
+    commands
+      .getWebpageSaved(activeTabId)
+      .then((saved) => {
+        if (!cancelled) setPageSaved(saved);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [isWeb, activeTabId, doc?.pdf_path]);
+
+  const handleSubmitUrl = async () => {
+    const value = urlInput.trim();
+    setUrlPromptOpen(false);
+    if (!value) return;
+    await openUrl(value);
+  };
+
+  const handleToggleSavedPage = async () => {
+    if (!activeTabId) return;
+    const next = !pageSaved;
+    setPageSaved(next);
+    try {
+      await commands.setWebpageSaved(activeTabId, next);
+    } catch {
+      setPageSaved(!next);
+    }
+  };
+
+  const handleWebHistory = (delta: number) => {
+    const nav = (window as unknown as Record<string, unknown>).__webHistory as
+      | ((delta: number) => void)
+      | undefined;
+    nav?.(delta);
+  };
+
+  // .vellumweb export state for the active web tab
+  const [exportState, setExportState] = useState<{
+    status: "idle" | "exporting" | "done" | "error";
+    detail: string;
+  }>({ status: "idle", detail: "" });
+
+  useEffect(() => {
+    setExportState({ status: "idle", detail: "" });
+  }, [activeTabId, doc?.pdf_path]);
+
+  const handleExportVellumweb = async () => {
+    if (!activeTabId || !doc) return;
+
+    const slug =
+      (doc.title ?? "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 60) || "article";
+    const destPath = await save({
+      defaultPath: `${slug}.vellumweb`,
+      filters: [{ name: "Vellum Web Archive", extensions: ["vellumweb"] }],
+    });
+    if (!destPath) return;
+
+    const pageTexts = useAiStore.getState().pageTexts;
+    const pages = Object.keys(pageTexts)
+      .map(Number)
+      .filter((n) => Number.isFinite(n))
+      .sort((a, b) => a - b)
+      .map((number) => ({ number, text: pageTexts[number] }));
+
+    setExportState({ status: "exporting", detail: "Exporting…" });
+    try {
+      const summary = await commands.exportVellumweb(activeTabId, destPath, pages);
+      const sizeMb = (summary.bytes / (1024 * 1024)).toFixed(2);
+      setExportState({
+        status: "done",
+        detail: `Exported ${sizeMb} MB (${summary.asset_count} assets${
+          summary.assets_skipped > 0 ? `, ${summary.assets_skipped} skipped` : ""
+        })`,
+      });
+    } catch (err) {
+      setExportState({ status: "error", detail: String(err) });
+    }
+  };
+
+  // Find the bookmark at the current reading position (current page for PDFs,
+  // the on-screen anchor for webpages).
+  const currentBookmark = findCurrentBookmark(
+    annotations,
+    doc?.kind,
+    currentPage,
+    webVisibleRange,
   );
   const isBookmarked = !!currentBookmark;
 
@@ -199,10 +320,9 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
     const selected = await open({
       multiple: true,
       filters: [
-        {
-          name: "PDF",
-          extensions: ["pdf"],
-        },
+        { name: "Documents", extensions: ["pdf", "vellumweb"] },
+        { name: "PDF", extensions: ["pdf"] },
+        { name: "Vellum Web Archive", extensions: ["vellumweb"] },
       ],
     });
     if (!selected) return;
@@ -219,11 +339,7 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
   };
 
   const handleBookmark = async () => {
-    if (currentBookmark) {
-      await deleteAnnotation(currentBookmark.id);
-    } else {
-      await addBookmark(currentPage);
-    }
+    await toggleBookmark();
   };
 
   const handleResetZoom = () => {
@@ -266,16 +382,59 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
   }
 
   return (
-    <div className="flex h-11 items-center gap-0.5 border-b bg-background px-2">
+    <div className="relative flex h-11 items-center gap-0.5 border-b bg-background px-2">
       {/* File operations */}
       <IconButton onClick={handleOpen} title={`Open file (${shortcut("O")})`}>
         <FolderOpen size={16} />
       </IconButton>
 
-      {doc && (
+      <IconButton
+        variant={urlPromptOpen ? "active" : "ghost"}
+        onClick={() => setUrlPromptOpen((v) => !v)}
+        title={`Add webpage (${shortcut("L")})`}
+      >
+        <Globe size={16} />
+      </IconButton>
+
+      {urlPromptOpen && (
+        <div className="absolute left-2 top-11 z-50 mt-1 flex w-96 gap-1.5 rounded-lg border bg-background p-2 shadow-lg">
+          <input
+            ref={urlInputRef}
+            type="text"
+            className="focus-ring h-8 flex-1 rounded-md border border-border bg-surface px-2 text-sm text-foreground"
+            placeholder="Paste an article URL…"
+            value={urlInput}
+            onChange={(e) => setUrlInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleSubmitUrl();
+              if (e.key === "Escape") setUrlPromptOpen(false);
+            }}
+          />
+          <button
+            className="focus-ring h-8 rounded-md bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+            onClick={() => void handleSubmitUrl()}
+          >
+            Open
+          </button>
+        </div>
+      )}
+
+      {doc && !isWeb && (
         <IconButton onClick={handleSave} title={`Save (${shortcut("S")})`}>
           <Save size={16} />
         </IconButton>
+      )}
+
+      {doc && isWeb && (
+        <>
+          <Divider />
+          <IconButton onClick={() => handleWebHistory(-1)} title="Back">
+            <ArrowLeft size={16} />
+          </IconButton>
+          <IconButton onClick={() => handleWebHistory(1)} title="Forward">
+            <ArrowRight size={16} />
+          </IconButton>
+        </>
       )}
 
       {doc && (
@@ -343,19 +502,75 @@ export function Toolbar({ sidebarOpen, onToggleSidebar }: ToolbarProps) {
           <IconButton
             onClick={handleBookmark}
             className={cn(isBookmarked && "text-gold hover:text-gold")}
-            title={isBookmarked ? "Remove bookmark" : "Bookmark this page"}
+            title={
+              isBookmarked
+                ? "Remove bookmark"
+                : isWeb
+                  ? "Bookmark this spot"
+                  : "Bookmark this page"
+            }
           >
             <Bookmark size={16} fill={isBookmarked ? "currentColor" : "none"} />
           </IconButton>
 
-          {/* Sticky Note tool */}
-          <IconButton
-            variant={mode === "note" ? "active" : "ghost"}
-            onClick={() => setMode(mode === "note" ? "view" : "note")}
-            title="Sticky note tool (N) — click on the page to place a note"
-          >
-            <StickyNote size={16} />
-          </IconButton>
+          {/* Sticky Note tool (PDF only — web notes attach to selections) */}
+          {!isWeb && (
+            <IconButton
+              variant={mode === "note" ? "active" : "ghost"}
+              onClick={() => setMode(mode === "note" ? "view" : "note")}
+              title="Sticky note tool (N) — click on the page to place a note"
+            >
+              <StickyNote size={16} />
+            </IconButton>
+          )}
+
+          {/* Save webpage to library */}
+          {isWeb && (
+            <IconButton
+              onClick={() => void handleToggleSavedPage()}
+              className={cn(pageSaved && "text-gold hover:text-gold")}
+              title={
+                pageSaved
+                  ? "Remove from saved pages"
+                  : "Save page to library (keeps an offline snapshot)"
+              }
+            >
+              <BookmarkPlus size={16} fill={pageSaved ? "currentColor" : "none"} />
+            </IconButton>
+          )}
+
+          {/* Export portable .vellumweb archive */}
+          {isWeb && (
+            <IconButton
+              onClick={() => void handleExportVellumweb()}
+              disabled={exportState.status === "exporting"}
+              className={cn(
+                exportState.status === "done" && "text-emerald-600",
+                exportState.status === "error" && "text-destructive",
+              )}
+              title={
+                exportState.status === "idle"
+                  ? "Export as .vellumweb (portable archive with snapshot + annotations)"
+                  : exportState.detail
+              }
+            >
+              {exportState.status === "exporting" ? (
+                <LoaderCircle size={16} className="animate-spin" />
+              ) : (
+                <FileDown size={16} />
+              )}
+            </IconButton>
+          )}
+
+          {/* Page URL (web tabs) */}
+          {isWeb && (
+            <span
+              className="ml-1 max-w-[16rem] truncate text-xs text-muted-foreground"
+              title={doc.pdf_path}
+            >
+              {doc.pdf_path.replace(/^https?:\/\//, "")}
+            </span>
+          )}
         </>
       )}
 

--- a/src/components/web/WebNotePopovers.tsx
+++ b/src/components/web/WebNotePopovers.tsx
@@ -1,0 +1,299 @@
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
+import { useAnnotationStore } from "@/stores/annotation-store";
+import { StickyNote, Trash2 } from "lucide-react";
+
+/**
+ * Note popovers for webpage tabs. The page lives in a sandboxed iframe, so
+ * the PDF viewer's in-page sticky-note editor can't be composited over it;
+ * these app-shell popovers (anchored at iframe coordinates mapped by the
+ * caller) are the iframe-safe equivalent.
+ */
+
+type PopoverPlacement = "above" | "below" | "menu";
+
+/**
+ * Position a fixed popover near an anchor point, measured after render so the
+ * whole box is clamped inside the window (anchors near an edge — e.g. note
+ * markers in the left margin — must not push it offscreen). "above"/"below"
+ * center horizontally and flip vertically when there's no room; "menu" hangs
+ * from the point like a native context menu.
+ */
+function useAnchoredPosition(
+  x: number,
+  y: number,
+  placement: PopoverPlacement,
+): { ref: React.RefObject<HTMLDivElement | null>; style: CSSProperties } {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const measure = () => {
+      const { offsetWidth: w, offsetHeight: h } = el;
+      const margin = 8;
+
+      let left: number;
+      let top: number;
+      if (placement === "menu") {
+        left = x;
+        top = y;
+      } else {
+        left = x - w / 2;
+        top = placement === "above" ? y - h - 10 : y + 10;
+        // Flip when the preferred side lacks room.
+        if (placement === "above" && top < margin) top = y + 10;
+        if (placement === "below" && top + h > window.innerHeight - margin) {
+          top = y - h - 10;
+        }
+      }
+      left = Math.min(Math.max(left, margin), Math.max(margin, window.innerWidth - w - margin));
+      top = Math.min(Math.max(top, margin), Math.max(margin, window.innerHeight - h - margin));
+      setPos({ left, top });
+    };
+
+    measure();
+    // Re-clamp when the popover's own size changes (e.g. the viewer growing
+    // when it enters edit mode) or the window is resized.
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    window.addEventListener("resize", measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [x, y, placement]);
+
+  return {
+    ref,
+    style: pos
+      ? { left: pos.left, top: pos.top }
+      : // Render invisibly at the anchor for the measuring frame.
+        { left: x, top: y, visibility: "hidden" as const },
+  };
+}
+
+interface WebNoteComposerProps {
+  x: number;
+  y: number;
+  onSubmit: (content: string) => void;
+  onClose: () => void;
+}
+
+export function WebNoteComposer({ x, y, onSubmit, onClose }: WebNoteComposerProps) {
+  const [text, setText] = useState("");
+  const { ref, style } = useAnchoredPosition(x, y, "below");
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 w-72 rounded-lg border bg-background p-2 shadow-lg"
+      style={style}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <StickyNote size={13} className="text-amber-500" />
+        New note
+      </div>
+      <textarea
+        className="h-20 w-full resize-none rounded border bg-muted px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary"
+        placeholder="Write a note…"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            submit();
+          }
+          if (e.key === "Escape") onClose();
+        }}
+        autoFocus
+      />
+      <div className="mt-1.5 flex justify-end gap-1.5">
+        <button
+          className="focus-ring rounded-md px-2.5 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+          onClick={onClose}
+        >
+          Cancel
+        </button>
+        <button
+          className="focus-ring rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          onClick={submit}
+          disabled={!text.trim()}
+        >
+          Add note
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface WebContextMenuProps {
+  x: number;
+  y: number;
+  canAddNote: boolean;
+  onAddNote: () => void;
+  onClose: () => void;
+}
+
+export function WebContextMenu({ x, y, canAddNote, onAddNote, onClose }: WebContextMenuProps) {
+  const { ref, style } = useAnchoredPosition(x, y, "menu");
+
+  // Dismiss on any app-shell click or Escape (clicks inside the iframe are
+  // handled by the caller via content-script messages).
+  useEffect(() => {
+    const dismiss = () => onClose();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("click", dismiss);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("click", dismiss);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 min-w-[160px] rounded-lg border bg-background py-1 shadow-lg"
+      style={style}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <button
+        className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-accent disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent"
+        onClick={onAddNote}
+        disabled={!canAddNote}
+        title={canAddNote ? undefined : "No text near this spot to attach a note to"}
+      >
+        <StickyNote size={14} className="text-amber-500" />
+        Add note here
+      </button>
+    </div>
+  );
+}
+
+interface WebNoteViewerProps {
+  annotationId: string;
+  x: number;
+  y: number;
+  onClose: () => void;
+}
+
+export function WebNoteViewer({ annotationId, x, y, onClose }: WebNoteViewerProps) {
+  const annotation = useAnnotationStore((s) =>
+    s.annotations.find((a) => a.id === annotationId),
+  );
+  const updateAnnotation = useAnnotationStore((s) => s.updateAnnotation);
+  const deleteAnnotation = useAnnotationStore((s) => s.deleteAnnotation);
+
+  // Open straight into editing when the note has no content yet.
+  const [isEditing, setIsEditing] = useState(!annotation?.content);
+  const [text, setText] = useState(annotation?.content ?? "");
+  const { ref, style } = useAnchoredPosition(x, y, "above");
+
+  if (!annotation) return null;
+
+  const save = () => {
+    const trimmed = text.trim();
+    if (trimmed !== (annotation.content ?? "")) {
+      void updateAnnotation({ id: annotation.id, content: trimmed });
+    }
+    setIsEditing(false);
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="fixed z-50 w-72 rounded-lg border bg-background p-2 shadow-lg"
+      style={style}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      <div className="mb-1.5 flex items-center justify-between">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <StickyNote size={13} className="text-amber-500" />
+          Note
+        </span>
+        <button
+          className="focus-ring flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-destructive"
+          onClick={() => {
+            void deleteAnnotation(annotation.id);
+            onClose();
+          }}
+          title="Delete note"
+        >
+          <Trash2 size={13} />
+        </button>
+      </div>
+
+      {isEditing ? (
+        <>
+          <textarea
+            className="h-20 w-full resize-none rounded border bg-muted px-2 py-1.5 text-sm outline-none focus:ring-1 focus:ring-primary"
+            placeholder="Write a note…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                save();
+              }
+              if (e.key === "Escape") onClose();
+            }}
+            autoFocus
+          />
+          <div className="mt-1.5 flex justify-end gap-1.5">
+            <button
+              className="focus-ring rounded-md px-2.5 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              className="focus-ring rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+              onClick={save}
+            >
+              Save
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="max-h-40 overflow-auto whitespace-pre-wrap break-words px-0.5 text-sm text-foreground">
+            {annotation.content}
+          </p>
+          {annotation.position_data?.selected_text && (
+            <p className="mt-1.5 truncate border-l-2 border-amber-300 pl-2 text-xs italic text-muted-foreground">
+              {annotation.position_data.selected_text}
+            </p>
+          )}
+          <div className="mt-1.5 flex justify-end">
+            <button
+              className="focus-ring rounded-md px-2.5 py-1 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+              onClick={() => {
+                setText(annotation.content ?? "");
+                setIsEditing(true);
+              }}
+            >
+              Edit
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/web/WebViewer.tsx
+++ b/src/components/web/WebViewer.tsx
@@ -345,6 +345,13 @@ export function WebViewer() {
               end: data.visibleEnd,
             });
           }
+          if (Array.isArray(data.visibleBookmarks)) {
+            store.setWebVisibleBookmarks(
+              (data.visibleBookmarks as unknown[]).filter(
+                (id): id is string => typeof id === "string",
+              ),
+            );
+          }
           break;
         }
 
@@ -577,7 +584,17 @@ export function WebViewer() {
           a.position_data?.start_offset != null,
       )
       .map((a) => ({ ...anchor(a), content: a.content ?? "" }));
-    postToFrame("apply-annotations", { highlights, notes });
+    // Point bookmarks go along too so the content script can re-anchor them
+    // and report which are on screen (drives the toolbar bookmark state).
+    const bookmarks = annotations
+      .filter(
+        (a) =>
+          a.type === "bookmark" &&
+          a.position_data?.selected_text &&
+          a.position_data?.start_offset != null,
+      )
+      .map(anchor);
+    postToFrame("apply-annotations", { highlights, notes, bookmarks });
   }, [annotations, initCount, postToFrame]);
 
   // --- Keep the frame's interaction mode in sync (note placement) ---

--- a/src/components/web/WebViewer.tsx
+++ b/src/components/web/WebViewer.tsx
@@ -1,0 +1,539 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePdfStore } from "@/stores/pdf-store";
+import { useAnnotationStore } from "@/stores/annotation-store";
+import { useAiStore } from "@/stores/ai-store";
+import { SelectionPopover } from "@/components/annotations/SelectionPopover";
+import * as commands from "@/lib/tauri-commands";
+import type { PositionData } from "@/types";
+import { WifiOff } from "lucide-react";
+
+// Tauri custom protocols are exposed as `<scheme>://localhost/` on
+// macOS/Linux and `http://<scheme>.localhost/` on Windows.
+const IS_WINDOWS = navigator.userAgent.includes("Windows");
+
+function webProxyUrl(target: string): string {
+  const query = `?url=${encodeURIComponent(target)}`;
+  return IS_WINDOWS
+    ? `http://vellum-web.localhost/${query}`
+    : `vellum-web://localhost/${query}`;
+}
+
+interface FrameRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface WebSelection {
+  text: string;
+  pageNumber: number;
+  positionData: PositionData;
+}
+
+interface LocatedWebText {
+  positionData: PositionData;
+  pageNumber: number;
+}
+
+interface PendingLocate {
+  resolve: (value: LocatedWebText | null) => void;
+  timer: number;
+}
+
+interface CapturedWebPosition {
+  pageNumber: number;
+  positionData: PositionData;
+}
+
+interface PendingCapture {
+  resolve: (value: CapturedWebPosition | null) => void;
+  timer: number;
+}
+
+export function WebViewer() {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const pendingLocatesRef = useRef<Map<string, PendingLocate>>(new Map());
+  const pendingCapturesRef = useRef<Map<string, PendingCapture>>(new Map());
+  // Whether the injected content script supports point anchors (declared in
+  // its init handshake). False for older embedded scripts.
+  const supportsPositionsRef = useRef(false);
+  // Auto-archive bookkeeping: the URL already archived this mount, and a
+  // debounce timer so the fullest text extraction wins.
+  const archivedUrlRef = useRef<string | null>(null);
+  const archiveTimerRef = useRef<number | null>(null);
+  // The tab this viewer instance was mounted for. Messages processed after a
+  // tab switch (queued before React unmounts the old viewer) must not act on
+  // the new active tab's state.
+  const mountTabIdRef = useRef<string | null>(usePdfStore.getState().activeTabId);
+  // Target of an in-flight link navigation: late messages from the outgoing
+  // document (e.g. its delayed re-extraction init) are ignored until the new
+  // document reports in, so they can't rebind the tab backwards.
+  const pendingNavUrlRef = useRef<string | null>(null);
+  // URL whose reading position has already been restored this mount; the
+  // content script re-sends init after late re-extraction and that must not
+  // yank the reader back.
+  const restoredUrlRef = useRef<string | null>(null);
+
+  const doc = usePdfStore((s) => s.document);
+  const activeTabId = usePdfStore((s) => s.activeTabId);
+  const zoom = usePdfStore((s) => s.zoom);
+  const annotations = useAnnotationStore((s) => s.annotations);
+  const selectedAnnotationId = useAnnotationStore((s) => s.selectedAnnotationId);
+
+  // Counts inits from the document currently bound to this tab; 0 = nothing
+  // loaded yet. A counter (not a boolean) so highlight application re-fires
+  // after in-tab navigation replaces the document.
+  const [initCount, setInitCount] = useState(0);
+  const [isOffline, setIsOffline] = useState(false);
+  const [selection, setSelection] = useState<WebSelection | null>(null);
+  const [popoverPosition, setPopoverPosition] = useState<{ x: number; y: number } | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  // The iframe src is set once per mount; link navigation swaps it explicitly.
+  const [frameSrc, setFrameSrc] = useState(() =>
+    doc ? webProxyUrl(doc.pdf_path) : "about:blank",
+  );
+
+  const postToFrame = useCallback((vellumCmd: string, payload?: Record<string, unknown>) => {
+    iframeRef.current?.contentWindow?.postMessage({ vellumCmd, ...payload }, "*");
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelection(null);
+    setPopoverPosition(null);
+    postToFrame("clear-selection");
+  }, [postToFrame]);
+
+  const cancelPendingArchive = useCallback(() => {
+    if (archiveTimerRef.current !== null) {
+      window.clearTimeout(archiveTimerRef.current);
+      archiveTimerRef.current = null;
+    }
+  }, []);
+
+  // --- Inbound messages from the content script ---
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      const frame = iframeRef.current;
+      if (!frame || event.source !== frame.contentWindow) return;
+      const data = event.data as Record<string, unknown> | null;
+      if (!data || data.vellum !== true || typeof data.type !== "string") return;
+
+      const store = usePdfStore.getState();
+      // Drop messages queued from before a tab switch: this viewer belongs to
+      // one tab, and acting on another tab's state would corrupt it.
+      if (store.activeTabId !== mountTabIdRef.current) return;
+
+      switch (data.type) {
+        case "init": {
+          const tabId = store.activeTabId;
+          const currentDoc = store.document;
+          if (!tabId || !currentDoc) break;
+
+          const reportedUrl = typeof data.url === "string" ? data.url : null;
+
+          // Mid-navigation: ignore late reports from the outgoing document
+          // (its delayed re-extraction) so they can't rebind us backwards.
+          if (pendingNavUrlRef.current !== null) {
+            if (reportedUrl !== pendingNavUrlRef.current) break;
+            pendingNavUrlRef.current = null;
+          }
+
+          setIsOffline(Boolean(data.offline));
+          supportsPositionsRef.current = Boolean(data.positionAnchors);
+
+          if (reportedUrl && reportedUrl !== currentDoc.pdf_path) {
+            // The frame navigated (back/forward or a redirect changed the
+            // effective URL): rebind the session, then ask the page to
+            // report again so the fresh context lands after the App-level
+            // document reset.
+            cancelPendingArchive();
+            void store.webNavigated(tabId, reportedUrl).then((rebound) => {
+              if (rebound) postToFrame("request-init");
+            });
+            break;
+          }
+
+          setInitCount((count) => count + 1);
+
+          const pageCount = typeof data.pageCount === "number" ? data.pageCount : 0;
+          if (pageCount > 0) store.setNumPages(pageCount);
+
+          const pages = Array.isArray(data.pages)
+            ? (data.pages as Array<{ number: number; text: string }>)
+            : [];
+          const setPageText = useAiStore.getState().setPageText;
+          for (const page of pages) {
+            if (typeof page?.number === "number" && typeof page?.text === "string") {
+              setPageText(page.number, page.text);
+            }
+          }
+
+          if (typeof data.title === "string" && data.title) {
+            store.updateDocumentTitle(tabId, data.title);
+            commands.setDocumentMetadata(tabId, "title", data.title).catch(() => {});
+          }
+
+          // Default behaviour: archive every opened page as a .vellumweb in
+          // the managed library. Skip when we're already showing a snapshot
+          // (offline) — re-archiving from a fallback would only degrade it.
+          // Debounced so a late re-extraction with fuller text wins, and run
+          // once per URL per mount. The Rust side re-checks the URL, so a
+          // navigation that slips between the timer and the command can't
+          // archive mismatched content.
+          if (!data.offline && archivedUrlRef.current !== currentDoc.pdf_path) {
+            const archiveTabId = tabId;
+            const archiveUrl = currentDoc.pdf_path;
+            const pagesForArchive = pages.filter(
+              (p) => typeof p?.number === "number" && typeof p?.text === "string",
+            );
+            cancelPendingArchive();
+            archiveTimerRef.current = window.setTimeout(() => {
+              archiveTimerRef.current = null;
+              archivedUrlRef.current = archiveUrl;
+              commands
+                .archiveWebpageDefault(archiveTabId, pagesForArchive, archiveUrl)
+                .catch(() => {
+                  // Non-fatal: reading works without the archive. Allow a
+                  // retry on the next init for this URL.
+                  if (archivedUrlRef.current === archiveUrl) {
+                    archivedUrlRef.current = null;
+                  }
+                });
+            }, 1500);
+          }
+
+          // Restore the reading position once per document; later inits from
+          // re-extraction must not yank the reader away from where they are.
+          if (restoredUrlRef.current !== currentDoc.pdf_path) {
+            restoredUrlRef.current = currentDoc.pdf_path;
+            const target = store.currentPage;
+            if (target > 1) postToFrame("scroll-to-page", { page: target });
+          }
+          break;
+        }
+
+        case "scroll": {
+          if (typeof data.currentPage === "number") {
+            store.setCurrentPage(data.currentPage);
+          }
+          if (Array.isArray(data.visiblePages)) {
+            store.setVisiblePages(data.visiblePages as number[]);
+          }
+          if (
+            typeof data.visibleStart === "number" &&
+            typeof data.visibleEnd === "number"
+          ) {
+            store.setWebVisibleRange({
+              start: data.visibleStart,
+              end: data.visibleEnd,
+            });
+          }
+          break;
+        }
+
+        case "selection": {
+          const rects = Array.isArray(data.rects) ? (data.rects as FrameRect[]) : [];
+          const text = typeof data.text === "string" ? data.text : "";
+          if (!text || rects.length === 0) break;
+
+          const frameRect = frame.getBoundingClientRect();
+          const scale = usePdfStore.getState().zoom;
+          const last = rects[rects.length - 1];
+
+          setPopoverPosition({
+            x: frameRect.left + (last.x + last.width / 2) * scale,
+            y: frameRect.top + last.y * scale - 10,
+          });
+          setSelection({
+            text,
+            pageNumber: typeof data.pageNumber === "number" ? data.pageNumber : 1,
+            positionData: {
+              rects: [],
+              page_width: 1,
+              page_height: 1,
+              selected_text: text,
+              start_offset: typeof data.start === "number" ? data.start : null,
+              end_offset: typeof data.end === "number" ? data.end : null,
+              prefix: typeof data.prefix === "string" ? data.prefix : null,
+              suffix: typeof data.suffix === "string" ? data.suffix : null,
+            },
+          });
+          break;
+        }
+
+        case "selection-cleared": {
+          setSelection(null);
+          setPopoverPosition(null);
+          break;
+        }
+
+        case "navigate": {
+          const url = typeof data.url === "string" ? data.url : null;
+          const tabId = store.activeTabId;
+          if (!url || !tabId) break;
+          // A pending auto-archive for the outgoing page must not fire
+          // against the rebound session.
+          cancelPendingArchive();
+          clearSelection();
+          void store.webNavigated(tabId, url).then((rebound) => {
+            if (rebound) {
+              pendingNavUrlRef.current = rebound.pdf_path;
+              setInitCount(0);
+              setFrameSrc(webProxyUrl(rebound.pdf_path));
+            }
+          });
+          break;
+        }
+
+        case "viewport-scrolled": {
+          // The selection popover is positioned in app-shell coordinates from
+          // selection-time rects; scrolling the page underneath invalidates
+          // it (mirrors the PDF viewer's scroll behaviour).
+          setSelection((current) => {
+            if (current) {
+              setPopoverPosition(null);
+              postToFrame("clear-selection");
+              return null;
+            }
+            return current;
+          });
+          break;
+        }
+
+        case "locate-result": {
+          const requestId = typeof data.requestId === "string" ? data.requestId : null;
+          if (!requestId) break;
+          const pending = pendingLocatesRef.current.get(requestId);
+          if (!pending) break;
+          pendingLocatesRef.current.delete(requestId);
+          window.clearTimeout(pending.timer);
+          if (data.found && typeof data.start === "number" && typeof data.end === "number") {
+            pending.resolve({
+              pageNumber: typeof data.pageNumber === "number" ? data.pageNumber : 0,
+              positionData: {
+                rects: [],
+                page_width: 1,
+                page_height: 1,
+                selected_text: null,
+                start_offset: data.start,
+                end_offset: data.end,
+                prefix: typeof data.prefix === "string" ? data.prefix : null,
+                suffix: typeof data.suffix === "string" ? data.suffix : null,
+              },
+            });
+          } else {
+            pending.resolve(null);
+          }
+          break;
+        }
+
+        case "position-result": {
+          const requestId = typeof data.requestId === "string" ? data.requestId : null;
+          if (!requestId) break;
+          const pending = pendingCapturesRef.current.get(requestId);
+          if (!pending) break;
+          pendingCapturesRef.current.delete(requestId);
+          window.clearTimeout(pending.timer);
+          if (
+            data.found &&
+            typeof data.start === "number" &&
+            typeof data.end === "number" &&
+            typeof data.text === "string"
+          ) {
+            pending.resolve({
+              pageNumber: typeof data.pageNumber === "number" ? data.pageNumber : 1,
+              positionData: {
+                rects: [],
+                page_width: 1,
+                page_height: 1,
+                selected_text: data.text,
+                start_offset: data.start,
+                end_offset: data.end,
+                prefix: typeof data.prefix === "string" ? data.prefix : null,
+                suffix: typeof data.suffix === "string" ? data.suffix : null,
+                viewport_offset: typeof data.offset === "number" ? data.offset : null,
+              },
+            });
+          } else {
+            pending.resolve(null);
+          }
+          break;
+        }
+      }
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [postToFrame, cancelPendingArchive, clearSelection]);
+
+  // --- Push highlight annotations into the frame ---
+  useEffect(() => {
+    if (initCount === 0) return;
+    const highlights = annotations
+      .filter((a) => a.type === "highlight" && a.position_data?.selected_text)
+      .map((a) => ({
+        id: a.id,
+        color: a.color ?? "#fef08a",
+        start: a.position_data?.start_offset ?? null,
+        end: a.position_data?.end_offset ?? null,
+        text: a.position_data?.selected_text ?? "",
+        prefix: a.position_data?.prefix ?? null,
+        suffix: a.position_data?.suffix ?? null,
+      }));
+    postToFrame("apply-annotations", { highlights });
+  }, [annotations, initCount, postToFrame]);
+
+  // --- Scroll to an annotation when it is selected in the sidebar ---
+  useEffect(() => {
+    if (initCount === 0 || !selectedAnnotationId) return;
+    const annotation = annotations.find((a) => a.id === selectedAnnotationId);
+    if (annotation?.type === "highlight" && annotation.position_data?.selected_text) {
+      postToFrame("scroll-to-annotation", { id: selectedAnnotationId });
+    } else if (
+      annotation?.type === "bookmark" &&
+      annotation.position_data?.start_offset != null
+    ) {
+      const pd = annotation.position_data;
+      postToFrame("scroll-to-position", {
+        start: pd.start_offset,
+        end: pd.end_offset,
+        text: pd.selected_text,
+        prefix: pd.prefix ?? null,
+        suffix: pd.suffix ?? null,
+        offset: pd.viewport_offset ?? null,
+        page: annotation.page_number,
+      });
+    }
+    // Scrolling should re-run only when the selection changes, not when the
+    // annotation list is refreshed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAnnotationId, initCount, postToFrame]);
+
+  // --- Global hooks used by the toolbar, sidebar, and AI tool execution ---
+  useEffect(() => {
+    const globals = window as unknown as Record<string, unknown>;
+
+    globals.__scrollToPage = (page: number) => {
+      postToFrame("scroll-to-page", { page });
+    };
+
+    globals.__webHistory = (delta: number) => {
+      postToFrame("history", { delta });
+    };
+
+    globals.__locateWebText = (page: number, text: string) =>
+      new Promise<LocatedWebText | null>((resolve) => {
+        const requestId = crypto.randomUUID();
+        const timer = window.setTimeout(() => {
+          pendingLocatesRef.current.delete(requestId);
+          resolve(null);
+        }, 4000);
+        pendingLocatesRef.current.set(requestId, { resolve, timer });
+        postToFrame("locate-text", { requestId, page, text });
+      });
+
+    globals.__captureWebPosition = () =>
+      new Promise<CapturedWebPosition | null>((resolve) => {
+        if (!supportsPositionsRef.current) {
+          resolve(null);
+          return;
+        }
+        const requestId = crypto.randomUUID();
+        const timer = window.setTimeout(() => {
+          pendingCapturesRef.current.delete(requestId);
+          resolve(null);
+        }, 1500);
+        pendingCapturesRef.current.set(requestId, { resolve, timer });
+        postToFrame("capture-position", { requestId });
+      });
+
+    globals.__scrollToWebPosition = (pd: PositionData, page?: number) => {
+      if (!supportsPositionsRef.current) return false;
+      postToFrame("scroll-to-position", {
+        start: pd.start_offset,
+        end: pd.end_offset,
+        text: pd.selected_text,
+        prefix: pd.prefix ?? null,
+        suffix: pd.suffix ?? null,
+        offset: pd.viewport_offset ?? null,
+        page,
+      });
+      return true;
+    };
+
+    return () => {
+      delete globals.__scrollToPage;
+      delete globals.__webHistory;
+      delete globals.__locateWebText;
+      delete globals.__captureWebPosition;
+      delete globals.__scrollToWebPosition;
+    };
+  }, [postToFrame]);
+
+  // Reject in-flight locates and cancel a pending archive when the viewer
+  // unmounts.
+  useEffect(() => {
+    const pendingLocates = pendingLocatesRef.current;
+    const pendingCaptures = pendingCapturesRef.current;
+    return () => {
+      for (const pending of pendingLocates.values()) {
+        window.clearTimeout(pending.timer);
+        pending.resolve(null);
+      }
+      pendingLocates.clear();
+      for (const pending of pendingCaptures.values()) {
+        window.clearTimeout(pending.timer);
+        pending.resolve(null);
+      }
+      pendingCaptures.clear();
+      if (archiveTimerRef.current !== null) {
+        window.clearTimeout(archiveTimerRef.current);
+        archiveTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  if (!doc || !activeTabId) return null;
+
+  // Zoom is applied by scaling the iframe itself: the page reflows to a
+  // narrower layout width, like a browser text zoom. The content script
+  // stays zoom-agnostic; selection rects are scaled back here.
+  const inverse = 100 / zoom;
+
+  return (
+    <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-well">
+      <iframe
+        ref={iframeRef}
+        src={frameSrc}
+        title={doc.title ?? doc.pdf_path}
+        className="border-0 bg-white"
+        style={{
+          width: `${inverse}%`,
+          height: `${inverse}%`,
+          transform: `scale(${zoom})`,
+          transformOrigin: "0 0",
+        }}
+        sandbox="allow-scripts allow-same-origin allow-forms"
+      />
+
+      {isOffline && (
+        <div className="absolute right-3 top-3 z-40 flex items-center gap-1.5 rounded-full border border-border bg-background/95 px-2.5 py-1 text-xs text-muted-foreground shadow-soft">
+          <WifiOff size={12} />
+          Offline snapshot
+        </div>
+      )}
+
+      {selection && popoverPosition && (
+        <SelectionPopover
+          ref={popoverRef}
+          position={popoverPosition}
+          selection={selection}
+          currentPage={selection.pageNumber}
+          onClose={clearSelection}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/web/WebViewer.tsx
+++ b/src/components/web/WebViewer.tsx
@@ -3,6 +3,11 @@ import { usePdfStore } from "@/stores/pdf-store";
 import { useAnnotationStore } from "@/stores/annotation-store";
 import { useAiStore } from "@/stores/ai-store";
 import { SelectionPopover } from "@/components/annotations/SelectionPopover";
+import {
+  WebContextMenu,
+  WebNoteComposer,
+  WebNoteViewer,
+} from "@/components/web/WebNotePopovers";
 import * as commands from "@/lib/tauri-commands";
 import type { PositionData } from "@/types";
 import { WifiOff } from "lucide-react";
@@ -13,6 +18,10 @@ const IS_WINDOWS = navigator.userAgent.includes("Windows");
 
 function webProxyUrl(target: string): string {
   const query = `?url=${encodeURIComponent(target)}`;
+  // Test hook: lets browser-based integration tests substitute an HTTP proxy
+  // for the vellum-web custom protocol (which only exists inside Tauri).
+  const devProxy = (window as unknown as Record<string, unknown>).__VELLUM_DEV_PROXY__;
+  if (typeof devProxy === "string") return `${devProxy}${query}`;
   return IS_WINDOWS
     ? `http://vellum-web.localhost/${query}`
     : `vellum-web://localhost/${query}`;
@@ -44,6 +53,59 @@ interface PendingLocate {
 interface CapturedWebPosition {
   pageNumber: number;
   positionData: PositionData;
+}
+
+/** Text-quote anchor for a note placed at a point in the page. */
+interface WebNoteAnchor {
+  start: number;
+  end: number;
+  text: string;
+  prefix: string | null;
+  suffix: string | null;
+  pageNumber: number;
+}
+
+interface NoteComposerState {
+  x: number;
+  y: number;
+  anchor: WebNoteAnchor;
+  openedAt: number;
+}
+
+interface WebContextMenuState {
+  x: number;
+  y: number;
+  anchor: WebNoteAnchor | null;
+  openedAt: number;
+}
+
+interface NoteViewerState {
+  id: string;
+  x: number;
+  y: number;
+  openedAt: number;
+}
+
+function parseNoteAnchor(data: Record<string, unknown>): WebNoteAnchor | null {
+  if (
+    typeof data.start !== "number" ||
+    typeof data.end !== "number" ||
+    typeof data.text !== "string" ||
+    !data.text
+  ) {
+    return null;
+  }
+  return {
+    start: data.start,
+    end: data.end,
+    text: data.text,
+    prefix: typeof data.prefix === "string" ? data.prefix : null,
+    suffix: typeof data.suffix === "string" ? data.suffix : null,
+    pageNumber:
+      typeof data.pageNumber === "number" && data.pageNumber >= 1
+        ? data.pageNumber
+        : 1,
+  };
 }
 
 interface PendingCapture {
@@ -78,6 +140,7 @@ export function WebViewer() {
   const doc = usePdfStore((s) => s.document);
   const activeTabId = usePdfStore((s) => s.activeTabId);
   const zoom = usePdfStore((s) => s.zoom);
+  const mode = usePdfStore((s) => s.mode);
   const annotations = useAnnotationStore((s) => s.annotations);
   const selectedAnnotationId = useAnnotationStore((s) => s.selectedAnnotationId);
 
@@ -89,6 +152,13 @@ export function WebViewer() {
   const [selection, setSelection] = useState<WebSelection | null>(null);
   const [popoverPosition, setPopoverPosition] = useState<{ x: number; y: number } | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  // Note UI popovers (rendered in the app shell, anchored over the iframe):
+  // composer for new notes, context menu for right-clicks, viewer for
+  // clicking an existing marker.
+  const [noteComposer, setNoteComposer] = useState<NoteComposerState | null>(null);
+  const [webContextMenu, setWebContextMenu] = useState<WebContextMenuState | null>(null);
+  const [noteViewer, setNoteViewer] = useState<NoteViewerState | null>(null);
 
   // The iframe src is set once per mount; link navigation swaps it explicitly.
   const [frameSrc, setFrameSrc] = useState(() =>
@@ -110,6 +180,48 @@ export function WebViewer() {
       window.clearTimeout(archiveTimerRef.current);
       archiveTimerRef.current = null;
     }
+  }, []);
+
+  // Map iframe-viewport coordinates to app-shell coordinates (the iframe is
+  // scaled by the zoom transform).
+  const frameToParent = useCallback((x: number, y: number) => {
+    const rect = iframeRef.current?.getBoundingClientRect();
+    const scale = usePdfStore.getState().zoom;
+    return {
+      x: (rect?.left ?? 0) + x * scale,
+      y: (rect?.top ?? 0) + y * scale,
+    };
+  }, []);
+
+  const closeNotePopovers = useCallback(() => {
+    setNoteComposer(null);
+    setWebContextMenu(null);
+    setNoteViewer(null);
+  }, []);
+
+  const createAnchoredNote = useCallback((anchor: WebNoteAnchor, content: string) => {
+    void useAnnotationStore
+      .getState()
+      .addNote({
+        type: "note",
+        page_number: anchor.pageNumber,
+        content,
+        position_data: {
+          rects: [],
+          page_width: 1,
+          page_height: 1,
+          selected_text: anchor.text,
+          start_offset: anchor.start,
+          end_offset: anchor.end,
+          prefix: anchor.prefix,
+          suffix: anchor.suffix,
+        },
+      })
+      .then((annotation) => {
+        if (annotation) {
+          useAnnotationStore.getState().selectAnnotation(annotation.id);
+        }
+      });
   }, []);
 
   // --- Inbound messages from the content script ---
@@ -147,8 +259,11 @@ export function WebViewer() {
             // The frame navigated (back/forward or a redirect changed the
             // effective URL): rebind the session, then ask the page to
             // report again so the fresh context lands after the App-level
-            // document reset.
+            // document reset. Any open note popovers belong to the outgoing
+            // document — submitting them against the new one would save
+            // wrong-page anchors.
             cancelPendingArchive();
+            closeNotePopovers();
             void store.webNavigated(tabId, reportedUrl).then((rebound) => {
               if (rebound) postToFrame("request-init");
             });
@@ -266,6 +381,69 @@ export function WebViewer() {
         case "selection-cleared": {
           setSelection(null);
           setPopoverPosition(null);
+          // A plain click inside the page doubles as "click outside" for the
+          // note popovers (parent-window clicks can't reach the iframe). The
+          // grace period keeps the event fired by the opening click itself
+          // from instantly dismissing them.
+          const clickOutside = (openedAt: number) => Date.now() - openedAt > 400;
+          setWebContextMenu((cur) => (cur && clickOutside(cur.openedAt) ? null : cur));
+          setNoteViewer((cur) => (cur && clickOutside(cur.openedAt) ? null : cur));
+          setNoteComposer((cur) => (cur && clickOutside(cur.openedAt) ? null : cur));
+          break;
+        }
+
+        case "note-placed": {
+          const anchor = parseNoteAnchor(data);
+          if (!anchor) break;
+          const point = frameToParent(
+            typeof data.x === "number" ? data.x : 0,
+            typeof data.y === "number" ? data.y : 0,
+          );
+          setWebContextMenu(null);
+          setNoteViewer(null);
+          setNoteComposer({
+            x: point.x,
+            y: point.y,
+            anchor,
+            openedAt: Date.now(),
+          });
+          // Mirror the PDF viewer: placing a note returns to view mode.
+          store.setMode("view");
+          break;
+        }
+
+        case "context-menu": {
+          const point = frameToParent(
+            typeof data.x === "number" ? data.x : 0,
+            typeof data.y === "number" ? data.y : 0,
+          );
+          setNoteComposer(null);
+          setNoteViewer(null);
+          setWebContextMenu({
+            x: point.x,
+            y: point.y,
+            anchor: data.found ? parseNoteAnchor(data) : null,
+            openedAt: Date.now(),
+          });
+          break;
+        }
+
+        case "annotation-click": {
+          const id = typeof data.id === "string" ? data.id : null;
+          if (!id) break;
+          useAnnotationStore.getState().selectAnnotation(id);
+          const annotation = useAnnotationStore
+            .getState()
+            .annotations.find((a) => a.id === id);
+          if (annotation?.type === "note") {
+            const point = frameToParent(
+              typeof data.x === "number" ? data.x : 0,
+              typeof data.y === "number" ? data.y : 0,
+            );
+            setNoteComposer(null);
+            setWebContextMenu(null);
+            setNoteViewer({ id, x: point.x, y: point.y, openedAt: Date.now() });
+          }
           break;
         }
 
@@ -277,6 +455,7 @@ export function WebViewer() {
           // against the rebound session.
           cancelPendingArchive();
           clearSelection();
+          closeNotePopovers();
           void store.webNavigated(tabId, url).then((rebound) => {
             if (rebound) {
               pendingNavUrlRef.current = rebound.pdf_path;
@@ -288,9 +467,9 @@ export function WebViewer() {
         }
 
         case "viewport-scrolled": {
-          // The selection popover is positioned in app-shell coordinates from
-          // selection-time rects; scrolling the page underneath invalidates
-          // it (mirrors the PDF viewer's scroll behaviour).
+          // Popovers are positioned in app-shell coordinates from event-time
+          // rects; scrolling the page underneath invalidates them (mirrors
+          // the PDF viewer's scroll behaviour).
           setSelection((current) => {
             if (current) {
               setPopoverPosition(null);
@@ -299,6 +478,13 @@ export function WebViewer() {
             }
             return current;
           });
+          setWebContextMenu(null);
+          setNoteViewer(null);
+          // Keep the composer only if it just opened (the placement click
+          // can nudge scroll on some pages); otherwise typing continues.
+          setNoteComposer((current) =>
+            current && Date.now() - current.openedAt < 400 ? current : null,
+          );
           break;
         }
 
@@ -366,30 +552,48 @@ export function WebViewer() {
 
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, [postToFrame, cancelPendingArchive, clearSelection]);
+  }, [postToFrame, cancelPendingArchive, clearSelection, closeNotePopovers, frameToParent]);
 
-  // --- Push highlight annotations into the frame ---
+  // --- Push highlight + note annotations into the frame ---
   useEffect(() => {
     if (initCount === 0) return;
+    const anchor = (a: (typeof annotations)[number]) => ({
+      id: a.id,
+      color: a.color ?? "#fef08a",
+      start: a.position_data?.start_offset ?? null,
+      end: a.position_data?.end_offset ?? null,
+      text: a.position_data?.selected_text ?? "",
+      prefix: a.position_data?.prefix ?? null,
+      suffix: a.position_data?.suffix ?? null,
+    });
     const highlights = annotations
       .filter((a) => a.type === "highlight" && a.position_data?.selected_text)
-      .map((a) => ({
-        id: a.id,
-        color: a.color ?? "#fef08a",
-        start: a.position_data?.start_offset ?? null,
-        end: a.position_data?.end_offset ?? null,
-        text: a.position_data?.selected_text ?? "",
-        prefix: a.position_data?.prefix ?? null,
-        suffix: a.position_data?.suffix ?? null,
-      }));
-    postToFrame("apply-annotations", { highlights });
+      .map(anchor);
+    const notes = annotations
+      .filter(
+        (a) =>
+          a.type === "note" &&
+          a.position_data?.selected_text &&
+          a.position_data?.start_offset != null,
+      )
+      .map((a) => ({ ...anchor(a), content: a.content ?? "" }));
+    postToFrame("apply-annotations", { highlights, notes });
   }, [annotations, initCount, postToFrame]);
+
+  // --- Keep the frame's interaction mode in sync (note placement) ---
+  useEffect(() => {
+    if (initCount === 0) return;
+    postToFrame("set-mode", { mode });
+  }, [mode, initCount, postToFrame]);
 
   // --- Scroll to an annotation when it is selected in the sidebar ---
   useEffect(() => {
     if (initCount === 0 || !selectedAnnotationId) return;
     const annotation = annotations.find((a) => a.id === selectedAnnotationId);
-    if (annotation?.type === "highlight" && annotation.position_data?.selected_text) {
+    if (
+      (annotation?.type === "highlight" || annotation?.type === "note") &&
+      annotation.position_data?.selected_text
+    ) {
       postToFrame("scroll-to-annotation", { id: selectedAnnotationId });
     } else if (
       annotation?.type === "bookmark" &&
@@ -507,7 +711,9 @@ export function WebViewer() {
       <iframe
         ref={iframeRef}
         src={frameSrc}
-        title={doc.title ?? doc.pdf_path}
+        // aria-label rather than title: a title attribute makes the browser
+        // show a hover tooltip over the entire reading surface.
+        aria-label={doc.title ?? doc.pdf_path}
         className="border-0 bg-white"
         style={{
           width: `${inverse}%`,
@@ -532,6 +738,51 @@ export function WebViewer() {
           selection={selection}
           currentPage={selection.pageNumber}
           onClose={clearSelection}
+        />
+      )}
+
+      {webContextMenu && (
+        <WebContextMenu
+          x={webContextMenu.x}
+          y={webContextMenu.y}
+          canAddNote={webContextMenu.anchor !== null}
+          onAddNote={() => {
+            const menu = webContextMenu;
+            setWebContextMenu(null);
+            if (menu.anchor) {
+              setNoteComposer({
+                x: menu.x,
+                y: menu.y,
+                anchor: menu.anchor,
+                openedAt: Date.now(),
+              });
+            }
+          }}
+          onClose={() => setWebContextMenu(null)}
+        />
+      )}
+
+      {noteComposer && (
+        <WebNoteComposer
+          x={noteComposer.x}
+          y={noteComposer.y}
+          onSubmit={(content) => {
+            createAnchoredNote(noteComposer.anchor, content);
+            setNoteComposer(null);
+          }}
+          onClose={() => setNoteComposer(null)}
+        />
+      )}
+
+      {noteViewer && (
+        <WebNoteViewer
+          // Keyed by annotation so switching markers never carries one
+          // note's edit draft into another.
+          key={noteViewer.id}
+          annotationId={noteViewer.id}
+          x={noteViewer.x}
+          y={noteViewer.y}
+          onClose={() => setNoteViewer(null)}
         />
       )}
     </div>

--- a/src/lib/recent-pdfs.ts
+++ b/src/lib/recent-pdfs.ts
@@ -1,7 +1,9 @@
-import type { DocumentInfo } from "@/types";
+import type { DocumentInfo, DocumentKind } from "@/types";
 
 export interface RecentPdf {
+  /** File path for PDFs, normalized URL for webpages. */
   pdf_path: string;
+  kind: DocumentKind;
   title: string | null;
   page_count: number | null;
   opened_at: string;
@@ -27,6 +29,7 @@ export function getRecentPdfs(): RecentPdf[] {
 export function recordRecentPdf(document: DocumentInfo): void {
   const recentPdf: RecentPdf = {
     pdf_path: document.pdf_path,
+    kind: document.kind ?? "pdf",
     title: document.title,
     page_count: document.page_count,
     opened_at: new Date().toISOString(),
@@ -49,16 +52,36 @@ export function getPdfFileName(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
 }
 
+/** Compact display label for a webpage URL, e.g. "example.com/post". */
+export function getWebpageDisplayName(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname === "/" ? "" : parsed.pathname.replace(/\/$/, "");
+    return `${parsed.hostname}${path}`;
+  } catch {
+    return url;
+  }
+}
+
 function isRecentPdf(value: unknown): value is RecentPdf {
   if (typeof value !== "object" || value === null) return false;
 
-  const pdf = value as Partial<RecentPdf>;
-  return (
-    typeof pdf.pdf_path === "string" &&
-    (typeof pdf.title === "string" || pdf.title === null) &&
-    (typeof pdf.page_count === "number" || pdf.page_count === null) &&
-    typeof pdf.opened_at === "string"
-  );
+  const pdf = value as Partial<RecentPdf> & { kind?: unknown };
+  if (
+    typeof pdf.pdf_path !== "string" ||
+    !(typeof pdf.title === "string" || pdf.title === null) ||
+    !(typeof pdf.page_count === "number" || pdf.page_count === null) ||
+    typeof pdf.opened_at !== "string"
+  ) {
+    return false;
+  }
+
+  // Entries written before webpage support have no kind; treat them as PDFs.
+  if (pdf.kind === undefined) {
+    (pdf as RecentPdf).kind = "pdf";
+    return true;
+  }
+  return pdf.kind === "pdf" || pdf.kind === "web";
 }
 
 function writeRecentPdfs(recentPdfs: RecentPdf[]): void {

--- a/src/lib/tauri-commands.ts
+++ b/src/lib/tauri-commands.ts
@@ -6,6 +6,8 @@ import type {
   CreateAnnotationInput,
   DocumentInfo,
   UpdateAnnotationInput,
+  VellumwebExportSummary,
+  WebLibraryEntry,
 } from "@/types";
 
 interface CodexAiImageInput {
@@ -18,6 +20,64 @@ export async function openFile(
   sessionId: string,
 ): Promise<DocumentInfo> {
   return invoke<DocumentInfo>("open_file", { path, sessionId });
+}
+
+export async function openWebDocument(
+  url: string,
+  sessionId: string,
+): Promise<DocumentInfo> {
+  return invoke<DocumentInfo>("open_web_document", { url, sessionId });
+}
+
+export async function setWebpageSaved(
+  sessionId: string,
+  saved: boolean,
+): Promise<void> {
+  return invoke("set_webpage_saved", { sessionId, saved });
+}
+
+export async function getWebpageSaved(sessionId: string): Promise<boolean> {
+  return invoke<boolean>("get_webpage_saved", { sessionId });
+}
+
+export async function listSavedWebpages(): Promise<WebLibraryEntry[]> {
+  return invoke<WebLibraryEntry[]>("list_saved_webpages");
+}
+
+export async function removeSavedWebpage(url: string): Promise<void> {
+  return invoke("remove_saved_webpage", { url });
+}
+
+export async function exportVellumweb(
+  sessionId: string,
+  destPath: string,
+  pages: Array<{ number: number; text: string }>,
+): Promise<VellumwebExportSummary> {
+  return invoke<VellumwebExportSummary>("export_vellumweb", {
+    sessionId,
+    destPath,
+    pages,
+  });
+}
+
+export async function openVellumwebFile(
+  path: string,
+  sessionId: string,
+): Promise<DocumentInfo> {
+  return invoke<DocumentInfo>("open_vellumweb_file", { path, sessionId });
+}
+
+/** Auto-archive an opened webpage into the managed library as .vellumweb. */
+export async function archiveWebpageDefault(
+  sessionId: string,
+  pages: Array<{ number: number; text: string }>,
+  expectedUrl: string,
+): Promise<boolean> {
+  return invoke<boolean>("archive_webpage_default", {
+    sessionId,
+    pages,
+    expectedUrl,
+  });
 }
 
 export async function saveFile(sessionId: string): Promise<void> {

--- a/src/prompts/tool-mode-system.md
+++ b/src/prompts/tool-mode-system.md
@@ -1,9 +1,12 @@
-# Skill: PDF Assistant With Tool Calling
+# Skill: Document Assistant With Tool Calling
 
 ## Role
-You are an AI research assistant embedded in a PDF reader.
+You are an AI research assistant embedded in a document reader. The open
+document is either a PDF or a webpage (blog post, research article).
 You may receive a screenshot image of the current page for visual reasoning.
 Use that image for charts, diagrams, layout cues, and tables when relevant.
+For webpages, "pages" are virtual sections of the article split in reading
+order; page numbers, navigation, and highlighting work the same way.
 
 ## Objective
 Answer the latest user request and propose concrete UI actions when appropriate.

--- a/src/stores/ai-store.ts
+++ b/src/stores/ai-store.ts
@@ -7,7 +7,7 @@ import { locateTextOnPage } from "@/lib/highlight-locator";
 import * as commands from "@/lib/tauri-commands";
 import { useAnnotationStore } from "@/stores/annotation-store";
 import { usePdfStore } from "@/stores/pdf-store";
-import type { Annotation, DocumentInfo } from "@/types";
+import type { Annotation, DocumentInfo, PositionData } from "@/types";
 
 type AiRole = "user" | "assistant";
 type AiProvider = "gemini" | "openai" | "codex";
@@ -592,20 +592,49 @@ async function executeToolAction(action: ToolAction): Promise<string> {
     if (!query) return "Skipped addHighlight: no text provided to locate.";
     const color = sanitizeColor(action.args.color, "#fef08a");
 
-    // Resolve the highlight geometry from the actual page text instead of
+    // Resolve the highlight anchor from the actual page text instead of
     // trusting model-supplied coordinates, which land on arbitrary positions.
-    const positionData = await locateTextOnPage(pageNumber, query);
-    if (!positionData || positionData.rects.length === 0) {
+    // Webpages anchor by text offsets (resolved inside the page's content
+    // script); PDFs anchor by on-page geometry.
+    const isWebDocument = usePdfStore.getState().document?.kind === "web";
+    let positionData: PositionData | null;
+    // The web locator may find the text on a different virtual page than the
+    // model guessed; file the annotation under the real one.
+    let resolvedPage = pageNumber;
+    if (isWebDocument) {
+      const locateWebText = (window as unknown as Record<string, unknown>)
+        .__locateWebText as
+        | ((
+            page: number,
+            text: string,
+          ) => Promise<{ positionData: PositionData; pageNumber: number } | null>)
+        | undefined;
+      const located = locateWebText
+        ? await locateWebText(pageNumber, query)
+        : null;
+      positionData = located
+        ? { ...located.positionData, selected_text: query }
+        : null;
+      if (located && located.pageNumber >= 1) {
+        resolvedPage = clampPage(located.pageNumber);
+      }
+    } else {
+      positionData = await locateTextOnPage(pageNumber, query);
+    }
+    if (
+      !positionData ||
+      (!isWebDocument && positionData.rects.length === 0)
+    ) {
       return `Skipped addHighlight: couldn't find "${query}" on page ${pageNumber}.`;
     }
 
     await useAnnotationStore.getState().addHighlight({
       type: "highlight",
-      page_number: pageNumber,
+      page_number: resolvedPage,
       color,
       position_data: positionData,
     });
-    return `Highlighted "${query}" on page ${pageNumber}.`;
+    return `Highlighted "${query}" on page ${resolvedPage}.`;
   }
 
   // Unknown tools are filtered out before this point; this guards against a

--- a/src/stores/annotation-store.ts
+++ b/src/stores/annotation-store.ts
@@ -19,14 +19,18 @@ export function findCurrentBookmark(
   annotations: Annotation[],
   docKind: DocumentKind | undefined,
   currentPage: number,
-  webVisibleRange: { start: number; end: number } | null,
+  webVisibleBookmarks: string[],
 ): Annotation | undefined {
   return annotations.find((a) => {
     if (a.type !== "bookmark") return false;
     const start = a.position_data?.start_offset;
     if (docKind === "web" && start != null) {
-      if (!webVisibleRange) return false;
-      return start >= webVisibleRange.start && start < webVisibleRange.end;
+      // The content script re-anchors each bookmark against the live DOM and
+      // reports the ones actually on screen. Stored offsets come from the
+      // session that created them, so comparing them to the current visible
+      // text span drifts after restarts — and a span covers whole virtual
+      // pages, which lit the star for an entire short article.
+      return webVisibleBookmarks.includes(a.id);
     }
     return a.page_number === currentPage;
   });
@@ -157,7 +161,7 @@ export const useAnnotationStore = create<AnnotationState>((set, get) => ({
       get().annotations,
       doc.kind,
       pdfState.currentPage,
-      pdfState.webVisibleRange,
+      pdfState.webVisibleBookmarks,
     );
     if (existing) {
       await get().deleteAnnotation(existing.id);

--- a/src/stores/annotation-store.ts
+++ b/src/stores/annotation-store.ts
@@ -2,10 +2,35 @@ import { create } from "zustand";
 import type {
   Annotation,
   CreateAnnotationInput,
+  DocumentKind,
+  PositionData,
   UpdateAnnotationInput,
 } from "@/types";
 import * as commands from "@/lib/tauri-commands";
 import { usePdfStore } from "@/stores/pdf-store";
+
+/**
+ * The bookmark the toggle button/shortcut acts on. PDF bookmarks are per
+ * page; web bookmarks anchor to a text position, so "current" means a
+ * bookmark whose anchor is on screen right now. Web bookmarks from before
+ * point anchoring existed have no offsets and fall back to page matching.
+ */
+export function findCurrentBookmark(
+  annotations: Annotation[],
+  docKind: DocumentKind | undefined,
+  currentPage: number,
+  webVisibleRange: { start: number; end: number } | null,
+): Annotation | undefined {
+  return annotations.find((a) => {
+    if (a.type !== "bookmark") return false;
+    const start = a.position_data?.start_offset;
+    if (docKind === "web" && start != null) {
+      if (!webVisibleRange) return false;
+      return start >= webVisibleRange.start && start < webVisibleRange.end;
+    }
+    return a.page_number === currentPage;
+  });
+}
 
 interface AnnotationState {
   // All annotations for the current document
@@ -19,7 +44,12 @@ interface AnnotationState {
   loadAnnotations: () => Promise<void>;
   addHighlight: (input: CreateAnnotationInput) => Promise<Annotation | null>;
   addNote: (input: CreateAnnotationInput) => Promise<Annotation | null>;
-  addBookmark: (pageNumber: number) => Promise<Annotation | null>;
+  addBookmark: (
+    pageNumber: number,
+    positionData?: PositionData,
+  ) => Promise<Annotation | null>;
+  /** Add or remove the bookmark at the current reading position. */
+  toggleBookmark: () => Promise<void>;
   updateAnnotation: (input: UpdateAnnotationInput) => Promise<void>;
   deleteAnnotation: (id: string) => Promise<void>;
   selectAnnotation: (id: string | null) => void;
@@ -96,13 +126,14 @@ export const useAnnotationStore = create<AnnotationState>((set, get) => ({
     }
   },
 
-  addBookmark: async (pageNumber: number) => {
+  addBookmark: async (pageNumber: number, positionData?: PositionData) => {
     const sessionId = usePdfStore.getState().activeTabId;
     if (!sessionId) return null;
     try {
       const annotation = await commands.createAnnotation(sessionId, {
         type: "bookmark",
         page_number: pageNumber,
+        ...(positionData && { position_data: positionData }),
       });
       if (usePdfStore.getState().activeTabId === sessionId) {
         set((state) => ({
@@ -115,6 +146,36 @@ export const useAnnotationStore = create<AnnotationState>((set, get) => ({
       console.error("[annotation-store] Failed to create bookmark:", err);
       return null;
     }
+  },
+
+  toggleBookmark: async () => {
+    const pdfState = usePdfStore.getState();
+    const doc = pdfState.document;
+    if (!doc) return;
+
+    const existing = findCurrentBookmark(
+      get().annotations,
+      doc.kind,
+      pdfState.currentPage,
+      pdfState.webVisibleRange,
+    );
+    if (existing) {
+      await get().deleteAnnotation(existing.id);
+      return;
+    }
+
+    if (doc.kind === "web") {
+      const capture = (window as unknown as Record<string, unknown>)
+        .__captureWebPosition as
+        | (() => Promise<{ pageNumber: number; positionData: PositionData } | null>)
+        | undefined;
+      const captured = capture ? await capture() : null;
+      if (captured) {
+        await get().addBookmark(captured.pageNumber, captured.positionData);
+        return;
+      }
+    }
+    await get().addBookmark(pdfState.currentPage);
   },
 
   updateAnnotation: async (input: UpdateAnnotationInput) => {

--- a/src/stores/pdf-store.ts
+++ b/src/stores/pdf-store.ts
@@ -22,6 +22,9 @@ interface PdfState {
   visiblePages: number[];
   /** Raw text-offset span currently on screen (web documents only). */
   webVisibleRange: { start: number; end: number } | null;
+  /** Ids of point bookmarks currently on screen (re-anchored by the content
+   *  script, so valid across restarts and page reflows). */
+  webVisibleBookmarks: string[];
 
   // Active interaction mode
   mode: InteractionMode;
@@ -44,6 +47,7 @@ interface PdfState {
   zoomOut: () => void;
   setVisiblePages: (pages: number[]) => void;
   setWebVisibleRange: (range: { start: number; end: number } | null) => void;
+  setWebVisibleBookmarks: (ids: string[]) => void;
   goToPage: (page: number) => void;
   setMode: (mode: InteractionMode) => void;
 }
@@ -60,6 +64,7 @@ const EMPTY_ACTIVE_STATE = {
   zoom: 1.0,
   visiblePages: [] as number[],
   webVisibleRange: null as { start: number; end: number } | null,
+  webVisibleBookmarks: [] as string[],
   mode: "view" as InteractionMode,
 };
 
@@ -72,6 +77,7 @@ function activeStateFromTab(tab: PdfTab) {
     zoom: tab.zoom,
     visiblePages: tab.visiblePages,
     webVisibleRange: tab.webVisibleRange,
+    webVisibleBookmarks: tab.webVisibleBookmarks,
     mode: tab.mode,
   };
 }
@@ -107,6 +113,7 @@ export const usePdfStore = create<PdfState>((set, get) => {
       zoom: 1.0,
       visiblePages: [],
       webVisibleRange: null,
+      webVisibleBookmarks: [],
       mode: "view",
     };
 
@@ -201,6 +208,7 @@ export const usePdfStore = create<PdfState>((set, get) => {
                   numPages: doc.page_count ?? 0,
                   visiblePages: [],
                   webVisibleRange: null,
+                  webVisibleBookmarks: [],
                 }
               : candidate,
           ),
@@ -211,6 +219,7 @@ export const usePdfStore = create<PdfState>((set, get) => {
                 numPages: doc.page_count ?? 0,
                 visiblePages: [] as number[],
                 webVisibleRange: null,
+                webVisibleBookmarks: [] as string[],
               }
             : {}),
         }));
@@ -362,6 +371,18 @@ export const usePdfStore = create<PdfState>((set, get) => {
       }
       set({ webVisibleRange: range });
       updateActiveTab({ webVisibleRange: range });
+    },
+
+    setWebVisibleBookmarks: (ids: string[]) => {
+      const prev = get().webVisibleBookmarks;
+      if (
+        prev.length === ids.length &&
+        prev.every((id, index) => id === ids[index])
+      ) {
+        return;
+      }
+      set({ webVisibleBookmarks: ids });
+      updateActiveTab({ webVisibleBookmarks: ids });
     },
 
     goToPage: (page: number) => {

--- a/src/stores/pdf-store.ts
+++ b/src/stores/pdf-store.ts
@@ -20,6 +20,8 @@ interface PdfState {
   numPages: number;
   zoom: number;
   visiblePages: number[];
+  /** Raw text-offset span currently on screen (web documents only). */
+  webVisibleRange: { start: number; end: number } | null;
 
   // Active interaction mode
   mode: InteractionMode;
@@ -27,6 +29,11 @@ interface PdfState {
   // Actions
   openFile: (path: string) => Promise<void>;
   openFiles: (paths: string[]) => Promise<void>;
+  openUrl: (url: string) => Promise<void>;
+  /** Rebind a webpage tab to a new URL (in-tab link navigation). */
+  webNavigated: (tabId: string, url: string) => Promise<DocumentInfo | null>;
+  /** Update a tab's document title (reported by the webpage content script). */
+  updateDocumentTitle: (tabId: string, title: string) => void;
   closeFile: () => Promise<void>;
   closeTab: (tabId: string) => Promise<void>;
   activateTab: (tabId: string) => void;
@@ -36,6 +43,7 @@ interface PdfState {
   zoomIn: () => void;
   zoomOut: () => void;
   setVisiblePages: (pages: number[]) => void;
+  setWebVisibleRange: (range: { start: number; end: number } | null) => void;
   goToPage: (page: number) => void;
   setMode: (mode: InteractionMode) => void;
 }
@@ -51,6 +59,7 @@ const EMPTY_ACTIVE_STATE = {
   numPages: 0,
   zoom: 1.0,
   visiblePages: [] as number[],
+  webVisibleRange: null as { start: number; end: number } | null,
   mode: "view" as InteractionMode,
 };
 
@@ -62,6 +71,7 @@ function activeStateFromTab(tab: PdfTab) {
     numPages: tab.numPages,
     zoom: tab.zoom,
     visiblePages: tab.visiblePages,
+    webVisibleRange: tab.webVisibleRange,
     mode: tab.mode,
   };
 }
@@ -77,9 +87,7 @@ export const usePdfStore = create<PdfState>((set, get) => {
     }));
   };
 
-  const openOneFile = async (path: string) => {
-    const sessionId = crypto.randomUUID();
-    const doc = await commands.openFile(path, sessionId);
+  const adoptOpenedDocument = async (doc: DocumentInfo, sessionId: string) => {
     recordRecentPdf(doc);
     const existing = get().tabs.find(
       (tab) => tab.document.pdf_path === doc.pdf_path,
@@ -98,6 +106,7 @@ export const usePdfStore = create<PdfState>((set, get) => {
       numPages: doc.page_count ?? 0,
       zoom: 1.0,
       visiblePages: [],
+      webVisibleRange: null,
       mode: "view",
     };
 
@@ -105,6 +114,28 @@ export const usePdfStore = create<PdfState>((set, get) => {
       tabs: [...state.tabs, tab],
       ...activeStateFromTab(tab),
     }));
+  };
+
+  const openOneFile = async (path: string) => {
+    const sessionId = crypto.randomUUID();
+    // .vellumweb archives import as web documents; everything else is a PDF.
+    const isArchive = path.toLowerCase().endsWith(".vellumweb");
+    const doc = isArchive
+      ? await commands.openVellumwebFile(path, sessionId)
+      : await commands.openFile(path, sessionId);
+    await adoptOpenedDocument(doc, sessionId);
+    if (isArchive) {
+      // The import may have merged annotations into a tab that is already
+      // open and active, in which case no document change fires — nudge the
+      // annotation store to reload.
+      window.dispatchEvent(new CustomEvent("vellum:annotations-updated"));
+    }
+  };
+
+  const openOneUrl = async (url: string) => {
+    const sessionId = crypto.randomUUID();
+    const doc = await commands.openWebDocument(url, sessionId);
+    await adoptOpenedDocument(doc, sessionId);
   };
 
   return {
@@ -139,6 +170,70 @@ export const usePdfStore = create<PdfState>((set, get) => {
       set({
         isLoading: false,
         error: errors.length > 0 ? errors.join("\n") : null,
+      });
+    },
+
+    openUrl: async (url: string) => {
+      set({ isLoading: true, error: null });
+      try {
+        await openOneUrl(url);
+        set({ isLoading: false });
+      } catch (e) {
+        set({ isLoading: false, error: String(e) });
+      }
+    },
+
+    webNavigated: async (tabId: string, url: string) => {
+      const tab = get().tabs.find((candidate) => candidate.id === tabId);
+      if (!tab || tab.document.kind !== "web") return null;
+      try {
+        // Reuse the session id: the Rust side rebinds the session to the new
+        // URL, so annotation commands keep working against the same tab.
+        const doc = await commands.openWebDocument(url, tabId);
+        recordRecentPdf(doc);
+        set((state) => ({
+          tabs: state.tabs.map((candidate) =>
+            candidate.id === tabId
+              ? {
+                  ...candidate,
+                  document: doc,
+                  currentPage: doc.last_page ?? 1,
+                  numPages: doc.page_count ?? 0,
+                  visiblePages: [],
+                  webVisibleRange: null,
+                }
+              : candidate,
+          ),
+          ...(state.activeTabId === tabId
+            ? {
+                document: doc,
+                currentPage: doc.last_page ?? 1,
+                numPages: doc.page_count ?? 0,
+                visiblePages: [] as number[],
+                webVisibleRange: null,
+              }
+            : {}),
+        }));
+        return doc;
+      } catch (e) {
+        set({ error: String(e) });
+        return null;
+      }
+    },
+
+    updateDocumentTitle: (tabId: string, title: string) => {
+      const trimmed = title.trim();
+      if (!trimmed) return;
+      set((state) => {
+        const tab = state.tabs.find((candidate) => candidate.id === tabId);
+        if (!tab || tab.document.title === trimmed) return state;
+        const document = { ...tab.document, title: trimmed };
+        return {
+          tabs: state.tabs.map((candidate) =>
+            candidate.id === tabId ? { ...candidate, document } : candidate,
+          ),
+          ...(state.activeTabId === tabId ? { document } : {}),
+        };
       });
     },
 
@@ -257,8 +352,23 @@ export const usePdfStore = create<PdfState>((set, get) => {
       updateActiveTab({ visiblePages: pages });
     },
 
+    setWebVisibleRange: (range) => {
+      const prev = get().webVisibleRange;
+      if (
+        prev === range ||
+        (prev && range && prev.start === range.start && prev.end === range.end)
+      ) {
+        return;
+      }
+      set({ webVisibleRange: range });
+      updateActiveTab({ webVisibleRange: range });
+    },
+
     goToPage: (page: number) => {
       const { numPages } = get();
+      // Before the document reports its page count, clamping would produce
+      // page 0 — ignore navigation until pages exist.
+      if (numPages < 1) return;
       const clamped = Math.min(numPages, Math.max(1, page));
       get().setCurrentPage(clamped);
       const scrollToPage = (window as unknown as Record<string, unknown>)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,13 @@ export interface PositionData {
   selected_text: string | null;
   start_offset: number | null;
   end_offset: number | null;
+  /** Text-quote anchor context for webpage annotations (normalized text,
+   *  ~32 chars each side). Absent for PDF annotations. */
+  prefix?: string | null;
+  suffix?: string | null;
+  /** How far below the viewport top (CSS px) the anchor text sat when a
+   *  webpage point bookmark was captured. Absent for PDFs and selections. */
+  viewport_offset?: number | null;
 }
 
 export interface Annotation {
@@ -44,11 +51,32 @@ export interface UpdateAnnotationInput {
   position_data?: PositionData;
 }
 
+export type DocumentKind = "pdf" | "web";
+
 export interface DocumentInfo {
+  /** "pdf" for files on disk, "web" for proxied webpages. */
+  kind: DocumentKind;
+  /** Generic document URI: a filesystem path for PDFs, a normalized URL for
+   *  webpages. The name is kept for compatibility with stored data keyed on it. */
   pdf_path: string;
   title: string | null;
   page_count: number | null;
   last_page: number | null;
+}
+
+export interface VellumwebExportSummary {
+  path: string;
+  bytes: number;
+  asset_count: number;
+  assets_skipped: number;
+}
+
+export interface WebLibraryEntry {
+  url: string;
+  title: string | null;
+  page_count: number | null;
+  saved_at: string | null;
+  has_snapshot: boolean;
 }
 
 export interface PdfTab {
@@ -58,6 +86,8 @@ export interface PdfTab {
   numPages: number;
   zoom: number;
   visiblePages: number[];
+  /** Raw text-offset span currently on screen (web documents only). */
+  webVisibleRange: { start: number; end: number } | null;
   mode: "view" | "note";
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,6 +88,9 @@ export interface PdfTab {
   visiblePages: number[];
   /** Raw text-offset span currently on screen (web documents only). */
   webVisibleRange: { start: number; end: number } | null;
+  /** Ids of point bookmarks whose re-anchored position is on screen right
+   *  now (web documents only; reported by the content script). */
+  webVisibleBookmarks: string[];
   mode: "view" | "note";
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,5 +29,15 @@ export default defineConfig({
       // Tell vite to ignore watching `src-tauri`
       ignored: ["**/src-tauri/**"],
     },
+    proxy: {
+      // Dev/testing only: same-origin route to a local stand-in for the
+      // vellum-web custom protocol, so the webpage reader can be exercised
+      // in a plain browser (see __VELLUM_DEV_PROXY__ in WebViewer).
+      "/__vellum-dev-proxy": {
+        target: "http://127.0.0.1:8632",
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/__vellum-dev-proxy/, ""),
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Adds a new live webpage reading mode alongside PDFs, with webpage tabs, URL opening, and updated welcome screen/library flows.
- Introduces a Rust proxy and web archive/session plumbing to load live pages through a sandboxed iframe while preserving reading interactions.
- Expands the frontend store, toolbar, sidebar, AI context, and command layer to handle web documents and webpage-specific metadata.
- Includes a content script and web viewer implementation for selection handling, virtual paging, highlights, and navigation inside live pages.

## Testing
- Not run
- `npm run lint` not run
- `npx tsc --noEmit` not run
- `cargo check` not run