### PR TITLE
Add OpenRouter provider with searchable model picker and Keychain keys

### DIFF
--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		5AA233123955997046F4F9EB /* WebNotePopovers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACABB2AAB4911563C0148AD6 /* WebNotePopovers.swift */; };
 		67B320CA1556DCBF8C2A8507 /* PdfGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102BFBC5EF5B66C15AC2BC86 /* PdfGeometry.swift */; };
 		6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30CD609AEA2C0A662890153 /* TabBarView.swift */; };
+		6D737237057DD944A4616889 /* ModelSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B43A2E8F7A54C9B8E4E160D /* ModelSelector.swift */; };
 		75B9FA69511BBE233AAB665A /* WebPageExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E209F0AEC418389859234E /* WebPageExtractor.swift */; };
 		7A22F35E2A3DE9629E53A11D /* StickyNoteOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D731F7DD5287488D2021276D /* StickyNoteOverlay.swift */; };
 		806EDA3BB34A3680F7B39E1B /* PdfPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5003641A54B311693588C6C /* PdfPersistenceTests.swift */; };
@@ -46,12 +47,15 @@
 		9E139713CC03274E03B94E92 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E2B3DF66E30481C363C740 /* ToolbarView.swift */; };
 		A5E5A42BE09B4A7911646AFF /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723EC058218A6DF8D994CC26 /* UpdateChecker.swift */; };
 		AB9A39277DECF67164B86B08 /* tool-mode-native.md in Resources */ = {isa = PBXBuildFile; fileRef = 88825E2B57F4AFE2A2D1DE36 /* tool-mode-native.md */; };
+		AD1B694B784E1CEF4F4AAB48 /* RevealableSecureField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E506B1F5144DA0A96843FEE /* RevealableSecureField.swift */; };
+		B127FEC17DDF285AD902A52B /* OpenRouterCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */; };
 		B1EA8A76FD9FE32930829528 /* SessionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7280818785023514C87C04C9 /* SessionService.swift */; };
 		BB776BF184FBD5A0469377E2 /* AiPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90963B42EE17356826E8DE90 /* AiPrompts.swift */; };
 		C7F0A762A988E52CD11D2A5E /* PdfAtomicWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E923D872F0FF00E6DAB9BA8 /* PdfAtomicWriter.swift */; };
 		CCD31E1E8A71BB0E987EC90B /* SelectionPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0B4D5702156DFEC64496C9 /* SelectionPopover.swift */; };
 		D0D4EC9C2F31C5D40C71A2AC /* CodexAiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445794DE3CECBDEB9414F5C2 /* CodexAiClient.swift */; };
 		D0E1C1D4A6D6A54C194A3389 /* SpeechService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3AC0340E126F7BB9CDC0B6 /* SpeechService.swift */; };
+		D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82487970E20F6628200C4BE /* KeychainStore.swift */; };
 		D4A79DFDB08A01D35D47933A /* AiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F38132FDC803C6ACEB43CC /* AiStore.swift */; };
 		D77E5170582527BDF9282B70 /* tool-descriptions.md in Resources */ = {isa = PBXBuildFile; fileRef = 3E954582457ABFF5574EC93C /* tool-descriptions.md */; };
 		E5F120A320C5FC13A9026B70 /* MarkdownMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A774391C8C286453B790F75 /* MarkdownMessage.swift */; };
@@ -61,6 +65,7 @@
 		EF7A65F99A00454F851FA17C /* AiSettingsPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4DE459571959DABFA99D4BB /* AiSettingsPanel.swift */; };
 		F14F33AEF8094C593CF6A6DE /* DocumentSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */; };
 		F5DFB55D5AEB2B65E76E5613 /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8909CC21C72AF947D20B4B6C /* AppStore.swift */; };
+		FE7D8E1CF0734B927687D5AF /* OpenRouterClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96768879872A93B8FD39C342 /* OpenRouterClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +83,7 @@
 		027E09C0BD7A98F4590A5878 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		03E209F0AEC418389859234E /* WebPageExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageExtractor.swift; sourceTree = "<group>"; };
 		0A7870954383EAE833F32ABF /* FindBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindBar.swift; sourceTree = "<group>"; };
+		0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRouterCatalog.swift; sourceTree = "<group>"; };
 		102BFBC5EF5B66C15AC2BC86 /* PdfGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfGeometry.swift; sourceTree = "<group>"; };
 		195A20D8270BAD8604C2E641 /* PdfAnnotationCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfAnnotationCodec.swift; sourceTree = "<group>"; };
 		2423823E0BE86C417B6ABBC6 /* AiPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiPanel.swift; sourceTree = "<group>"; };
@@ -99,7 +105,9 @@
 		7280818785023514C87C04C9 /* SessionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionService.swift; sourceTree = "<group>"; };
 		775C6AD8C83907CD1B8F65B2 /* VellumTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VellumTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		78E2B3DF66E30481C363C740 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
+		7B43A2E8F7A54C9B8E4E160D /* ModelSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSelector.swift; sourceTree = "<group>"; };
 		7E4C07C56943274B9E062A70 /* RecentFilesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesService.swift; sourceTree = "<group>"; };
+		7E506B1F5144DA0A96843FEE /* RevealableSecureField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevealableSecureField.swift; sourceTree = "<group>"; };
 		87B22387C1A8E19F0316151E /* PdfViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfViewerView.swift; sourceTree = "<group>"; };
 		88825E2B57F4AFE2A2D1DE36 /* tool-mode-native.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "tool-mode-native.md"; sourceTree = "<group>"; };
 		8909CC21C72AF947D20B4B6C /* AppStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStore.swift; sourceTree = "<group>"; };
@@ -108,6 +116,7 @@
 		8DEAE7F1D56A4A84D94F3F79 /* tool-mode-system.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "tool-mode-system.md"; sourceTree = "<group>"; };
 		90614A8F48AEDB52A5B7FE1E /* VellumCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VellumCommands.swift; sourceTree = "<group>"; };
 		90963B42EE17356826E8DE90 /* AiPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiPrompts.swift; sourceTree = "<group>"; };
+		96768879872A93B8FD39C342 /* OpenRouterClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRouterClient.swift; sourceTree = "<group>"; };
 		9A1D02EF244DA61F5397D68B /* PdfSelectionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfSelectionBridge.swift; sourceTree = "<group>"; };
 		9D58D6980122701CBA30200F /* Vellum.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vellum.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5003641A54B311693588C6C /* PdfPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfPersistenceTests.swift; sourceTree = "<group>"; };
@@ -125,6 +134,7 @@
 		D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentSessionManager.swift; sourceTree = "<group>"; };
 		D731F7DD5287488D2021276D /* StickyNoteOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyNoteOverlay.swift; sourceTree = "<group>"; };
 		D7CB0D2C34D6696D7D75D9F0 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		D82487970E20F6628200C4BE /* KeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainStore.swift; sourceTree = "<group>"; };
 		DF9C9C837F5B62D523BD8E97 /* AnnotationSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationSidebar.swift; sourceTree = "<group>"; };
 		E064C75923B5E7D98E256470 /* WebArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebArchive.swift; sourceTree = "<group>"; };
 		E30CD609AEA2C0A662890153 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
@@ -151,6 +161,8 @@
 				445794DE3CECBDEB9414F5C2 /* CodexAiClient.swift */,
 				C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */,
 				BE90299DD7109284EF8AE43D /* OpenAIClient.swift */,
+				0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */,
+				96768879872A93B8FD39C342 /* OpenRouterClient.swift */,
 				3F3AC0340E126F7BB9CDC0B6 /* SpeechService.swift */,
 			);
 			path = Ai;
@@ -202,6 +214,8 @@
 				2423823E0BE86C417B6ABBC6 /* AiPanel.swift */,
 				C4DE459571959DABFA99D4BB /* AiSettingsPanel.swift */,
 				8A774391C8C286453B790F75 /* MarkdownMessage.swift */,
+				7B43A2E8F7A54C9B8E4E160D /* ModelSelector.swift */,
+				7E506B1F5144DA0A96843FEE /* RevealableSecureField.swift */,
 			);
 			path = AI;
 			sourceTree = "<group>";
@@ -210,6 +224,7 @@
 			isa = PBXGroup;
 			children = (
 				D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */,
+				D82487970E20F6628200C4BE /* KeychainStore.swift */,
 				7E4C07C56943274B9E062A70 /* RecentFilesService.swift */,
 				7280818785023514C87C04C9 /* SessionService.swift */,
 				1B073A6D74EA890EC3F5822C /* Ai */,
@@ -462,9 +477,13 @@
 				8DDA7D560DAB61C377817B0D /* FindBar.swift in Sources */,
 				4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */,
 				4FF972F2B1437D5D46AE6BA4 /* HighlightLayer.swift in Sources */,
+				D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */,
 				E5F120A320C5FC13A9026B70 /* MarkdownMessage.swift in Sources */,
+				6D737237057DD944A4616889 /* ModelSelector.swift in Sources */,
 				290AF491B1EFDE622262DCD7 /* Models.swift in Sources */,
 				08677253114CE30123D3BD54 /* OpenAIClient.swift in Sources */,
+				B127FEC17DDF285AD902A52B /* OpenRouterCatalog.swift in Sources */,
+				FE7D8E1CF0734B927687D5AF /* OpenRouterClient.swift in Sources */,
 				019D03DA6C4B054E963D7C4C /* PdfAnnotationCodec.swift in Sources */,
 				C7F0A762A988E52CD11D2A5E /* PdfAtomicWriter.swift in Sources */,
 				1FCCAC565DBDC21D62F833FB /* PdfBookmarks.swift in Sources */,
@@ -476,6 +495,7 @@
 				40D4C8C74B050905AF690FD5 /* PdfSessionBackend.swift in Sources */,
 				3F4C2E045464817FDB1ED160 /* PdfViewerView.swift in Sources */,
 				1F884AF6AF2ABD755DFE414D /* RecentFilesService.swift in Sources */,
+				AD1B694B784E1CEF4F4AAB48 /* RevealableSecureField.swift in Sources */,
 				CCD31E1E8A71BB0E987EC90B /* SelectionPopover.swift in Sources */,
 				B1EA8A76FD9FE32930829528 /* SessionService.swift in Sources */,
 				2439956FEFA7E14A045B9289 /* SettingsView.swift in Sources */,

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -31,6 +31,7 @@ struct VellumApp: App {
     @State private var appStore: AppStore
     @State private var annotationStore: AnnotationStore
     @State private var aiStore: AiStore
+    @State private var openRouterCatalog: OpenRouterCatalog
 
     init() {
         let theme = ThemeStore()
@@ -38,12 +39,15 @@ struct VellumApp: App {
         let app = AppStore(sessions: sessions)
         let annotations = AnnotationStore(app: app)
         let ai = AiStore()
+        let openRouter = OpenRouterCatalog()
         ai.app = app
         ai.annotationStore = annotations
+        ai.openRouterCatalog = openRouter
         _themeStore = State(initialValue: theme)
         _appStore = State(initialValue: app)
         _annotationStore = State(initialValue: annotations)
         _aiStore = State(initialValue: ai)
+        _openRouterCatalog = State(initialValue: openRouter)
         VellumAppDelegate.appStore = app
     }
 
@@ -57,6 +61,7 @@ struct VellumApp: App {
                 .environment(appStore)
                 .environment(annotationStore)
                 .environment(aiStore)
+                .environment(openRouterCatalog)
                 .environment(\.palette, themeStore.palette)
                 .preferredColorScheme(themeStore.colorScheme)
                 .background(themeStore.palette.background)
@@ -75,6 +80,7 @@ struct VellumApp: App {
                 .environment(themeStore)
                 .environment(appStore)
                 .environment(aiStore)
+                .environment(openRouterCatalog)
                 .environment(\.palette, themeStore.palette)
                 .preferredColorScheme(themeStore.colorScheme)
                 .tint(themeStore.palette.primary)

--- a/Vellum/Services/Ai/AiPersistence.swift
+++ b/Vellum/Services/Ai/AiPersistence.swift
@@ -17,24 +17,67 @@ enum AiPersistence {
         guard let raw = UserDefaults.standard.string(forKey: settingsKey),
               let data = raw.data(using: .utf8),
               let value = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return defaults }
+        else {
+            // No stored blob yet: still surface any keys already in the Keychain.
+            var settings = defaults
+            settings.apiKey = KeychainStore.get(KeychainStore.Account.gemini) ?? ""
+            settings.openaiApiKey = KeychainStore.get(KeychainStore.Account.openai) ?? ""
+            settings.openrouterApiKey = KeychainStore.get(KeychainStore.Account.openrouter) ?? ""
+            return settings
+        }
 
         var settings = defaults
         if let provider = value["provider"] as? String {
-            settings.provider = provider == "codex" ? .codex : (provider == "openai" ? .openai : .gemini)
+            settings.provider = AiProvider(rawValue: provider) ?? .gemini
         }
         if let model = value["model"] as? String { settings.model = model }
-        if let apiKey = value["apiKey"] as? String { settings.apiKey = apiKey }
         if let model = value["openaiModel"] as? String { settings.openaiModel = model }
-        if let apiKey = value["openaiApiKey"] as? String { settings.openaiApiKey = apiKey }
         if let model = value["codexModel"] as? String { settings.codexModel = model }
+        if let model = value["openrouterModel"] as? String { settings.openrouterModel = model }
+        if let pinned = value["pinnedModels"] as? [String] { settings.pinnedModels = pinned }
         settings.voiceMode = value["voiceMode"] as? String == "push-to-talk" ? .pushToTalk : .off
         if let enabled = value["ttsEnabled"] as? Bool { settings.ttsEnabled = enabled }
+
+        // Keys now live in the Keychain. Migrate any legacy plaintext keys still
+        // present in the UserDefaults blob, then prefer the Keychain copy.
+        var didMigrate = false
+        migrate(account: KeychainStore.Account.gemini, legacy: value["apiKey"] as? String, didMigrate: &didMigrate)
+        migrate(account: KeychainStore.Account.openai, legacy: value["openaiApiKey"] as? String, didMigrate: &didMigrate)
+        migrate(account: KeychainStore.Account.openrouter, legacy: value["openrouterApiKey"] as? String, didMigrate: &didMigrate)
+        settings.apiKey = KeychainStore.get(KeychainStore.Account.gemini) ?? ""
+        settings.openaiApiKey = KeychainStore.get(KeychainStore.Account.openai) ?? ""
+        settings.openrouterApiKey = KeychainStore.get(KeychainStore.Account.openrouter) ?? ""
+
+        // Rewrite the blob without plaintext keys once migrated.
+        if didMigrate { saveSettings(settings) }
         return settings
     }
 
+    /// Copies a legacy plaintext key into the Keychain if the Keychain slot is
+    /// empty and the legacy value is non-empty.
+    private static func migrate(account: String, legacy: String?, didMigrate: inout Bool) {
+        let value = legacy?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !value.isEmpty else {
+            if legacy != nil { didMigrate = true } // strip empty key field on rewrite
+            return
+        }
+        didMigrate = true
+        if KeychainStore.get(account)?.isEmpty ?? true {
+            KeychainStore.set(account, value)
+        }
+    }
+
     static func saveSettings(_ settings: AiSettings) {
-        guard let data = try? JSONEncoder().encode(settings),
+        // Keys go to the Keychain, never the UserDefaults blob.
+        KeychainStore.set(KeychainStore.Account.gemini, settings.apiKey)
+        KeychainStore.set(KeychainStore.Account.openai, settings.openaiApiKey)
+        KeychainStore.set(KeychainStore.Account.openrouter, settings.openrouterApiKey)
+
+        var stripped = settings
+        stripped.apiKey = ""
+        stripped.openaiApiKey = ""
+        stripped.openrouterApiKey = ""
+        guard let data = try? JSONEncoder().encode(stripped),
               let raw = String(data: data, encoding: .utf8) else { return }
         UserDefaults.standard.set(raw, forKey: settingsKey)
     }

--- a/Vellum/Services/Ai/OpenRouterCatalog.swift
+++ b/Vellum/Services/Ai/OpenRouterCatalog.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Observation
+
+/// One model exposed by OpenRouter's `/api/v1/models` endpoint, reduced to the
+/// fields the selector and send pipeline care about.
+struct OpenRouterModel: Identifiable, Sendable, Equatable {
+    var id: String
+    var name: String
+    var contextLength: Int?
+    var promptPrice: Double?
+    var completionPrice: Double?
+    var created: Int?
+    /// True when the model accepts image input ("image" in input_modalities).
+    var supportsVision: Bool
+    /// True when the model supports function/tool calling ("tools" in supported_parameters).
+    var supportsTools: Bool
+}
+
+/// Fetches and caches OpenRouter's model catalog. The list endpoint needs no
+/// API key. Cached to UserDefaults so the selector opens instantly and works
+/// offline; refreshed at most daily unless forced.
+@MainActor
+@Observable
+final class OpenRouterCatalog {
+    private(set) var models: [OpenRouterModel] = []
+    private(set) var isLoading = false
+    private(set) var error: String?
+
+    private static let cacheKey = "openrouter-models-cache-v1"
+    private static let cacheStampKey = "openrouter-models-cache-stamp-v1"
+    private static let maxCacheAge: TimeInterval = 24 * 60 * 60
+    private static let endpoint = "https://openrouter.ai/api/v1/models"
+
+    init() {
+        models = Self.loadCache()
+    }
+
+    /// Refreshes the catalog from the network. Skips the fetch when a recent
+    /// cache exists unless `force` is set.
+    func refresh(force: Bool = false) async {
+        if !force, !models.isEmpty, !Self.cacheIsStale() { return }
+        if isLoading { return }
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        guard let url = URL(string: Self.endpoint) else {
+            error = "Invalid OpenRouter endpoint."
+            return
+        }
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+                error = "Couldn't load OpenRouter models."
+                return
+            }
+            let parsed = Self.parse(data)
+            if parsed.isEmpty {
+                error = "OpenRouter returned no models."
+                return
+            }
+            models = parsed
+            Self.saveCache(data)
+        } catch {
+            self.error = "Couldn't load OpenRouter models: \(error.localizedDescription)"
+        }
+    }
+
+    /// Capability lookup used by the send pipeline. Unknown ids default to
+    /// permissive (assume both supported) so a stale cache never silently
+    /// strips a capability the model actually has.
+    func model(for id: String) -> OpenRouterModel? {
+        models.first { $0.id == id }
+    }
+
+    // MARK: - Parsing
+
+    private static func parse(_ data: Data) -> [OpenRouterModel] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let list = root["data"] as? [[String: Any]] else { return [] }
+        return list.compactMap(parseModel)
+    }
+
+    private static func parseModel(_ raw: [String: Any]) -> OpenRouterModel? {
+        guard let id = raw["id"] as? String, !id.isEmpty else { return nil }
+        let name = (raw["name"] as? String).flatMap { $0.isEmpty ? nil : $0 } ?? id
+        let architecture = raw["architecture"] as? [String: Any]
+        let inputModalities = architecture?["input_modalities"] as? [String] ?? []
+        let supportedParameters = raw["supported_parameters"] as? [String] ?? []
+        let pricing = raw["pricing"] as? [String: Any]
+        return OpenRouterModel(
+            id: id,
+            name: name,
+            contextLength: (raw["context_length"] as? NSNumber)?.intValue,
+            promptPrice: price(pricing?["prompt"]),
+            completionPrice: price(pricing?["completion"]),
+            created: (raw["created"] as? NSNumber)?.intValue,
+            supportsVision: inputModalities.contains("image"),
+            supportsTools: supportedParameters.contains("tools")
+        )
+    }
+
+    /// OpenRouter encodes per-token prices as strings ("0", "0.000003").
+    private static func price(_ value: Any?) -> Double? {
+        if let string = value as? String { return Double(string) }
+        if let number = value as? NSNumber { return number.doubleValue }
+        return nil
+    }
+
+    // MARK: - Cache
+
+    private static func loadCache() -> [OpenRouterModel] {
+        guard let data = UserDefaults.standard.data(forKey: cacheKey) else { return [] }
+        return parse(data)
+    }
+
+    private static func saveCache(_ data: Data) {
+        UserDefaults.standard.set(data, forKey: cacheKey)
+        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: cacheStampKey)
+    }
+
+    private static func cacheIsStale() -> Bool {
+        let stamp = UserDefaults.standard.double(forKey: cacheStampKey)
+        guard stamp > 0 else { return true }
+        return Date().timeIntervalSince1970 - stamp > maxCacheAge
+    }
+}

--- a/Vellum/Services/Ai/OpenRouterClient.swift
+++ b/Vellum/Services/Ai/OpenRouterClient.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// OpenRouter chat client. Uses the OpenAI-compatible **Chat Completions** API
+/// (not the Responses API `OpenAIClient` targets). Image and tool support are
+/// gated by the caller: `image` is passed nil for non-vision models and
+/// `allowTools` is false for models that don't support function calling.
+@MainActor
+final class OpenRouterClient {
+    func generate(
+        apiKey: String,
+        model: String,
+        systemPrompt: String,
+        userPrompt: String,
+        image: AiPageImageSnapshot?,
+        allowTools: Bool,
+        sessionIdAtStart: String,
+        toolEngine: AiToolEngine
+    ) async throws -> AiProviderResult {
+        guard let url = URL(string: "https://openrouter.ai/api/v1/chat/completions") else {
+            throw AiClientError.message("Invalid OpenRouter endpoint.")
+        }
+
+        var userContent: [[String: Any]] = [["type": "text", "text": userPrompt]]
+        if let image, !image.base64Data.isEmpty {
+            userContent.append([
+                "type": "image_url",
+                "image_url": ["url": "data:\(image.mediaType);base64,\(image.base64Data)"],
+            ])
+        }
+        var messages: [[String: Any]] = [
+            ["role": "system", "content": systemPrompt],
+            ["role": "user", "content": userContent],
+        ]
+        var actionResults: [String] = []
+
+        for _ in 0..<6 {
+            var body: [String: Any] = [
+                "model": model,
+                "messages": messages,
+            ]
+            if allowTools {
+                body["tools"] = Self.functionTools
+            }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.setValue("Vellum", forHTTPHeaderField: "X-Title")
+            request.setValue("https://vellum.app", forHTTPHeaderField: "HTTP-Referer")
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let data = try await sendWithRetry(request)
+            let root = try Self.jsonObject(data)
+            guard let choices = root["choices"] as? [[String: Any]],
+                  let message = choices.first?["message"] as? [String: Any] else {
+                throw AiClientError.message(Self.providerMessage(root, fallback: "OpenRouter returned an invalid response."))
+            }
+            let text = message["content"] as? String ?? ""
+            let toolCalls = message["tool_calls"] as? [[String: Any]] ?? []
+            if toolCalls.isEmpty {
+                return AiProviderResult(reply: Self.finalize(text, actions: actionResults), actionResults: actionResults)
+            }
+
+            // Echo the assistant turn (with its tool_calls) before the results.
+            var assistantMessage: [String: Any] = ["role": "assistant", "tool_calls": toolCalls]
+            assistantMessage["content"] = text.isEmpty ? NSNull() : text
+            messages.append(assistantMessage)
+
+            for call in toolCalls {
+                guard let callId = call["id"] as? String,
+                      let function = call["function"] as? [String: Any],
+                      let name = function["name"] as? String else { continue }
+                let argumentsText = function["arguments"] as? String ?? "{}"
+                let values = (try? JSONSerialization.jsonObject(with: Data(argumentsText.utf8))) as? [String: Any] ?? [:]
+                let action = AiToolAction(tool: name, args: Self.toolArguments(from: values))
+                let result = await toolEngine.run(
+                    action,
+                    sessionIdAtStart: sessionIdAtStart,
+                    actionCount: actionResults.count
+                )
+                actionResults.append(result)
+                messages.append([
+                    "role": "tool",
+                    "tool_call_id": callId,
+                    "content": result,
+                ])
+            }
+        }
+        return AiProviderResult(reply: Self.finalize("", actions: actionResults), actionResults: actionResults)
+    }
+
+    private func sendWithRetry(_ request: URLRequest) async throws -> Data {
+        var lastError: Error?
+        for attempt in 0...1 {
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let http = response as? HTTPURLResponse else {
+                    throw AiClientError.message("OpenRouter returned an invalid HTTP response.")
+                }
+                if (200..<300).contains(http.statusCode) { return data }
+                let message = Self.providerMessage((try? Self.jsonObject(data)) ?? [:], fallback: String(decoding: data, as: UTF8.self))
+                let error = AiClientError.message(message.isEmpty ? "OpenRouter request failed with status \(http.statusCode)." : message)
+                if attempt == 0, http.statusCode == 408 || http.statusCode == 429 || http.statusCode >= 500 {
+                    lastError = error
+                    continue
+                }
+                throw error
+            } catch {
+                lastError = error
+                if attempt == 1 { throw error }
+            }
+        }
+        throw lastError ?? AiClientError.message("OpenRouter request failed.")
+    }
+
+    private static func jsonObject(_ data: Data) throws -> [String: Any] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AiClientError.message("OpenRouter returned invalid JSON.")
+        }
+        return object
+    }
+
+    private static func providerMessage(_ object: [String: Any], fallback: String) -> String {
+        ((object["error"] as? [String: Any])?["message"] as? String) ?? fallback
+    }
+
+    private static func toolArguments(from value: [String: Any]) -> AiToolArguments {
+        AiToolArguments(
+            pageNumber: (value["pageNumber"] as? NSNumber)?.doubleValue,
+            text: value["text"] as? String,
+            color: value["color"] as? String,
+            x: (value["x"] as? NSNumber)?.doubleValue,
+            y: (value["y"] as? NSNumber)?.doubleValue
+        )
+    }
+
+    private static func finalize(_ text: String, actions: [String]) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return actions.isEmpty ? "I couldn't produce a response." : "Done."
+    }
+
+    /// Chat Completions tool schema (function wrapped), mirroring the three
+    /// tools defined for the other providers.
+    private static let functionTools: [[String: Any]] = [
+        [
+            "type": "function",
+            "function": [
+                "name": "goToPage",
+                "description": "Navigate the document viewport to a specific 1-indexed page.",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["pageNumber": ["type": "number", "description": "1-indexed page number to navigate to. Out-of-range values are clamped."]],
+                    "required": ["pageNumber"], "additionalProperties": false,
+                ],
+            ],
+        ],
+        [
+            "type": "function",
+            "function": [
+                "name": "addNote",
+                "description": "Create a sticky-note annotation with visible text on a page.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "pageNumber": ["type": "number", "description": "1-indexed page number for the note."],
+                        "text": ["type": "string", "description": "Note body. Must be non-empty."],
+                        "x": ["type": "number", "description": "Optional top-left x in PDF points (default 72)."],
+                        "y": ["type": "number", "description": "Optional top-left y in PDF points (default 96)."],
+                    ],
+                    "required": ["pageNumber", "text"], "additionalProperties": false,
+                ],
+            ],
+        ],
+        [
+            "type": "function",
+            "function": [
+                "name": "addHighlight",
+                "description": "Highlight an exact phrase on a page. Provide the verbatim text; the app locates and draws it.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "pageNumber": ["type": "number", "description": "1-indexed page number for the highlight."],
+                        "text": ["type": "string", "description": "Exact phrase to highlight, quoted verbatim from the page text. The app locates it; do not supply coordinates."],
+                        "color": ["type": "string", "description": "Optional CSS color (e.g. #fef08a). Invalid values fall back to yellow."],
+                    ],
+                    "required": ["pageNumber", "text"], "additionalProperties": false,
+                ],
+            ],
+        ],
+    ]
+}

--- a/Vellum/Services/KeychainStore.swift
+++ b/Vellum/Services/KeychainStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Security
+
+/// Thin wrapper over the macOS Keychain for storing AI provider API keys as
+/// generic passwords. All keys live under one service; the account string is
+/// the provider identifier (e.g. "gemini", "openai", "openrouter").
+enum KeychainStore {
+    static let service = "com.vellum.ai"
+
+    /// Returns the stored secret for an account, or nil if absent/unreadable.
+    static func get(_ account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let value = String(data: data, encoding: .utf8) else { return nil }
+        return value
+    }
+
+    /// Stores (or updates) the secret for an account. An empty value deletes it.
+    static func set(_ account: String, _ value: String) {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            delete(account)
+            return
+        }
+        let data = Data(trimmed.utf8)
+        let baseQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemUpdate(baseQuery as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+        if status == errSecItemNotFound {
+            var addQuery = baseQuery
+            addQuery[kSecValueData as String] = data
+            SecItemAdd(addQuery as CFDictionary, nil)
+        }
+    }
+
+    static func delete(_ account: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // Account identifiers, one per provider with a stored key.
+    enum Account {
+        static let gemini = "gemini"
+        static let openai = "openai"
+        static let openrouter = "openrouter"
+    }
+}

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -12,6 +12,7 @@ enum AiProvider: String, Codable, Sendable {
     case gemini
     case openai
     case codex
+    case openrouter
 }
 
 enum VoiceMode: String, Codable, Sendable {
@@ -33,6 +34,10 @@ struct AiSettings: Codable, Equatable, Sendable {
     var openaiModel: String = "gpt-5.5"
     var openaiApiKey: String = ""
     var codexModel: String = "gpt-5.5"
+    var openrouterModel: String = ""
+    var openrouterApiKey: String = ""
+    /// Model ids the user has pinned to the top of the model selector.
+    var pinnedModels: [String] = []
     var voiceMode: VoiceMode = .off
     var ttsEnabled: Bool = false
 }
@@ -70,6 +75,8 @@ final class AiStore {
     // Wired in by VellumApp; used by sendMessage's tool engine.
     weak var app: AppStore?
     weak var annotationStore: AnnotationStore?
+    /// Wired in by VellumApp; used to resolve OpenRouter model capabilities.
+    weak var openRouterCatalog: OpenRouterCatalog?
 
     private(set) var messages: [AiMessage] = []
     private(set) var isThinking = false
@@ -176,6 +183,11 @@ final class AiStore {
             error = "Set your Gemini API key in AI settings."
             return
         }
+        if settingsAtStart.provider == .openrouter,
+           settingsAtStart.openrouterApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            error = "Set your OpenRouter API key in AI settings."
+            return
+        }
 
         let userMessage = AiPersistence.makeMessage(role: .user, content: trimmed)
         messages.append(userMessage)
@@ -213,6 +225,26 @@ final class AiStore {
                     systemPrompt: try AiPrompts.nativeSystemPrompt(),
                     userPrompt: AiPrompts.buildNativeToolUserPrompt(parameters),
                     image: context.currentPageImage,
+                    sessionIdAtStart: sessionIdAtStart,
+                    toolEngine: engine
+                )
+            case .openrouter:
+                let model = settingsAtStart.openrouterModel.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !model.isEmpty else {
+                    throw AiClientError.message("Choose an OpenRouter model in AI settings.")
+                }
+                // Unknown ids (stale cache) default to permissive so we never
+                // silently strip a capability the model actually has.
+                let capabilities = openRouterCatalog?.model(for: model)
+                let supportsVision = capabilities?.supportsVision ?? true
+                let supportsTools = capabilities?.supportsTools ?? true
+                result = try await OpenRouterClient().generate(
+                    apiKey: settingsAtStart.openrouterApiKey.trimmingCharacters(in: .whitespacesAndNewlines),
+                    model: model,
+                    systemPrompt: try AiPrompts.nativeSystemPrompt(),
+                    userPrompt: AiPrompts.buildNativeToolUserPrompt(parameters),
+                    image: supportsVision ? context.currentPageImage : nil,
+                    allowTools: supportsTools,
                     sessionIdAtStart: sessionIdAtStart,
                     toolEngine: engine
                 )

--- a/Vellum/Views/AI/AiSettingsPanel.swift
+++ b/Vellum/Views/AI/AiSettingsPanel.swift
@@ -19,6 +19,30 @@ enum AiModelCatalog {
         case .gemini: gemini
         case .openai: openAI
         case .codex: codex
+        case .openrouter: []
+        }
+    }
+
+    /// Unified options for the model selector. Built-in provider models are all
+    /// vision- and tool-capable; OpenRouter models come from the live catalog.
+    @MainActor
+    static func options(for provider: AiProvider, catalog: OpenRouterCatalog) -> [AiModelOption] {
+        if provider == .openrouter {
+            return catalog.models.map {
+                AiModelOption(
+                    id: $0.id,
+                    name: $0.name,
+                    supportsVision: $0.supportsVision,
+                    supportsTools: $0.supportsTools,
+                    contextLength: $0.contextLength,
+                    promptPrice: $0.promptPrice,
+                    created: $0.created
+                )
+            }
+        }
+        return models(for: provider).map {
+            AiModelOption(id: $0, name: $0, supportsVision: true, supportsTools: true,
+                          contextLength: nil, promptPrice: nil, created: nil)
         }
     }
 }
@@ -27,6 +51,7 @@ struct AiSettingsPanel: View {
     var onStopRecognition: () -> Void = {}
 
     @Environment(AiStore.self) private var aiStore
+    @Environment(OpenRouterCatalog.self) private var openRouterCatalog
     @Environment(\.palette) private var palette
 
     var body: some View {
@@ -35,27 +60,28 @@ struct AiSettingsPanel: View {
                 Picker("", selection: providerBinding) {
                     Text("Gemini").tag(AiProvider.gemini)
                     Text("OpenAI API").tag(AiProvider.openai)
+                    Text("OpenRouter").tag(AiProvider.openrouter)
                     Text("Codex CLI").tag(AiProvider.codex)
                 }
                 .labelsHidden()
             }
 
             if aiStore.settings.provider != .codex {
-                field(aiStore.settings.provider == .openai ? "OpenAI API key" : "Gemini API key") {
-                    SecureField(
-                        aiStore.settings.provider == .openai ? "sk-..." : "AIza...",
-                        text: apiKeyBinding
-                    )
-                    .textFieldStyle(.roundedBorder)
-                    .controlSize(.small)
+                field(keyFieldLabel) {
+                    RevealableSecureField(placeholder: keyFieldPlaceholder, text: apiKeyBinding)
+                        .id(aiStore.settings.provider)
                 }
             }
 
             field("Model") {
-                Picker("", selection: modelBinding) {
-                    ForEach(models, id: \.self) { Text($0).tag($0) }
-                }
-                .labelsHidden()
+                ModelSelector(
+                    options: modelOptions,
+                    selection: modelBinding,
+                    pinned: pinnedBinding,
+                    isLoading: aiStore.settings.provider == .openrouter && openRouterCatalog.isLoading,
+                    onOpen: { if aiStore.settings.provider == .openrouter { Task { await openRouterCatalog.refresh() } } }
+                )
+                capabilityWarnings
             }
 
             field("Voice mode") {
@@ -83,8 +109,50 @@ struct AiSettingsPanel: View {
         }
     }
 
-    private var models: [String] {
-        AiModelCatalog.models(for: aiStore.settings.provider)
+    private var modelOptions: [AiModelOption] {
+        AiModelCatalog.options(for: aiStore.settings.provider, catalog: openRouterCatalog)
+    }
+
+    private var keyFieldLabel: String {
+        switch aiStore.settings.provider {
+        case .openai: "OpenAI API key"
+        case .openrouter: "OpenRouter API key"
+        default: "Gemini API key"
+        }
+    }
+
+    private var keyFieldPlaceholder: String {
+        switch aiStore.settings.provider {
+        case .openai: "sk-..."
+        case .openrouter: "sk-or-..."
+        default: "AIza..."
+        }
+    }
+
+    private var selectedOption: AiModelOption? {
+        modelOptions.first { $0.id == modelBinding.wrappedValue }
+    }
+
+    @ViewBuilder
+    private var capabilityWarnings: some View {
+        if let option = selectedOption {
+            if !option.supportsVision {
+                warning("This model can't see the page image — answers about page contents may be less accurate.")
+            }
+            if !option.supportsTools {
+                warning("This model can't run navigation, highlight, or note actions.")
+            }
+        }
+    }
+
+    private func warning(_ text: String) -> some View {
+        HStack(alignment: .top, spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 9))
+            Text(text)
+        }
+        .font(.system(size: 10))
+        .foregroundStyle(palette.gold)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
     private var providerBinding: Binding<AiProvider> {
@@ -97,10 +165,20 @@ struct AiSettingsPanel: View {
 
     private var apiKeyBinding: Binding<String> {
         Binding(
-            get: { aiStore.settings.provider == .openai ? aiStore.settings.openaiApiKey : aiStore.settings.apiKey },
+            get: {
+                switch aiStore.settings.provider {
+                case .openai: aiStore.settings.openaiApiKey
+                case .openrouter: aiStore.settings.openrouterApiKey
+                default: aiStore.settings.apiKey
+                }
+            },
             set: { value in
                 var settings = aiStore.settings
-                if settings.provider == .openai { settings.openaiApiKey = value } else { settings.apiKey = value }
+                switch settings.provider {
+                case .openai: settings.openaiApiKey = value
+                case .openrouter: settings.openrouterApiKey = value
+                default: settings.apiKey = value
+                }
                 aiStore.setSettings(settings)
             }
         )
@@ -113,6 +191,7 @@ struct AiSettingsPanel: View {
                 case .gemini: aiStore.settings.model
                 case .openai: aiStore.settings.openaiModel
                 case .codex: aiStore.settings.codexModel
+                case .openrouter: aiStore.settings.openrouterModel
                 }
             },
             set: { value in
@@ -121,7 +200,19 @@ struct AiSettingsPanel: View {
                 case .gemini: settings.model = value
                 case .openai: settings.openaiModel = value
                 case .codex: settings.codexModel = value
+                case .openrouter: settings.openrouterModel = value
                 }
+                aiStore.setSettings(settings)
+            }
+        )
+    }
+
+    private var pinnedBinding: Binding<[String]> {
+        Binding(
+            get: { aiStore.settings.pinnedModels },
+            set: { value in
+                var settings = aiStore.settings
+                settings.pinnedModels = value
                 aiStore.setSettings(settings)
             }
         )

--- a/Vellum/Views/AI/ModelSelector.swift
+++ b/Vellum/Views/AI/ModelSelector.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+/// One selectable model, unified across providers. Built-in provider models
+/// carry no pricing/context metadata; OpenRouter models carry all of it.
+struct AiModelOption: Identifiable, Equatable {
+    var id: String
+    var name: String
+    var supportsVision: Bool
+    var supportsTools: Bool
+    var contextLength: Int?
+    var promptPrice: Double?
+    var created: Int?
+}
+
+enum ModelSort: String, CaseIterable, Identifiable {
+    case name = "Name"
+    case priceAsc = "Price"
+    case contextDesc = "Context"
+    case recent = "Newest"
+    var id: String { rawValue }
+}
+
+/// Searchable, sortable, pinnable model picker. Replaces the plain `Picker`
+/// across every provider; scales to OpenRouter's large catalog. Presented as a
+/// popover so it works both inside the AI side panel and the Settings window.
+struct ModelSelector: View {
+    let options: [AiModelOption]
+    @Binding var selection: String
+    @Binding var pinned: [String]
+    var isLoading = false
+    var onOpen: (() -> Void)?
+
+    @Environment(\.palette) private var palette
+    @State private var isPresented = false
+    @State private var query = ""
+    @State private var sort: ModelSort = .name
+
+    var body: some View {
+        Button {
+            isPresented = true
+            onOpen?()
+        } label: {
+            triggerLabel
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            popover.frame(width: 340, height: 380)
+        }
+    }
+
+    private var selectedOption: AiModelOption? {
+        options.first { $0.id == selection }
+    }
+
+    private var triggerLabel: some View {
+        HStack(spacing: 6) {
+            Text(selectedOption?.name ?? (selection.isEmpty ? "Select a model" : selection))
+                .lineLimit(1)
+                .foregroundStyle(selection.isEmpty ? palette.mutedForeground : palette.foreground)
+            if let option = selectedOption, !(option.supportsVision && option.supportsTools) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(palette.gold)
+                    .font(.system(size: 10))
+            }
+            Spacer(minLength: 4)
+            Image(systemName: "chevron.up.chevron.down")
+                .font(.system(size: 9))
+                .foregroundStyle(palette.mutedForeground)
+        }
+        .font(.system(size: 12))
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 6).fill(palette.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 6).stroke(palette.border, lineWidth: 1)
+        )
+    }
+
+    // MARK: - Popover
+
+    private var popover: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if options.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 1) {
+                        if !pinnedOptions.isEmpty {
+                            sectionHeader("Pinned")
+                            ForEach(pinnedOptions) { row($0) }
+                            sectionHeader("All models")
+                        }
+                        ForEach(unpinnedOptions) { row($0) }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+        .background(palette.surface)
+        .font(.system(size: 12))
+    }
+
+    private var header: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 11))
+                    .foregroundStyle(palette.mutedForeground)
+                // Empty label + prompt so grouped-Form styling (inherited by the
+                // popover in the Settings window) can't render "Search models"
+                // as a trailing form label.
+                TextField("", text: $query, prompt: Text("Search models"))
+                    .textFieldStyle(.plain)
+                    .multilineTextAlignment(.leading)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if isLoading {
+                    ProgressView().controlSize(.small)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(RoundedRectangle(cornerRadius: 6).fill(palette.surfaceMuted))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(palette.border, lineWidth: 1))
+
+            Picker("", selection: $sort) {
+                ForEach(ModelSort.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+        }
+        .padding(12)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Spacer()
+            if isLoading {
+                ProgressView()
+                Text("Loading models…").foregroundStyle(palette.mutedForeground)
+            } else {
+                Text("No models found").foregroundStyle(palette.mutedForeground)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.system(size: 9, weight: .semibold))
+            .foregroundStyle(palette.mutedForeground)
+            .padding(.horizontal, 6)
+            .padding(.top, 8)
+            .padding(.bottom, 2)
+    }
+
+    private func row(_ option: AiModelOption) -> some View {
+        let isSelected = option.id == selection
+        return Button {
+            selection = option.id
+            isPresented = false
+        } label: {
+            HStack(spacing: 8) {
+                Button {
+                    togglePin(option.id)
+                } label: {
+                    Image(systemName: pinned.contains(option.id) ? "star.fill" : "star")
+                        .font(.system(size: 11))
+                        .foregroundStyle(pinned.contains(option.id) ? palette.gold : palette.mutedForeground)
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(option.name).lineLimit(1).foregroundStyle(palette.foreground)
+                    HStack(spacing: 6) {
+                        if let subtitle = subtitle(option) {
+                            Text(subtitle).foregroundStyle(palette.mutedForeground)
+                        }
+                        if !option.supportsVision { badge("no image") }
+                        if !option.supportsTools { badge("no actions") }
+                    }
+                    .font(.system(size: 10))
+                }
+                Spacer(minLength: 4)
+                if isSelected {
+                    Image(systemName: "checkmark").font(.system(size: 11)).foregroundStyle(palette.primary)
+                }
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 5)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 5).fill(isSelected ? palette.primary.opacity(0.14) : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func badge(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(palette.gold)
+            .padding(.horizontal, 4)
+            .padding(.vertical, 1)
+            .background(RoundedRectangle(cornerRadius: 3).fill(palette.gold.opacity(0.15)))
+    }
+
+    // MARK: - Data
+
+    private func togglePin(_ id: String) {
+        if let index = pinned.firstIndex(of: id) {
+            pinned.remove(at: index)
+        } else {
+            pinned.append(id)
+        }
+    }
+
+    private var filtered: [AiModelOption] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let base = q.isEmpty ? options : options.filter {
+            $0.id.lowercased().contains(q) || $0.name.lowercased().contains(q)
+        }
+        return base.sorted(by: sortComparator)
+    }
+
+    private var pinnedOptions: [AiModelOption] {
+        filtered.filter { pinned.contains($0.id) }
+    }
+
+    private var unpinnedOptions: [AiModelOption] {
+        pinnedOptions.isEmpty ? filtered : filtered.filter { !pinned.contains($0.id) }
+    }
+
+    private func sortComparator(_ a: AiModelOption, _ b: AiModelOption) -> Bool {
+        switch sort {
+        case .name:
+            return a.name.localizedCaseInsensitiveCompare(b.name) == .orderedAscending
+        case .priceAsc:
+            return (a.promptPrice ?? .greatestFiniteMagnitude) < (b.promptPrice ?? .greatestFiniteMagnitude)
+        case .contextDesc:
+            return (a.contextLength ?? 0) > (b.contextLength ?? 0)
+        case .recent:
+            return (a.created ?? 0) > (b.created ?? 0)
+        }
+    }
+
+    private func subtitle(_ option: AiModelOption) -> String? {
+        var parts: [String] = []
+        if let context = option.contextLength {
+            parts.append("\(context / 1000)K ctx")
+        }
+        if let price = option.promptPrice {
+            if price == 0 {
+                parts.append("free")
+            } else {
+                // per-token USD → per-million tokens.
+                parts.append(String(format: "$%.2f/M", price * 1_000_000))
+            }
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}

--- a/Vellum/Views/AI/RevealableSecureField.swift
+++ b/Vellum/Views/AI/RevealableSecureField.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// A secure text field with an eye toggle that reveals the value in plaintext.
+/// Used for API-key entry so users can verify what they pasted. Swaps between a
+/// `SecureField` and a `TextField` on toggle, preserving the same binding.
+struct RevealableSecureField: View {
+    let placeholder: String
+    @Binding var text: String
+
+    @Environment(\.palette) private var palette
+    @State private var isRevealed = false
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Group {
+                if isRevealed {
+                    TextField(placeholder, text: $text)
+                } else {
+                    SecureField(placeholder, text: $text)
+                }
+            }
+            .textFieldStyle(.roundedBorder)
+            .controlSize(.small)
+
+            Button {
+                isRevealed.toggle()
+            } label: {
+                Image(systemName: isRevealed ? "eye.slash" : "eye")
+                    .font(.system(size: 12))
+                    .foregroundStyle(palette.mutedForeground)
+                    .frame(width: 18, height: 18)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(isRevealed ? "Hide API key" : "Show API key")
+            .accessibilityLabel(isRevealed ? "Hide API key" : "Show API key")
+        }
+    }
+}

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -154,6 +154,8 @@ private struct AnnotationsSettingsTab: View {
 
 private struct AiSettingsTab: View {
     @Environment(AiStore.self) private var aiStore
+    @Environment(OpenRouterCatalog.self) private var openRouterCatalog
+    @Environment(\.palette) private var palette
 
     var body: some View {
         Form {
@@ -161,20 +163,27 @@ private struct AiSettingsTab: View {
                 Picker("Provider", selection: providerBinding) {
                     Text("Gemini").tag(AiProvider.gemini)
                     Text("OpenAI API").tag(AiProvider.openai)
+                    Text("OpenRouter").tag(AiProvider.openrouter)
                     Text("Codex CLI").tag(AiProvider.codex)
                 }
 
                 if aiStore.settings.provider != .codex {
-                    SecureField(
-                        aiStore.settings.provider == .openai ? "OpenAI API key" : "Gemini API key",
-                        text: apiKeyBinding,
-                        prompt: Text(aiStore.settings.provider == .openai ? "sk-…" : "AIza…")
-                    )
+                    LabeledContent(keyFieldLabel) {
+                        RevealableSecureField(placeholder: keyFieldPlaceholder, text: apiKeyBinding)
+                            .id(aiStore.settings.provider)
+                    }
                 }
 
-                Picker("Model", selection: modelBinding) {
-                    ForEach(models, id: \.self) { Text($0).tag($0) }
+                LabeledContent("Model") {
+                    ModelSelector(
+                        options: modelOptions,
+                        selection: modelBinding,
+                        pinned: pinnedBinding,
+                        isLoading: aiStore.settings.provider == .openrouter && openRouterCatalog.isLoading,
+                        onOpen: { if aiStore.settings.provider == .openrouter { Task { await openRouterCatalog.refresh() } } }
+                    )
                 }
+                capabilityWarnings
             } header: {
                 Text("Assistant")
             }
@@ -193,8 +202,44 @@ private struct AiSettingsTab: View {
         .scrollDisabled(true)
     }
 
-    private var models: [String] {
-        AiModelCatalog.models(for: aiStore.settings.provider)
+    private var modelOptions: [AiModelOption] {
+        AiModelCatalog.options(for: aiStore.settings.provider, catalog: openRouterCatalog)
+    }
+
+    private var keyFieldLabel: String {
+        switch aiStore.settings.provider {
+        case .openai: "OpenAI API key"
+        case .openrouter: "OpenRouter API key"
+        default: "Gemini API key"
+        }
+    }
+
+    private var keyFieldPlaceholder: String {
+        switch aiStore.settings.provider {
+        case .openai: "sk-…"
+        case .openrouter: "sk-or-…"
+        default: "AIza…"
+        }
+    }
+
+    private var selectedOption: AiModelOption? {
+        modelOptions.first { $0.id == modelBinding.wrappedValue }
+    }
+
+    @ViewBuilder
+    private var capabilityWarnings: some View {
+        if let option = selectedOption {
+            if !option.supportsVision {
+                Label("This model can't see the page image — answers about page contents may be less accurate.", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(palette.gold)
+            }
+            if !option.supportsTools {
+                Label("This model can't run navigation, highlight, or note actions.", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(palette.gold)
+            }
+        }
     }
 
     private var providerBinding: Binding<AiProvider> {
@@ -207,10 +252,20 @@ private struct AiSettingsTab: View {
 
     private var apiKeyBinding: Binding<String> {
         Binding(
-            get: { aiStore.settings.provider == .openai ? aiStore.settings.openaiApiKey : aiStore.settings.apiKey },
+            get: {
+                switch aiStore.settings.provider {
+                case .openai: aiStore.settings.openaiApiKey
+                case .openrouter: aiStore.settings.openrouterApiKey
+                default: aiStore.settings.apiKey
+                }
+            },
             set: { value in
                 var settings = aiStore.settings
-                if settings.provider == .openai { settings.openaiApiKey = value } else { settings.apiKey = value }
+                switch settings.provider {
+                case .openai: settings.openaiApiKey = value
+                case .openrouter: settings.openrouterApiKey = value
+                default: settings.apiKey = value
+                }
                 aiStore.setSettings(settings)
             }
         )
@@ -223,6 +278,7 @@ private struct AiSettingsTab: View {
                 case .gemini: aiStore.settings.model
                 case .openai: aiStore.settings.openaiModel
                 case .codex: aiStore.settings.codexModel
+                case .openrouter: aiStore.settings.openrouterModel
                 }
             },
             set: { value in
@@ -231,7 +287,19 @@ private struct AiSettingsTab: View {
                 case .gemini: settings.model = value
                 case .openai: settings.openaiModel = value
                 case .codex: settings.codexModel = value
+                case .openrouter: settings.openrouterModel = value
                 }
+                aiStore.setSettings(settings)
+            }
+        )
+    }
+
+    private var pinnedBinding: Binding<[String]> {
+        Binding(
+            get: { aiStore.settings.pinnedModels },
+            set: { value in
+                var settings = aiStore.settings
+                settings.pinnedModels = value
                 aiStore.setSettings(settings)
             }
         )


### PR DESCRIPTION
## Summary

Lets users bring an **OpenRouter** API key and pick any of its ~340 models, with a proper searchable model picker and Keychain-backed key storage.

- **OpenRouter provider** — new provider using the Chat Completions API (`OpenRouterClient`), backed by a live model catalog fetched/cached from `/api/v1/models` (`OpenRouterCatalog`, no key needed to list).
- **Rich model selector** (`ModelSelector`) — search, sort (name / price / context / recency), and pin favorites. Replaces the plain `Picker` across **all** providers.
- **Capability-aware degradation** — per-model vision + tool-calling flags drive inline warnings; the send pipeline drops the page image for non-vision models and omits the tool schema for non-tool models instead of erroring.
- **Keychain migration** — all API keys (Gemini, OpenAI, OpenRouter) move from plaintext UserDefaults to the macOS Keychain (`KeychainStore`), with a one-time migration on load.
- **Reveal toggle** — an eye button on every API-key field (`RevealableSecureField`) to show/hide the key; resets when switching providers.

## Files
- **New:** `KeychainStore.swift`, `Services/Ai/OpenRouterCatalog.swift`, `Services/Ai/OpenRouterClient.swift`, `Views/AI/ModelSelector.swift`, `Views/AI/RevealableSecureField.swift`
- **Modified:** `AiStore.swift`, `AiPersistence.swift`, `AiSettingsPanel.swift`, `SettingsView.swift`, `VellumApp.swift`

## Verification
- `xcodebuild` → **BUILD SUCCEEDED**.
- End-to-end GUI walkthrough via codex computer-use: provider selection, API-key field, live 340-model popover with search/sort/pin, capability badges + warnings, and persistence across Settings reopen all passed. Keychain storage confirmed; dummy key confirmed absent from the plaintext UserDefaults blob.

## Notes / not covered
- An actual chat request through `OpenRouterClient` was code-reviewed (mirrors the working `OpenAIClient` tool loop) but not exercised against the live API — needs a real OpenRouter key.
- Legacy-key → Keychain migration on a profile that already had a saved plaintext key was not exercised end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a supported AI provider.
  * Introduced a searchable model picker with sorting, pinned models, and capability badges.
  * Added a show/hide toggle for API key fields.

* **Bug Fixes**
  * API keys are now stored more securely and migrated away from visible app storage.
  * The settings screen now warns when a selected model doesn’t support vision or tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->