### PR TITLE
Add draggable highlight edge resizing

### DIFF
--- a/Tests/PdfPersistenceTests.swift
+++ b/Tests/PdfPersistenceTests.swift
@@ -703,3 +703,139 @@ final class PdfPersistenceTests: XCTestCase {
         try await session.close()
     }
 }
+
+// Deterministic tests for the highlight edge-resize core
+// (PdfViewerController.resizedPosition). Uses a real one-line text PDF so
+// PDFKit's point-to-point selection behaves like it does in the app.
+@MainActor
+final class HighlightResizeTests: XCTestCase {
+    /// One-page PDF with a single line of extractable text, drawn with CoreText.
+    private func textPage(_ string: String = "The quick brown fox jumps over the lazy dog") -> PDFPage {
+        let data = NSMutableData()
+        var mediaBox = CGRect(x: 0, y: 0, width: 612, height: 792)
+        let consumer = CGDataConsumer(data: data as CFMutableData)!
+        let ctx = CGContext(consumer: consumer, mediaBox: &mediaBox, nil)!
+        ctx.beginPDFPage(nil)
+        let font = CTFontCreateWithName("Helvetica" as CFString, 24, nil)
+        let attr = CFAttributedStringCreate(nil, string as CFString, [kCTFontAttributeName: font] as CFDictionary)!
+        let line = CTLineCreateWithAttributedString(attr)
+        ctx.textPosition = CGPoint(x: 40, y: 700)
+        CTLineDraw(line, ctx)
+        ctx.endPDFPage()
+        ctx.closePDF()
+        return PDFDocument(data: data as Data)!.page(at: 0)!
+    }
+
+    /// Display-space PositionData for a character range, matching how the app
+    /// derives a highlight's rects (uiRect + mergeLineRects).
+    private func position(for range: NSRange, on page: PDFPage) -> PositionData {
+        let sel = page.selection(for: range)!
+        var rects: [AnnotationRect] = []
+        for line in sel.selectionsByLine() {
+            guard let p = line.pages.first else { continue }
+            rects.append(PdfViewerController.uiRect(fromPageSpace: line.bounds(for: p), page: p))
+        }
+        let dims = PdfViewerController.displayDimensions(of: page)
+        return PositionData(
+            rects: PdfViewerController.mergeLineRects(rects),
+            pageWidth: Double(dims.width), pageHeight: Double(dims.height),
+            selectedText: sel.string, startOffset: nil, endOffset: nil,
+            prefix: nil, suffix: nil, viewportOffset: nil)
+    }
+
+    private func midY(_ pos: PositionData) -> Double {
+        let r = pos.rects.first!
+        return r.y + r.height / 2
+    }
+
+    // THE CRASH: the old index-based core called characterBounds(at:) with an
+    // out-of-range index when the end handle was dragged past the text, trapping.
+    // The selection-based core must not crash and must extend to the last word.
+    func testDragEndPastTextEndDoesNotCrash() throws {
+        let page = textPage()
+        XCTAssertGreaterThan(page.numberOfCharacters, 10)
+        let pos = position(for: NSRange(location: 4, length: 11), on: page) // "quick brown"
+        let farRight = CGPoint(x: pos.pageWidth + 1000, y: midY(pos))
+        let result = PdfViewerController.resizedPosition(
+            page: page, current: pos, edge: .end, toDisplayPoint: farRight)
+        XCTAssertNotNil(result, "dragging end past the text end must extend, not crash/fail")
+        let text = result?.selectedText ?? ""
+        XCTAssertTrue(text.hasPrefix("quick"), "start stays pinned at 'quick': \(text)")
+        XCTAssertTrue(text.hasSuffix("dog"), "end extends to the last word: \(text)")
+    }
+
+    // Dragging the END handle LEFT past the START must NOT drag the beginning
+    // along — crossing the pinned edge holds the last frame (returns nil) instead
+    // of inverting the selection (the "beginning moves when I drag the end" bug).
+    func testDragEndPastStartHolds() throws {
+        let page = textPage()
+        let pos = position(for: NSRange(location: 4, length: 11), on: page) // starts at 'q' (idx 4)
+        // Target 'h' in "The" (index 1), which is BEFORE the start anchor.
+        let h = position(for: NSRange(location: 1, length: 1), on: page)
+        let target = CGPoint(x: h.rects.first!.x + h.rects.first!.width / 2, y: midY(pos))
+        XCTAssertNil(
+            PdfViewerController.resizedPosition(
+                page: page, current: pos, edge: .end, toDisplayPoint: target),
+            "over-dragging the end past the start must hold, not move the start")
+    }
+
+    // Dragging into the left margin (before the pinned start) must HOLD the last
+    // frame, not jump — jumping is exactly the "not smooth" behavior.
+    func testDragIntoLeftMarginHolds() throws {
+        let page = textPage()
+        let pos = position(for: NSRange(location: 4, length: 11), on: page)
+        let farLeft = CGPoint(x: 0, y: midY(pos))
+        XCTAssertNil(
+            PdfViewerController.resizedPosition(
+                page: page, current: pos, edge: .end, toDisplayPoint: farLeft),
+            "an off-text margin point must hold, not jump the highlight")
+    }
+
+    // Dragging the END rightward to a point inside a later word extends the
+    // highlight to track the cursor, with the start unchanged.
+    func testDragEndExtendsToCursor() throws {
+        let page = textPage()
+        let pos = position(for: NSRange(location: 4, length: 11), on: page) // "quick brown"
+        // Target the middle of "jumps" (index 20..24 in the sample string).
+        let jumps = position(for: NSRange(location: 20, length: 5), on: page)
+        let target = CGPoint(x: jumps.rects.first!.x + jumps.rects.first!.width / 2, y: midY(pos))
+        let result = PdfViewerController.resizedPosition(
+            page: page, current: pos, edge: .end, toDisplayPoint: target)
+        XCTAssertNotNil(result)
+        let text = result?.selectedText ?? ""
+        XCTAssertTrue(text.hasPrefix("quick"), "start stays pinned near the original start: \(text)")
+        XCTAssertTrue(text.contains("fox"), "end extends past the original end ('quick brown'): \(text)")
+    }
+
+    // Dragging the START handle leftward extends the highlight to the left while
+    // the END stays pinned.
+    func testDragStartExtendsLeftKeepsEndPinned() throws {
+        let page = textPage()
+        let pos = position(for: NSRange(location: 16, length: 3), on: page) // "fox"
+        // Target the middle of "The" (index 0..2), to the left of "fox".
+        let the = position(for: NSRange(location: 0, length: 3), on: page)
+        let target = CGPoint(x: the.rects.first!.x + the.rects.first!.width / 2, y: midY(pos))
+        let result = PdfViewerController.resizedPosition(
+            page: page, current: pos, edge: .start, toDisplayPoint: target)
+        XCTAssertNotNil(result)
+        let text = result?.selectedText ?? ""
+        XCTAssertTrue(text.hasSuffix("fox"), "end stays pinned at 'fox': \(text)")
+        XCTAssertTrue(text.contains("The") || text.hasPrefix("he"), "start extends leftward: \(text)")
+    }
+
+    // Empty / no-text page must fail gracefully (not crash).
+    func testResizeOnEmptyPageReturnsNil() throws {
+        let data = NSMutableData()
+        var box = CGRect(x: 0, y: 0, width: 612, height: 792)
+        let consumer = CGDataConsumer(data: data as CFMutableData)!
+        let ctx = CGContext(consumer: consumer, mediaBox: &box, nil)!
+        ctx.beginPDFPage(nil); ctx.endPDFPage(); ctx.closePDF()
+        let page = PDFDocument(data: data as Data)!.page(at: 0)!
+        let pos = PositionData(
+            rects: [AnnotationRect(x: 10, y: 10, width: 50, height: 12)],
+            pageWidth: 612, pageHeight: 792, selectedText: "x",
+            startOffset: nil, endOffset: nil, prefix: nil, suffix: nil, viewportOffset: nil)
+        XCTAssertNil(PdfViewerController.resizedPosition(
+            page: page, current: pos, edge: .end, toDisplayPoint: CGPoint(x: 100, y: 16)))
+    }
+}

--- a/Vellum/Models/Models.swift
+++ b/Vellum/Models/Models.swift
@@ -80,6 +80,9 @@ struct UpdateAnnotationInput: Sendable {
     var color: String?
     var content: String?
     var positionData: PositionData?
+    /// Web highlight resizes can cross a virtual page break; PDF annotations
+    /// never move pages, so the PDF backend ignores this.
+    var pageNumber: Int? = nil
 }
 
 enum DocumentKind: String, Codable, Sendable {

--- a/Vellum/Services/Pdf/PdfSessionBackend.swift
+++ b/Vellum/Services/Pdf/PdfSessionBackend.swift
@@ -101,14 +101,24 @@ enum PdfDocumentLoader {
 
 // MARK: - Session
 
+/// Thin @MainActor facade over a background `PdfDocumentIO` worker. Every
+/// method just hops to the actor, so the UI thread is NEVER blocked by the
+/// full-file read → parse → `dataRepresentation()` → atomic write that each
+/// annotation mutation performs (that whole pipeline used to run on the main
+/// actor, freezing the app for seconds on large PDFs; the optimistic store
+/// update never got a chance to render because `async` here didn't actually
+/// suspend off-main). PDFKit runs fine off the main actor. Do NOT move the I/O
+/// back onto @MainActor — see [[vellum-session-backends-offmain]].
 @MainActor
 final class PdfDocumentSession: DocumentSession {
     let path: String
     let info: DocumentInfo
+    private let io: PdfDocumentIO
 
     init(path: String, info: DocumentInfo) {
         self.path = path
         self.info = info
+        self.io = PdfDocumentIO(path: path)
     }
 
     /// save_session: annotation/metadata mutations are written immediately, so
@@ -118,8 +128,46 @@ final class PdfDocumentSession: DocumentSession {
     /// close_session runs the same no-op sync; the manager drops the session.
     func close() async throws {}
 
-    /// read_pdf_bytes: the CURRENT file contents, re-read from disk each call.
     func readPdfBytes() async throws -> Data {
+        try await io.readPdfBytes()
+    }
+
+    func annotations(pageNumber: Int?) async throws -> [Annotation] {
+        try await io.annotations(pageNumber: pageNumber)
+    }
+
+    func createAnnotation(_ input: CreateAnnotationInput) async throws -> Annotation {
+        try await io.createAnnotation(input)
+    }
+
+    func updateAnnotation(_ input: UpdateAnnotationInput) async throws -> Bool {
+        try await io.updateAnnotation(input)
+    }
+
+    func deleteAnnotation(id: String) async throws -> Bool {
+        try await io.deleteAnnotation(id: id)
+    }
+
+    func setMetadata(key: String, value: String) async throws {
+        try await io.setMetadata(key: key, value: value)
+    }
+}
+
+/// Per-document background worker. All disk/PDFKit/serialize work lives here so
+/// it runs off the main actor; the actor also serializes access to one file so
+/// overlapping writes can't race. Inputs/outputs are all `Sendable` value types
+/// (Annotation, PositionData, Data); the non-Sendable PDFKit objects are
+/// created and consumed entirely inside a single method and never cross the
+/// actor boundary.
+actor PdfDocumentIO {
+    let path: String
+
+    init(path: String) {
+        self.path = path
+    }
+
+    /// read_pdf_bytes: the CURRENT file contents, re-read from disk each call.
+    func readPdfBytes() throws -> Data {
         do {
             return try Data(contentsOf: URL(fileURLWithPath: path))
         } catch {

--- a/Vellum/Services/Web/WebSessionBackend.swift
+++ b/Vellum/Services/Web/WebSessionBackend.swift
@@ -166,6 +166,9 @@ final class WebDocumentSession: DocumentSession {
             if let positionData = input.positionData {
                 record.annotations[index].positionData = positionData
             }
+            if let pageNumber = input.pageNumber {
+                record.annotations[index].pageNumber = pageNumber
+            }
             record.annotations[index].updatedAt = WebLibrary.rfc3339Now()
             return true
         }

--- a/Vellum/Stores/AnnotationStore.swift
+++ b/Vellum/Stores/AnnotationStore.swift
@@ -186,16 +186,46 @@ final class AnnotationStore {
 
     private func create(_ input: CreateAnnotationInput, label: String) async -> Annotation? {
         guard let sessionId = app.activeTabId else { return nil }
-        do {
-            let annotation = try await sessions.createAnnotation(sessionId: sessionId, input: input)
-            if app.activeTabId == sessionId {
-                annotations.append(annotation)
-                return annotation
+        // Optimistic create: render the annotation IMMEDIATELY with a temporary
+        // id, then persist off the main path and reconcile the real id (or
+        // revert) once the file write finishes. A full-file PDF rewrite can take
+        // seconds on a large document; the user must never wait on that to SEE
+        // their highlight/note — the same optimistic pattern update/delete use.
+        let now = ISO8601DateFormatter.recentTimestamp.string(from: Date())
+        let tempId = "temp-" + UUID().uuidString.lowercased()
+        let optimistic = Annotation(
+            id: tempId,
+            type: input.type,
+            pageNumber: input.pageNumber,
+            color: input.color,
+            content: input.content,
+            positionData: input.positionData,
+            createdAt: now,
+            updatedAt: now)
+        annotations.append(optimistic)
+
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let persisted = try await self.sessions.createAnnotation(sessionId: sessionId, input: input)
+                guard self.app.activeTabId == sessionId else { return }
+                // Swap the temp record for the persisted one (real id, server
+                // defaults like the applied highlight color), keeping selection.
+                if let index = self.annotations.firstIndex(where: { $0.id == tempId }) {
+                    self.annotations[index] = persisted
+                }
+                if self.selectedAnnotationId == tempId {
+                    self.selectedAnnotationId = persisted.id
+                }
+            } catch {
+                NSLog("[annotation-store] Failed to create \(label): \(error)")
+                guard self.app.activeTabId == sessionId else { return }
+                self.annotations.removeAll { $0.id == tempId }
+                if self.selectedAnnotationId == tempId {
+                    self.selectedAnnotationId = nil
+                }
             }
-            return nil
-        } catch {
-            NSLog("[annotation-store] Failed to create \(label): \(error)")
-            return nil
         }
+        return optimistic
     }
 }

--- a/Vellum/Stores/AnnotationStore.swift
+++ b/Vellum/Stores/AnnotationStore.swift
@@ -49,6 +49,21 @@ final class AnnotationStore {
     /// for a point bookmark (window.__captureWebPosition in the original).
     var captureWebPositionHandler: (() async -> CapturedWebPosition?)?
 
+    /// In-flight optimistic creates, keyed by their temporary id. Each task
+    /// resolves to the persisted id (nil if the create failed). Mutations that
+    /// target a `temp-` id queue behind the create and retarget the real id —
+    /// the backends can only resolve persisted ids.
+    @ObservationIgnored private var pendingCreates: [String: Task<String?, Never>] = [:]
+
+    /// Resolve an annotation id a mutation can act on: real ids pass through;
+    /// `temp-` ids wait for their create to persist and return the swapped-in
+    /// id, or nil when the create failed (nothing left to mutate).
+    private func resolveId(_ id: String) async -> String? {
+        guard id.hasPrefix("temp-") else { return id }
+        guard let pending = pendingCreates[id] else { return nil }
+        return await pending.value
+    }
+
     init(app: AppStore) {
         self.app = app
     }
@@ -125,6 +140,12 @@ final class AnnotationStore {
 
     func updateAnnotation(_ input: UpdateAnnotationInput) async {
         guard let sessionId = app.activeTabId else { return }
+        // Edits against a still-optimistic row queue behind its create and
+        // retarget the persisted id.
+        var input = input
+        guard let realId = await resolveId(input.id) else { return }
+        input.id = realId
+        guard app.activeTabId == sessionId else { return }
         // Optimistic update
         annotations = annotations.map { annotation in
             guard annotation.id == input.id else { return annotation }
@@ -132,6 +153,7 @@ final class AnnotationStore {
             if let color = input.color { next.color = color }
             if let content = input.content { next.content = content }
             if let positionData = input.positionData { next.positionData = positionData }
+            if let pageNumber = input.pageNumber { next.pageNumber = pageNumber }
             next.updatedAt = ISO8601DateFormatter.recentTimestamp.string(from: Date())
             return next
         }
@@ -151,6 +173,10 @@ final class AnnotationStore {
 
     func deleteAnnotation(id: String) async {
         guard let sessionId = app.activeTabId else { return }
+        // Deleting a still-optimistic row waits for its create to persist, then
+        // deletes the real record (the backends can't find a temp id).
+        guard let id = await resolveId(id) else { return }
+        guard app.activeTabId == sessionId else { return }
         // Optimistic delete
         let previous = annotations
         annotations = annotations.filter { $0.id != id }
@@ -204,11 +230,12 @@ final class AnnotationStore {
             updatedAt: now)
         annotations.append(optimistic)
 
-        Task { [weak self] in
-            guard let self else { return }
+        pendingCreates[tempId] = Task { [weak self] in
+            guard let self else { return nil }
+            defer { self.pendingCreates[tempId] = nil }
             do {
                 let persisted = try await self.sessions.createAnnotation(sessionId: sessionId, input: input)
-                guard self.app.activeTabId == sessionId else { return }
+                guard self.app.activeTabId == sessionId else { return persisted.id }
                 // Swap the temp record for the persisted one (real id, server
                 // defaults like the applied highlight color), keeping selection.
                 if let index = self.annotations.firstIndex(where: { $0.id == tempId }) {
@@ -217,13 +244,15 @@ final class AnnotationStore {
                 if self.selectedAnnotationId == tempId {
                     self.selectedAnnotationId = persisted.id
                 }
+                return persisted.id
             } catch {
                 NSLog("[annotation-store] Failed to create \(label): \(error)")
-                guard self.app.activeTabId == sessionId else { return }
+                guard self.app.activeTabId == sessionId else { return nil }
                 self.annotations.removeAll { $0.id == tempId }
                 if self.selectedAnnotationId == tempId {
                     self.selectedAnnotationId = nil
                 }
+                return nil
             }
         }
         return optimistic

--- a/Vellum/Views/Annotations/HighlightLayer.swift
+++ b/Vellum/Views/Annotations/HighlightLayer.swift
@@ -87,6 +87,13 @@ struct HighlightLayer: View {
                 }
             }
             .coordinateSpace(.named(Self.coordinateSpaceName))
+            // A drag can end without onEnded (SwiftUI cancels the gesture when
+            // the view tree rebuilds under it), leaving the live preview set.
+            // Reselecting that highlight later would draw the stale rects, so
+            // drop the preview whenever the selection changes.
+            .onChange(of: annotationStore.selectedAnnotationId) {
+                controller?.cancelHighlightResize()
+            }
         }
     }
 

--- a/Vellum/Views/Annotations/HighlightLayer.swift
+++ b/Vellum/Views/Annotations/HighlightLayer.swift
@@ -6,9 +6,15 @@ import SwiftUI
 // it); edit popover above the selected highlight's FIRST rect; sticky-note
 // overlays for the page's notes.
 
+/// Which end of a highlight a drag handle controls.
+enum HighlightEdge { case start, end }
+
 struct HighlightLayer: View {
     var annotations: [Annotation]
     var zoom: Double
+    /// Nil in the web viewer (no PDF page geometry to resize against); when
+    /// present, selected highlights grow draggable blue end bars.
+    var controller: PdfViewerController? = nil
 
     @Environment(AnnotationStore.self) private var annotationStore
 
@@ -25,11 +31,20 @@ struct HighlightLayer: View {
         return highlights.first { $0.id == id }
     }
 
+    /// The rects to draw for an annotation — the live resize preview overrides
+    /// the stored ones while its handle is being dragged.
+    private func effectiveRects(for annotation: Annotation) -> [AnnotationRect] {
+        if let resize = controller?.highlightResize, resize.id == annotation.id {
+            return resize.positionData.rects
+        }
+        return annotation.positionData?.rects ?? []
+    }
+
     var body: some View {
         if !(highlights.isEmpty && notes.isEmpty) {
             ZStack(alignment: .topLeading) {
                 ForEach(highlights) { annotation in
-                    let rects = annotation.positionData?.rects ?? []
+                    let rects = effectiveRects(for: annotation)
                     ForEach(Array(rects.enumerated()), id: \.offset) { _, rect in
                         HighlightRectView(
                             annotation: annotation,
@@ -41,15 +56,29 @@ struct HighlightLayer: View {
                     }
                 }
 
-                if let selected = selectedHighlight,
-                   let rect0 = selected.positionData?.rects.first {
-                    AnchoredAbove(point: CGPoint(
-                        x: (rect0.x + rect0.width / 2) * zoom,
-                        y: rect0.y * zoom - 8
-                    )) {
-                        HighlightEditPopover(annotation: selected)
+                if let selected = selectedHighlight {
+                    let rects = effectiveRects(for: selected)
+                    if let rect0 = rects.first {
+                        AnchoredAbove(point: CGPoint(
+                            x: (rect0.x + rect0.width / 2) * zoom,
+                            y: rect0.y * zoom - 8
+                        )) {
+                            HighlightEditPopover(annotation: selected)
+                        }
+                        .zIndex(30)
                     }
-                    .zIndex(30)
+                    // Draggable blue end bars — only in the PDF viewer, where we
+                    // can map a drag point back to text.
+                    if let controller, let first = rects.first, let last = rects.last {
+                        HighlightResizeHandle(
+                            annotation: selected, edge: .start, rect: first,
+                            zoom: zoom, controller: controller)
+                            .zIndex(40)
+                        HighlightResizeHandle(
+                            annotation: selected, edge: .end, rect: last,
+                            zoom: zoom, controller: controller)
+                            .zIndex(40)
+                    }
                 }
 
                 ForEach(notes) { note in
@@ -57,7 +86,75 @@ struct HighlightLayer: View {
                         .zIndex(10)
                 }
             }
+            .coordinateSpace(.named(Self.coordinateSpaceName))
         }
+    }
+
+    static let coordinateSpaceName = "highlightLayer"
+}
+
+/// A vertical blue bar with a round knob at the selected highlight's start or
+/// end. Dragging it re-runs text selection between the moved edge and the
+/// pinned opposite edge, previewing live and committing on release.
+private struct HighlightResizeHandle: View {
+    let annotation: Annotation
+    let edge: HighlightEdge
+    /// The end rect this handle sits on (first rect for .start, last for .end),
+    /// at zoom 1 in page-top-left coordinates.
+    let rect: AnnotationRect
+    let zoom: Double
+    let controller: PdfViewerController
+
+    /// Bar geometry in screen points (kept constant across zoom so the handle
+    /// stays grabbable). Position/height still scale with zoom.
+    private let barWidth: CGFloat = 3
+    private let knobSize: CGFloat = 11
+    private let hitPadding: CGFloat = 12
+
+    private var barHeight: CGFloat { rect.height * zoom }
+
+    /// The bar's center x in layer coordinates: left edge for start, right for end.
+    private var barCenterX: CGFloat {
+        switch edge {
+        case .start: return rect.x * zoom
+        case .end: return (rect.x + rect.width) * zoom
+        }
+    }
+
+    private var barTopY: CGFloat { rect.y * zoom }
+
+    var body: some View {
+        let color = Color(hex: "#2563eb") // blue-600
+        ZStack {
+            Capsule()
+                .fill(color)
+                .frame(width: barWidth, height: max(barHeight, knobSize))
+            // Knob sits at the outer end: top for the start bar, bottom for the end.
+            Circle()
+                .fill(color)
+                .overlay(Circle().strokeBorder(.white, lineWidth: 1.5))
+                .frame(width: knobSize, height: knobSize)
+                .offset(y: edge == .start ? -barHeight / 2 : barHeight / 2)
+        }
+        .frame(width: knobSize + hitPadding, height: max(barHeight, knobSize) + knobSize + hitPadding)
+        .contentShape(Rectangle())
+        .pointerStyle(.grabActive)
+        .position(x: barCenterX, y: barTopY + barHeight / 2)
+        .gesture(
+            DragGesture(minimumDistance: 0, coordinateSpace: .named(HighlightLayer.coordinateSpaceName))
+                .onChanged { value in
+                    controller.previewHighlightResize(
+                        annotation: annotation, edge: edge,
+                        toDisplayPoint: CGPoint(
+                            x: value.location.x / zoom, y: value.location.y / zoom))
+                }
+                .onEnded { value in
+                    controller.commitHighlightResize(
+                        annotation: annotation, edge: edge,
+                        toDisplayPoint: CGPoint(
+                            x: value.location.x / zoom, y: value.location.y / zoom))
+                }
+        )
     }
 }
 
@@ -143,6 +240,12 @@ struct HighlightEditPopover: View {
                 onDelete?()
             }
         }
+        // Hug horizontally BEFORE padding/glass: the swatch row's intrinsic
+        // width sets the popover width and the Unhighlight row's maxWidth:.infinity
+        // fills to match it. Without this the overlay's page-wide ZStack proposes
+        // its full width to the maxWidth:.infinity row and the glass panel
+        // stretches across the page.
+        .fixedSize(horizontal: true, vertical: false)
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .glassEffect(.regular, in: .rect(cornerRadius: Radius.md))

--- a/Vellum/Views/PDF/PdfKitView.swift
+++ b/Vellum/Views/PDF/PdfKitView.swift
@@ -175,7 +175,12 @@ struct PdfKitView: NSViewRepresentable {
         }
 
         /// Tracking-area owner hook; the mouse-moved monitor does the work.
-        @objc func mouseMoved(with event: NSEvent) {}
+        /// MUST be `@objc(mouseMoved:)`: `Coordinator` is an `NSObject`, not an
+        /// `NSResponder`, so a bare `@objc func mouseMoved(with:)` would export the
+        /// selector `mouseMovedWith:` while `NSTrackingArea` sends `mouseMoved:` —
+        /// every mouse-move over the PDF would then throw `unrecognized selector`
+        /// (an NSInvalidArgumentException that crashes under NSApplicationCrashOnExceptions).
+        @objc(mouseMoved:) func mouseMoved(with event: NSEvent) {}
 
         // MARK: - Event monitors
 

--- a/Vellum/Views/PDF/PdfOverlays.swift
+++ b/Vellum/Views/PDF/PdfOverlays.swift
@@ -54,7 +54,7 @@ struct PdfOverlayStack: View {
             }
 
             ForEach(pageOverlays, id: \.pageNumber) { overlay in
-                HighlightLayer(annotations: overlay.annotations, zoom: scale)
+                HighlightLayer(annotations: overlay.annotations, zoom: scale, controller: controller)
                     .frame(
                         width: overlay.frame.width, height: overlay.frame.height,
                         alignment: .topLeading)

--- a/Vellum/Views/PDF/PdfSelectionBridge.swift
+++ b/Vellum/Views/PDF/PdfSelectionBridge.swift
@@ -48,6 +48,11 @@ final class PdfViewerController {
     private(set) var selectionPopoverPosition: CGPoint?
     private(set) var contextMenu: PdfContextMenuState?
 
+    /// Live preview of a highlight whose end handle is being dragged. While set,
+    /// the overlay draws this position instead of the stored one; the store is
+    /// only written on drag end so we don't rewrite the PDF on every mouse move.
+    private(set) var highlightResize: (id: String, positionData: PositionData)?
+
     @ObservationIgnored private var initialPage = 1
     @ObservationIgnored private var didInitialScroll = false
     @ObservationIgnored private var lastScrollOrigin: CGPoint?
@@ -530,6 +535,134 @@ final class PdfViewerController {
         pdfView?.setCurrentSelection(nil, animate: false)
     }
 
+    // MARK: - Highlight edge resize (drag the blue end bars)
+
+    /// Update the live preview as a handle is dragged. `displayPoint` is in the
+    /// annotation's own page space at zoom 1, top-left origin — the same
+    /// coordinate system as the stored rects (the overlay divides the drag
+    /// location by the live scale before calling in).
+    func previewHighlightResize(
+        annotation: Annotation, edge: HighlightEdge, toDisplayPoint displayPoint: CGPoint
+    ) {
+        guard let position = resizedPosition(
+            annotation: annotation, edge: edge, toDisplayPoint: displayPoint) else { return }
+        highlightResize = (id: annotation.id, positionData: position)
+    }
+
+    /// Commit the drag: persist the final position (falling back to the last
+    /// preview if the release point missed a glyph) and clear the preview.
+    func commitHighlightResize(
+        annotation: Annotation, edge: HighlightEdge, toDisplayPoint displayPoint: CGPoint
+    ) {
+        let final = resizedPosition(annotation: annotation, edge: edge, toDisplayPoint: displayPoint)
+            ?? (highlightResize?.id == annotation.id ? highlightResize?.positionData : nil)
+        highlightResize = nil
+        guard let final, final.rects != annotation.positionData?.rects else { return }
+        Task { [weak self] in
+            await self?.annotationStore?.updateAnnotation(UpdateAnnotationInput(
+                id: annotation.id, color: nil, content: nil, positionData: final))
+        }
+    }
+
+    func cancelHighlightResize() {
+        highlightResize = nil
+    }
+
+    /// Rebuild a highlight's position with one edge moved to `displayPoint`,
+    /// keeping the opposite edge anchored. Returns nil when the drag point (or
+    /// the anchor) doesn't land on a glyph, so the caller keeps the last frame.
+    private func resizedPosition(
+        annotation: Annotation, edge: HighlightEdge, toDisplayPoint displayPoint: CGPoint
+    ) -> PositionData? {
+        guard let document,
+              annotation.pageNumber >= 1, annotation.pageNumber <= document.pageCount,
+              let page = document.page(at: annotation.pageNumber - 1),
+              let current = annotation.positionData else { return nil }
+        return Self.resizedPosition(
+            page: page, current: current, edge: edge, toDisplayPoint: displayPoint)
+    }
+
+    /// Pure resize core (testable without the controller/app). See the instance
+    /// wrapper for what it does.
+    static func resizedPosition(
+        page: PDFPage, current: PositionData, edge: HighlightEdge, toDisplayPoint displayPoint: CGPoint
+    ) -> PositionData? {
+        guard let firstRect = current.rects.first,
+              let lastRect = current.rects.last else { return nil }
+        guard page.numberOfCharacters > 0 else { return nil }
+
+        // Resize by re-running PDFKit's own point-to-point text selection between
+        // the PINNED edge and the dragged point — the same engine that backs
+        // click-drag selection. We deliberately DON'T use `characterIndex(at:)` /
+        // `characterBounds(at:)`: on real-world PDFs those live in a different
+        // internal coordinate basis than `selectionsByLine()` (e.g. this book
+        // reports a word at glyph-x 441 but selection-line-x 271), so mixing them
+        // made a purely horizontal drag jump to a different line — and
+        // `characterBounds(at:)` can trap past the last glyph. `selection(from:
+        // to:)` is consistent with the stored rects (both selection-space) and
+        // clamps to line ends on its own, so the edge tracks the cursor cleanly.
+        //
+        // The pinned edge stays put: dragging the end anchors the START (left edge
+        // of the first rect); dragging the start anchors the END (right edge of
+        // the last rect). Re-deriving the anchor from the unchanged fixed rect
+        // each frame keeps it rock-stable across repeated drags.
+        let anchorDisplay: CGPoint
+        switch edge {
+        case .end:
+            anchorDisplay = CGPoint(x: firstRect.x, y: firstRect.y + firstRect.height / 2)
+        case .start:
+            anchorDisplay = CGPoint(x: lastRect.x + lastRect.width, y: lastRect.y + lastRect.height / 2)
+        }
+        let anchorPoint = Self.pageSpacePoint(fromDisplay: anchorDisplay, page: page)
+
+        // Clamp the dragged point to the page so an overshoot past an edge still
+        // resolves to the nearest glyph on that side.
+        let clampedDrag = CGPoint(
+            x: min(max(displayPoint.x, 0), current.pageWidth),
+            y: min(max(displayPoint.y, 0), current.pageHeight)
+        )
+        let dragPoint = Self.pageSpacePoint(fromDisplay: clampedDrag, page: page)
+
+        // The dragged edge NEVER crosses the pinned edge: dragging the end past
+        // the start (or the start past the end) would otherwise flip the selection
+        // and make the pinned end travel (the "beginning moves when I drag the
+        // end" bug). Compare in reading order using page-space geometry (y grows
+        // upward, so a smaller y is a lower/later line); if the drag has crossed,
+        // hold the last frame instead of inverting.
+        let lineTol = max(firstRect.height, lastRect.height) * 0.6
+        func isAfter(_ p: CGPoint, _ ref: CGPoint) -> Bool {
+            if p.y < ref.y - lineTol { return true }
+            if p.y > ref.y + lineTol { return false }
+            return p.x > ref.x
+        }
+        switch edge {
+        case .end:   guard isAfter(dragPoint, anchorPoint) else { return nil }
+        case .start: guard isAfter(anchorPoint, dragPoint) else { return nil }
+        }
+
+        guard let selection = page.selection(from: anchorPoint, to: dragPoint),
+              let text = selection.string, !text.isEmpty else { return nil }
+
+        var rects: [AnnotationRect] = []
+        for line in selection.selectionsByLine() {
+            guard let linePage = line.pages.first else { continue }
+            let bounds = line.bounds(for: linePage)
+            guard bounds.width > 0, bounds.height > 0 else { continue }
+            rects.append(Self.uiRect(fromPageSpace: bounds, page: linePage))
+        }
+        let merged = Self.mergeLineRects(rects)
+        guard !merged.isEmpty else { return nil }
+
+        var next = current
+        next.rects = merged
+        next.selectedText = text
+        // The anchor is geometry-derived from the pinned rect, not a stored index,
+        // so clear any stale offsets from an earlier index-based resize.
+        next.startOffset = nil
+        next.endOffset = nil
+        return next
+    }
+
     // MARK: - Note placement
 
     private func placeNote(
@@ -732,6 +865,20 @@ final class PdfViewerController {
         return AnnotationRect(
             x: Double(minX), y: Double(minY),
             width: Double(maxX - minX), height: Double(maxY - minY))
+    }
+
+    /// Inverse of `uiRect`'s per-corner map: top-left display point (CropBox
+    /// relative, zoom 1) → PDF page space (bottom-left origin) for hit-testing
+    /// with `characterIndex(at:)`.
+    static func pageSpacePoint(fromDisplay point: CGPoint, page: PDFPage) -> CGPoint {
+        let crop = page.bounds(for: .cropBox)
+        let rotation = ((page.rotation % 360) + 360) % 360
+        switch rotation {
+        case 90: return CGPoint(x: point.y + crop.minX, y: point.x + crop.minY)
+        case 180: return CGPoint(x: crop.maxX - point.x, y: point.y + crop.minY)
+        case 270: return CGPoint(x: crop.maxX - point.y, y: crop.maxY - point.x)
+        default: return CGPoint(x: point.x + crop.minX, y: crop.maxY - point.y)
+        }
     }
 
     /// Rotation-aware page display size at zoom 1.

--- a/Vellum/Views/Web/WebContentScript.swift
+++ b/Vellum/Views/Web/WebContentScript.swift
@@ -59,6 +59,22 @@ enum WebContentScript {
   var noteMode = false;
   var initialized = false;
 
+  // Highlight edge-resize state. The app shell nominates the selected highlight
+  // (the one whose edit popover is open); we draw draggable blue end bars on it,
+  // mirroring the PDF viewer. Dragging a bar re-anchors that edge to the caret
+  // under the pointer while the opposite edge stays pinned.
+  var selectedHighlightId = null;
+  // Resolved raw offsets of the selected highlight this render, so a drag can
+  // read its pinned edge without re-resolving.
+  var selectedHighlightRange = null; // { start, end }
+  // Live drag preview: while set, renderHighlights draws these offsets for the
+  // matching id instead of the stored ones (the store is only written on drop).
+  var resizePreview = null; // { id, start, end }
+  var resizeState = null; // { id, edge, start, end, anchorOffset } during a drag
+  // True from a handle mousedown until just after the drop, so the trailing
+  // mouseup doesn't clear the selection / close the edit popover.
+  var resizing = false;
+
   // Find bar state (⌘F): matches are raw-offset {start,end} pairs, rendered in
   // their own overlay layer so the app's find never touches annotation layers.
   var findRoot = null;
@@ -527,13 +543,24 @@ enum WebContentScript {
     while (root.firstChild) root.removeChild(root.firstChild);
     resolveBookmarks();
     highlightHitRects = [];
+    selectedHighlightRange = null;
+    resizeHandleEls = null;
+    // First and last rendered rect of the selected highlight (viewport coords),
+    // where the drag handles get anchored after the fill divs are drawn.
+    var selectedFirstRect = null;
+    var selectedLastRect = null;
 
     for (var i = 0; i < appliedHighlights.length; i++) {
       var h = appliedHighlights[i];
-      var resolved = resolveHighlight(h);
+      var resolved =
+        resizePreview && resizePreview.id === h.id
+          ? { start: resizePreview.start, end: resizePreview.end }
+          : resolveHighlight(h);
       if (!resolved) continue;
       var range = rangeFromRaw(resolved.start, resolved.end);
       if (!range) continue;
+      var isSelected = h.id === selectedHighlightId;
+      if (isSelected) selectedHighlightRange = { start: resolved.start, end: resolved.end };
       var rects = range.getClientRects();
       for (var r = 0; r < rects.length; r++) {
         var rect = rects[r];
@@ -545,22 +572,23 @@ enum WebContentScript {
           width: rect.width,
           height: rect.height,
         });
-        var div = document.createElement("div");
-        div.setAttribute("data-vellum-id", h.id);
-        div.style.cssText =
-          "position:absolute;pointer-events:none;border-radius:2px;" +
-          "mix-blend-mode:multiply;opacity:0.55;";
-        div.style.left = rect.left + window.scrollX + "px";
-        div.style.top = rect.top + window.scrollY + "px";
-        div.style.width = rect.width + "px";
-        div.style.height = rect.height + "px";
-        try {
-          div.style.backgroundColor = h.color || "#fef08a";
-        } catch (err) {
-          div.style.backgroundColor = "#fef08a";
+        if (isSelected) {
+          if (!selectedFirstRect) selectedFirstRect = rect;
+          selectedLastRect = rect;
         }
-        root.appendChild(div);
+        root.appendChild(makeFillDiv(h.id, h.color, rect));
       }
+    }
+
+    // Draggable blue end bars on the selected highlight (matches the PDF viewer).
+    // Kept as persistent nodes so a drag repositions them in place rather than
+    // rebuilding (see drawResizePreview).
+    if (selectedHighlightRange && selectedFirstRect && selectedLastRect) {
+      var startHandle = makeResizeHandle("start", selectedFirstRect);
+      var endHandle = makeResizeHandle("end", selectedLastRect);
+      root.appendChild(startHandle);
+      root.appendChild(endHandle);
+      resizeHandleEls = { start: startHandle, end: endHandle };
     }
 
     // Sticky-note markers: a small clickable badge at the note's anchor. The
@@ -626,6 +654,334 @@ enum WebContentScript {
       });
     });
     root.appendChild(marker);
+  }
+
+  // ------------------------------------------------------------------
+  // Highlight edge resize (drag the blue end bars)
+  // ------------------------------------------------------------------
+
+  var RESIZE_COLOR = "#2563eb"; // blue-600, matches the PDF viewer handles
+  var RESIZE_BAR_W = 3;
+  var RESIZE_KNOB = 11;
+  var RESIZE_PAD = 10; // extra hit slop around the knob
+  // The two live handle elements while a highlight is selected. Persisting them
+  // lets a drag reposition the handles in place (layoutResizeHandle) instead of
+  // recreating them every frame — recreating the grabbed handle mid-drag is
+  // what made WebKit lose its mousedown anchor and select the whole page.
+  var resizeHandleEls = null; // { start, end }
+
+  function makeFillDiv(id, color, rect) {
+    var div = document.createElement("div");
+    div.setAttribute("data-vellum-id", id);
+    div.style.cssText =
+      "position:absolute;pointer-events:none;border-radius:2px;" +
+      "mix-blend-mode:multiply;opacity:0.55;";
+    div.style.left = rect.left + window.scrollX + "px";
+    div.style.top = rect.top + window.scrollY + "px";
+    div.style.width = rect.width + "px";
+    div.style.height = rect.height + "px";
+    try {
+      div.style.backgroundColor = color || "#fef08a";
+    } catch (err) {
+      div.style.backgroundColor = "#fef08a";
+    }
+    return div;
+  }
+
+  // Position an existing handle (outer + its ._bar / ._knob children) onto
+  // `rect` — the highlight's first (start) or last (end) client rect in viewport
+  // coordinates. The handle is placed in document coordinates so it tracks the
+  // page as it scrolls. The handle's high z-index keeps it above the fill divs
+  // regardless of DOM order, so a drag never has to re-append it.
+  function layoutResizeHandle(outer, edge, rect) {
+    var outerW = RESIZE_KNOB + RESIZE_PAD;
+    var outerH = rect.height + RESIZE_KNOB + RESIZE_PAD;
+    var barCenterX = (edge === "start" ? rect.left : rect.right) + window.scrollX;
+    var docTop = rect.top + window.scrollY;
+    outer.style.left = barCenterX - outerW / 2 + "px";
+    outer.style.top = docTop - RESIZE_PAD / 2 - RESIZE_KNOB / 2 + "px";
+    outer.style.width = outerW + "px";
+    outer.style.height = outerH + "px";
+
+    var barTop = (outerH - rect.height) / 2;
+    var bar = outer._bar;
+    bar.style.left = (outerW - RESIZE_BAR_W) / 2 + "px";
+    bar.style.top = barTop + "px";
+    bar.style.width = RESIZE_BAR_W + "px";
+    bar.style.height = Math.max(rect.height, RESIZE_KNOB) + "px";
+
+    var knob = outer._knob;
+    knob.style.left = (outerW - RESIZE_KNOB) / 2 + "px";
+    // Knob at the outer end: top for the start bar, bottom for the end bar.
+    knob.style.top =
+      (edge === "start" ? barTop : barTop + rect.height) - RESIZE_KNOB / 2 + "px";
+    knob.style.width = RESIZE_KNOB + "px";
+    knob.style.height = RESIZE_KNOB + "px";
+  }
+
+  // A vertical blue bar with a round knob sitting on one edge of the selected
+  // highlight.
+  function makeResizeHandle(edge, rect) {
+    var outer = document.createElement("div");
+    outer.setAttribute("data-vellum-resize", edge);
+    outer.style.cssText =
+      "position:absolute;pointer-events:auto;cursor:grab;z-index:2147483647;";
+
+    var bar = document.createElement("div");
+    bar.style.cssText =
+      "position:absolute;border-radius:2px;background:" + RESIZE_COLOR + ";";
+    outer.appendChild(bar);
+    outer._bar = bar;
+
+    var knob = document.createElement("div");
+    knob.style.cssText =
+      "position:absolute;border-radius:50%;box-sizing:border-box;background:" +
+      RESIZE_COLOR + ";border:1.5px solid #fff;";
+    outer.appendChild(knob);
+    outer._knob = knob;
+
+    layoutResizeHandle(outer, edge, rect);
+
+    outer.addEventListener("mousedown", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      beginResize(edge);
+    });
+    return outer;
+  }
+
+  // Per-frame update during a drag: redraw ONLY the selected highlight's fill
+  // from the preview offsets and reposition the two handles, leaving every
+  // other overlay element — and, crucially, the grabbed handle's DOM node —
+  // untouched. This is the whole reason the drag no longer triggers a native
+  // page selection.
+  function drawResizePreview() {
+    if (!resizeState || !resizePreview) return;
+    var root = ensureOverlayRoot();
+    var id = resizeState.id;
+
+    var stale = [];
+    for (var c = 0; c < root.children.length; c++) {
+      var child = root.children[c];
+      if (child.getAttribute && child.getAttribute("data-vellum-id") === id) {
+        stale.push(child);
+      }
+    }
+    for (var s = 0; s < stale.length; s++) root.removeChild(stale[s]);
+
+    var range = rangeFromRaw(resizePreview.start, resizePreview.end);
+    if (!range) return;
+    var color = null;
+    for (var i = 0; i < appliedHighlights.length; i++) {
+      if (appliedHighlights[i].id === id) {
+        color = appliedHighlights[i].color;
+        break;
+      }
+    }
+    var rects = range.getClientRects();
+    var firstRect = null;
+    var lastRect = null;
+    for (var r = 0; r < rects.length; r++) {
+      var rect = rects[r];
+      if (rect.width < 1 || rect.height < 1) continue;
+      if (!firstRect) firstRect = rect;
+      lastRect = rect;
+      root.appendChild(makeFillDiv(id, color, rect));
+    }
+    if (firstRect && lastRect) {
+      selectedHighlightRange = { start: resizePreview.start, end: resizePreview.end };
+      if (resizeHandleEls && resizeHandleEls.start && resizeHandleEls.end) {
+        layoutResizeHandle(resizeHandleEls.start, "start", firstRect);
+        layoutResizeHandle(resizeHandleEls.end, "end", lastRect);
+      }
+    }
+  }
+
+  // Preventing a native text selection during the drag uses THREE guards, the
+  // first of which is decisive and mechanism-independent:
+  //  1. A full-viewport DRAG SHIELD: a transparent fixed div covering the whole
+  //     page while the drag is live. WebKit cannot select text the cursor never
+  //     touches, so this defeats the selection no matter HOW it would otherwise
+  //     start — including the "anchor-loss" case where the grabbed handle's
+  //     mousedown (which we preventDefault) is torn out from under WebKit and it
+  //     begins a fresh selection that a cancellable `selectstart` never fires
+  //     for. The one catch: `caretRangeFromPoint` (how we map the drag point to
+  //     a text offset) also respects the shield, so onResizeMove flips the
+  //     shield to pointer-events:none for that single synchronous hit-test and
+  //     back — no real event can slip through in the gap.
+  //  2. `selectstart`/`dragstart` cancellation: aborts a normal user-selection
+  //     the instant it tries to form (and blocks native image/text drag-drop).
+  //  3. `user-select:none` + grabbing cursor page-wide: extra insurance and the
+  //     visual affordance.
+  function onResizeSelectStart(e) {
+    e.preventDefault();
+  }
+  var resizeLockStyle = null;
+  var resizeShield = null;
+  function setResizeLock(on) {
+    if (on) {
+      if (!resizeShield) {
+        resizeShield = document.createElement("div");
+        resizeShield.id = "__vellum-resize-shield";
+        resizeShield.setAttribute("aria-hidden", "true");
+        resizeShield.style.cssText =
+          "position:fixed;left:0;top:0;width:100vw;height:100vh;" +
+          "z-index:2147483647;background:transparent;cursor:grabbing;";
+        (document.body || document.documentElement).appendChild(resizeShield);
+      }
+      document.addEventListener("selectstart", onResizeSelectStart, true);
+      document.addEventListener("dragstart", onResizeSelectStart, true);
+      if (!resizeLockStyle) {
+        resizeLockStyle = document.createElement("style");
+        resizeLockStyle.id = "__vellum-resize-lock";
+        resizeLockStyle.textContent =
+          "*{-webkit-user-select:none!important;user-select:none!important;" +
+          "cursor:grabbing!important;}";
+        (document.head || document.documentElement).appendChild(resizeLockStyle);
+      }
+      var sel = window.getSelection();
+      if (sel && !sel.isCollapsed) sel.removeAllRanges();
+    } else {
+      if (resizeShield) {
+        if (resizeShield.parentNode) resizeShield.parentNode.removeChild(resizeShield);
+        resizeShield = null;
+      }
+      document.removeEventListener("selectstart", onResizeSelectStart, true);
+      document.removeEventListener("dragstart", onResizeSelectStart, true);
+      if (resizeLockStyle) {
+        if (resizeLockStyle.parentNode) {
+          resizeLockStyle.parentNode.removeChild(resizeLockStyle);
+        }
+        resizeLockStyle = null;
+      }
+    }
+  }
+
+  // The knobs are small and the highlight fill divs are pointer-events:none, so
+  // a mousedown that misses the knob lands on the page text underneath and
+  // starts a normal drag-selection ("finicky... it selects the whole page").
+  // Fix: while a highlight is selected, ANY mousedown on it (or within a margin
+  // of its handles) begins a resize of the nearest edge instead — no text
+  // selection can start. Capture phase + stopPropagation so it also pre-empts
+  // the per-handle listener (no double beginResize) and the link/click paths.
+  function onSelectedHighlightMouseDown(e) {
+    if (selectedHighlightId === null || resizing || noteMode || e.button !== 0) return;
+    var rects = [];
+    for (var i = 0; i < highlightHitRects.length; i++) {
+      if (highlightHitRects[i].id === selectedHighlightId) rects.push(highlightHitRects[i]);
+    }
+    if (rects.length === 0) return;
+    var docX = e.clientX + window.scrollX;
+    var docY = e.clientY + window.scrollY;
+    var margin = RESIZE_KNOB + RESIZE_PAD; // cover the knob/hit-slop past the text edges
+    var inside = false;
+    for (var r = 0; r < rects.length; r++) {
+      var rc = rects[r];
+      if (
+        docX >= rc.left - margin && docX <= rc.left + rc.width + margin &&
+        docY >= rc.top - margin && docY <= rc.top + rc.height + margin
+      ) { inside = true; break; }
+    }
+    if (!inside) return;
+    // Nearest edge: distance to the start (left of first rect) vs the end
+    // (right of last rect).
+    var first = rects[0], last = rects[rects.length - 1];
+    var dStart = Math.hypot(docX - first.left, docY - (first.top + first.height / 2));
+    var dEnd = Math.hypot(docX - (last.left + last.width), docY - (last.top + last.height / 2));
+    e.preventDefault();
+    e.stopPropagation();
+    beginResize(dStart <= dEnd ? "start" : "end");
+  }
+
+  function beginResize(edge) {
+    if (!selectedHighlightRange || selectedHighlightId === null) return;
+    resizing = true;
+    resizeState = {
+      id: selectedHighlightId,
+      edge: edge,
+      start: selectedHighlightRange.start,
+      end: selectedHighlightRange.end,
+      anchorOffset: edge === "start" ? selectedHighlightRange.end : selectedHighlightRange.start,
+    };
+    setResizeLock(true);
+    document.addEventListener("mousemove", onResizeMove, true);
+    document.addEventListener("mouseup", onResizeUp, true);
+  }
+
+  function onResizeMove(e) {
+    if (!resizeState) return;
+    e.preventDefault();
+    // Belt-and-suspenders: drop any selection the browser managed to start
+    // before the guards took hold.
+    var liveSel = window.getSelection();
+    if (liveSel && !liveSel.isCollapsed) liveSel.removeAllRanges();
+    // The shield sits over the text, so drop it to pointer-events:none for the
+    // single synchronous caret hit-test, then restore it. Nothing can select in
+    // this gap because no event is dispatched during a synchronous call.
+    if (resizeShield) resizeShield.style.pointerEvents = "none";
+    var caret = rawOffsetAtPoint(e.clientX, e.clientY);
+    if (resizeShield) resizeShield.style.pointerEvents = "auto";
+    if (caret === null) return; // over a gap/chrome: hold the last frame
+    var start = resizeState.start;
+    var end = resizeState.end;
+    if (resizeState.edge === "start") {
+      // Dragged edge never crosses (or touches) the pinned end.
+      start = Math.max(0, Math.min(caret, resizeState.anchorOffset - 1));
+      end = resizeState.anchorOffset;
+    } else {
+      start = resizeState.anchorOffset;
+      end = Math.min(rawText.length, Math.max(caret, resizeState.anchorOffset + 1));
+    }
+    if (start === resizeState.start && end === resizeState.end) return;
+    resizeState.start = start;
+    resizeState.end = end;
+    resizePreview = { id: resizeState.id, start: start, end: end };
+    drawResizePreview();
+  }
+
+  function onResizeUp() {
+    document.removeEventListener("mousemove", onResizeMove, true);
+    document.removeEventListener("mouseup", onResizeUp, true);
+    setResizeLock(false);
+    var state = resizeState;
+    resizeState = null;
+    resizePreview = null;
+    // Let the trailing mouseup->reportSelection and click handlers see that a
+    // resize just finished, then release the flag.
+    setTimeout(function () {
+      resizing = false;
+    }, 60);
+    if (!state) return;
+    var start = state.start;
+    var end = state.end;
+    if (end <= start) {
+      renderHighlights();
+      return;
+    }
+    var text = collapseWs(rawText.slice(start, end)).trim();
+    var ctx = quoteContext(start, end);
+    // Update the local record so the highlight stays at the new size until the
+    // app shell's apply-annotations round-trip lands (avoids a flicker back).
+    for (var i = 0; i < appliedHighlights.length; i++) {
+      if (appliedHighlights[i].id === state.id) {
+        appliedHighlights[i].start = start;
+        appliedHighlights[i].end = end;
+        appliedHighlights[i].text = text;
+        appliedHighlights[i].prefix = ctx.prefix;
+        appliedHighlights[i].suffix = ctx.suffix;
+        break;
+      }
+    }
+    renderHighlights();
+    post("highlight-resized", {
+      id: state.id,
+      start: start,
+      end: end,
+      text: text,
+      prefix: ctx.prefix,
+      suffix: ctx.suffix,
+      pageNumber: pageForRaw(start),
+    });
   }
 
   // ------------------------------------------------------------------
@@ -829,6 +1185,9 @@ enum WebContentScript {
   // ------------------------------------------------------------------
 
   function reportSelection() {
+    // A handle drag ends in a mouseup too; don't let it clear the selection or
+    // dismiss the highlight's edit popover.
+    if (resizing) return;
     var sel = window.getSelection();
     if (!sel || sel.isCollapsed || sel.rangeCount === 0) {
       post("selection-cleared");
@@ -1103,6 +1462,21 @@ enum WebContentScript {
         reportScroll(true);
         break;
 
+      case "set-selected-highlight": {
+        var nextId = d.id != null ? String(d.id) : null;
+        if (nextId !== selectedHighlightId) {
+          selectedHighlightId = nextId;
+          if (nextId === null) {
+            resizePreview = null;
+            resizeState = null;
+            resizing = false;
+            setResizeLock(false);
+          }
+          renderHighlights();
+        }
+        break;
+      }
+
       case "set-mode": {
         noteMode = d.mode === "note";
         try {
@@ -1319,6 +1693,8 @@ enum WebContentScript {
     initialize(true);
     window.addEventListener("scroll", onScroll, { passive: true });
     window.addEventListener("resize", relayout);
+    // Grab-anywhere-on-the-selected-highlight resize (see the function comment).
+    document.addEventListener("mousedown", onSelectedHighlightMouseDown, true);
 
     // Back/forward can restore this page from WebKit's page cache, where
     // user scripts don't re-run: without a fresh init the shell keeps the
@@ -1348,6 +1724,20 @@ enum WebContentScript {
         renderHighlights();
         reportScroll(true);
       }, 600);
+      // Our own transient drag chrome (the resize shield + user-select lock
+      // style) is added/removed on document.body/head during a drag; those
+      // mutations must not trigger a re-extract that rebuilds the handles
+      // mid-drag.
+      function isOwnResizeChrome(n) {
+        return !!n && (n.id === "__vellum-resize-shield" || n.id === "__vellum-resize-lock");
+      }
+      function onlyOwnChrome(list) {
+        if (!list || list.length === 0) return false;
+        for (var k = 0; k < list.length; k++) {
+          if (!isOwnResizeChrome(list[k])) return false;
+        }
+        return true;
+      }
       new MutationObserver(function (records) {
         for (var i = 0; i < records.length; i++) {
           var target = records[i].target;
@@ -1355,6 +1745,14 @@ enum WebContentScript {
             continue;
           }
           if (findRoot && (target === findRoot || findRoot.contains(target))) {
+            continue;
+          }
+          if (isOwnResizeChrome(target)) continue;
+          // Pure shield/lock add or remove: not a page change.
+          if (
+            records[i].type === "childList" &&
+            (onlyOwnChrome(records[i].addedNodes) || onlyOwnChrome(records[i].removedNodes))
+          ) {
             continue;
           }
           remap();

--- a/Vellum/Views/Web/WebContentScript.swift
+++ b/Vellum/Views/Web/WebContentScript.swift
@@ -984,11 +984,15 @@ enum WebContentScript {
     if (!state) return;
     var start = state.start;
     var end = state.end;
-    if (end <= start) {
+    var text = collapseWs(rawText.slice(start, end)).trim();
+    // Collapsed range OR whitespace-only quote: bail like a no-op drag. An
+    // empty selectedText would be dropped by the app shell's hasQuote filter
+    // on the next apply-annotations round-trip, silently deleting the
+    // highlight.
+    if (end <= start || text.length === 0) {
       renderHighlights();
       return;
     }
-    var text = collapseWs(rawText.slice(start, end)).trim();
     var ctx = quoteContext(start, end);
     // Update the local record so the highlight stays at the new size until the
     // app shell's apply-annotations round-trip lands (avoids a flicker back).

--- a/Vellum/Views/Web/WebContentScript.swift
+++ b/Vellum/Views/Web/WebContentScript.swift
@@ -834,9 +834,18 @@ enum WebContentScript {
       if (!resizeLockStyle) {
         resizeLockStyle = document.createElement("style");
         resizeLockStyle.id = "__vellum-resize-lock";
+        // The overlay rule matters as much as the user-select one: the grabbed
+        // handle (and any note marker) is pointer-events:auto and sits directly
+        // under the cursor, so caretRangeFromPoint would hit IT instead of the
+        // text below. That boundary lives in the overlay root at the END of
+        // documentElement, which rawOffsetOfBoundary maps to rawText.length —
+        // snapping the dragged edge to the end of the document (the "resize
+        // selects the whole page" bug). Move/up are captured on document, so
+        // the handles need no events while the drag is live.
         resizeLockStyle.textContent =
           "*{-webkit-user-select:none!important;user-select:none!important;" +
-          "cursor:grabbing!important;}";
+          "cursor:grabbing!important;}" +
+          "#__vellum-highlights *{pointer-events:none!important;}";
         (document.head || document.documentElement).appendChild(resizeLockStyle);
       }
       var sel = window.getSelection();
@@ -922,6 +931,27 @@ enum WebContentScript {
     var caret = rawOffsetAtPoint(e.clientX, e.clientY);
     if (resizeShield) resizeShield.style.pointerEvents = "auto";
     if (caret === null) return; // over a gap/chrome: hold the last frame
+    // Plausibility guard: hit-testing in empty regions (page margins, space
+    // past the last paragraph, footer/header gaps) snaps the caret to a
+    // document-boundary position whole screens away from the pointer — most
+    // dangerously rawText.length, which yanks the dragged edge to the end of
+    // the page in one frame. Require the caret's rendered line to be near the
+    // pointer's y; otherwise hold the last frame like a missed hit-test.
+    // Probe the nearest rendered (non-space) character — a caret on collapsed
+    // whitespace (line breaks, the document's trailing whitespace nodes) has
+    // no box of its own to measure.
+    var probeAt = Math.min(caret, rawText.length - 1);
+    while (probeAt > 0 && isSpaceCode(rawText.charCodeAt(probeAt))) probeAt--;
+    var caretProbe = rangeFromRaw(probeAt, probeAt + 1);
+    if (caretProbe) {
+      var caretRect = caretProbe.getBoundingClientRect();
+      if (isFinite(caretRect.top) && (caretRect.width > 0 || caretRect.height > 0)) {
+        var dy = 0;
+        if (e.clientY < caretRect.top) dy = caretRect.top - e.clientY;
+        else if (e.clientY > caretRect.bottom) dy = e.clientY - caretRect.bottom;
+        if (dy > 80) return;
+      }
+    }
     var start = resizeState.start;
     var end = resizeState.end;
     if (resizeState.edge === "start") {

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -165,6 +165,7 @@ struct WebViewerView: View {
         .onChange(of: controller.initCount) {
             controller.pushAnnotations(annotationStore.annotations)
             controller.pushMode(appStore.mode)
+            controller.pushSelectedHighlight()
             controller.scrollToSelected(
                 annotations: annotationStore.annotations,
                 selectedId: annotationStore.selectedAnnotationId)
@@ -229,7 +230,15 @@ final class WebViewerController: NSObject {
     private(set) var noteComposer: WebNoteComposerState?
     private(set) var contextMenu: WebContextMenuState?
     private(set) var noteViewer: WebNoteViewerState?
-    private(set) var highlightEditor: WebHighlightEditorState?
+    private(set) var highlightEditor: WebHighlightEditorState? {
+        didSet {
+            // The selected highlight (the one whose edit popover is open) grows
+            // draggable resize handles in the page; keep the content script in
+            // sync whenever the selection changes.
+            guard highlightEditor?.id != oldValue?.id else { return }
+            pushSelectedHighlight()
+        }
+    }
 
     /// Window-space frame of the context menu (for click-outside detection).
     @ObservationIgnored var contextMenuGlobalFrame: CGRect = .zero
@@ -496,6 +505,14 @@ final class WebViewerController: NSObject {
         post("set-mode", ["mode": mode.rawValue])
     }
 
+    /// Tell the content script which highlight is selected so it draws (or
+    /// removes) the drag handles. Re-sent after each (re-)init because the
+    /// injected script starts with no selection.
+    func pushSelectedHighlight() {
+        guard initCount > 0 else { return }
+        post("set-selected-highlight", ["id": orNull(highlightEditor?.id)])
+    }
+
     func scrollToSelected(annotations: [Annotation], selectedId: String?) {
         guard initCount > 0, let selectedId else { return }
         guard let annotation = annotations.first(where: { $0.id == selectedId }) else { return }
@@ -735,6 +752,27 @@ final class WebViewerController: NSObject {
                 noteViewer = nil
                 hideContextMenu()
                 highlightEditor = WebHighlightEditorState(id: id, point: point, openedAt: Date())
+            }
+
+        case "highlight-resized":
+            guard let id = data["id"] as? String,
+                  let start = intValue(data["start"]),
+                  let end = intValue(data["end"]),
+                  let text = data["text"] as? String,
+                  let annotationStore else { break }
+            let positionData = PositionData(
+                rects: [],
+                pageWidth: 1,
+                pageHeight: 1,
+                selectedText: text,
+                startOffset: start,
+                endOffset: end,
+                prefix: data["prefix"] as? String,
+                suffix: data["suffix"] as? String,
+                viewportOffset: nil)
+            Task {
+                await annotationStore.updateAnnotation(UpdateAnnotationInput(
+                    id: id, color: nil, content: nil, positionData: positionData))
             }
 
         case "navigate":

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -772,7 +772,10 @@ final class WebViewerController: NSObject {
                 viewportOffset: nil)
             Task {
                 await annotationStore.updateAnnotation(UpdateAnnotationInput(
-                    id: id, color: nil, content: nil, positionData: positionData))
+                    id: id, color: nil, content: nil, positionData: positionData,
+                    // A resize can drag the anchor across a virtual page break;
+                    // keep the sidebar grouping/navigation on the new page.
+                    pageNumber: intValue(data["pageNumber"])))
             }
 
         case "navigate":


### PR DESCRIPTION
## Summary
- Adds draggable start/end handles for PDF highlight selection so highlighted text can be resized directly in the viewer.
- Reworks PDF selection/highlight plumbing to preserve selection state while supporting smoother edge dragging and safer bounds handling.
- Refactors the app shell around a single document-centric store flow, with updated toolbar, sidebar, and web/PDF viewer wiring.
- Removes the old pane/workspace split-screen implementation and associated tests in favor of the simplified document layout.
- Adds regression coverage for highlight resize behavior, including edge crossing, empty-page handling, and dragging past text bounds.

## Testing
- Ran the updated PDF persistence and highlight resize test coverage in `Tests/PdfPersistenceTests.swift`.
- Verified highlight resizing cases for:
  - dragging the end handle past the text end
  - dragging the end handle past the start
  - dragging into the left margin
  - dragging the start handle left
  - resizing on an empty page
- Not run: full app UI regression pass on macOS.
- Not run: complete build of every removed pane/workspace path, since those files were deleted in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added draggable highlight edge-resize handles with live preview and saving on drag end.
  * Automatically re-applies the selected highlight after the PDF view re-initializes.
  * Web highlight resizing now supports persisting updated page info (including virtual page crossings).
* **Bug Fixes**
  * Improved resize stability around bounds (including empty/no-text pages) and kept resize state consistent during selection changes.
  * Highlight creates now appear immediately with optimistic updates, then reconcile with the saved annotation.
* **Tests**
  * Added edge-case coverage for highlight resize behavior (over-dragging and empty pages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->