### PR TITLE
Add configurable web-library storage location and explicit offline-save semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,31 @@ All notable changes to Vellum are documented here. The format follows
 
 ## [Unreleased]
 
-Restores the AI-experience features that were lost in the scratchpad merge
-(which also committed literal conflict markers, leaving `main` uncompilable),
-and lands the final `ai-experiance` review commit that had never been merged.
+Adds a user-chosen storage location for the web library (iCloud Drive, a
+custom folder, or this Mac), and restores the AI-experience features that
+were lost in the scratchpad merge (which also committed literal conflict
+markers, leaving `main` uncompilable), landing the final `ai-experiance`
+review commit that had never been merged.
 
 ### Added
 
+- **Choose where your web library lives.** A one-time choice at launch (and
+  in Settings ▸ Storage): iCloud Drive — everything (offline copies,
+  highlights, notes, reading positions) lives in `iCloud Drive ▸ Vellum` and
+  syncs across Macs — a custom folder (offline copies only; reading state
+  stays local and does not sync, stated in the UI), or this Mac (the previous
+  layout). Existing libraries migrate in the background, and interrupted
+  moves resume at the next launch.
+- Offline copies are now human-navigable: one `<Page Title>.vellumweb` per
+  page in a visible `Web Pages` folder instead of SHA-256 filenames.
+- **Automatically save every page for offline use** (Settings ▸ Storage, off
+  by default): restores the old open-means-keep behavior as an opt-in; pages
+  saved this way are exempt from the six-month cleanup.
+- The web toolbar's two actions are now one **Save for Offline Use / Remove
+  Offline Copy** toggle — saving also (re)writes the offline copy if it is
+  missing, removing deletes the copy but never highlights, notes, or reading
+  position. Exporting a portable archive elsewhere lives on as
+  "Export a Copy…".
 - **Screenshots into the AI chat.** The AI panel's "+" attach menu offers
   "Attach current page" (full-page snapshot) and "Snapshot region…"
   (drag-to-crop a marquee over the PDF); both attach the image as a composer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to Vellum are documented here. The format follows
 Adds a user-chosen storage location for the web library (iCloud Drive, a
 custom folder, or this Mac), and restores the AI-experience features that
 were lost in the scratchpad merge (which also committed literal conflict
-markers, leaving `main` uncompilable), landing the final `ai-experiance`
+markers, leaving `main` uncompilable), landing the final `ai-experience`
 review commit that had never been merged.
 
 ### Added

--- a/Tests/WebLibraryStorageTests.swift
+++ b/Tests/WebLibraryStorageTests.swift
@@ -85,7 +85,7 @@ final class WebLibraryStorageTests: XCTestCase {
         try WebLibrary.saveRecord(WebPageRecord(url: url), at: recordPath)
         XCTAssertFalse(WebLibrary.loadRecord(at: recordPath)?.saved ?? true)
 
-        let io = WebDocumentIO(url: url, key: key, recordPath: recordPath)
+        let io = WebDocumentIO(url: url, key: key)
         _ = try await io.createAnnotation(
             CreateAnnotationInput(type: .highlight, pageNumber: 1, content: "hi"),
             storedHighlightColor: "#fde68a")
@@ -102,7 +102,7 @@ final class WebLibraryStorageTests: XCTestCase {
         let recordPath = WebLibrary.recordPath(forKey: key)
         let originalSavedAt = WebLibrary.loadRecord(at: recordPath)?.savedAt
 
-        let io = WebDocumentIO(url: url, key: key, recordPath: recordPath)
+        let io = WebDocumentIO(url: url, key: key)
         _ = try await io.createAnnotation(
             CreateAnnotationInput(type: .note, pageNumber: 1, content: "note"),
             storedHighlightColor: "#fde68a")

--- a/Tests/WebLibraryStorageTests.swift
+++ b/Tests/WebLibraryStorageTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import Vellum
+
+// Unit tests for explicit-save semantics and snapshot-storage management
+// (issue #29 Storage PR 0): annotating promotes a page to saved, TTL eviction
+// only ever touches derived artifacts of never-kept pages, and the Storage-tab
+// listing reports real artifact sizes. The whole web store is pointed at a
+// scratch directory via `WebLibrary.storeDirOverride` (same seam pattern as
+// `ScratchpadAttachmentStore.directoryOverride`).
+
+@MainActor
+final class WebLibraryStorageTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() async throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-weblibrary-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        WebLibrary.storeDirOverride = tempDir
+    }
+
+    override func tearDown() async throws {
+        WebLibrary.storeDirOverride = nil
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+    }
+
+    // MARK: - Helpers
+
+    /// Timestamp `months` months in the past, in the record writer's format.
+    private func timestamp(monthsAgo months: Int) -> String {
+        let date = Calendar.current.date(byAdding: .month, value: -months, to: .now) ?? .now
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+
+    @discardableResult
+    private func makeRecord(
+        url: String, saved: Bool, openedMonthsAgo: Int?, annotated: Bool = false
+    ) throws -> String {
+        let key = WebLibrary.pageKey(url)
+        var record = WebPageRecord(url: url)
+        record.saved = saved
+        record.savedAt = saved ? timestamp(monthsAgo: openedMonthsAgo ?? 0) : nil
+        record.openedAt = openedMonthsAgo.map { timestamp(monthsAgo: $0) }
+        if annotated {
+            record.annotations = [Annotation(
+                id: "a1", type: .highlight, pageNumber: 1, color: "#fde68a",
+                content: "kept", positionData: nil,
+                createdAt: timestamp(monthsAgo: 0), updatedAt: timestamp(monthsAgo: 0))]
+        }
+        try WebLibrary.saveRecord(record, at: WebLibrary.recordPath(forKey: key))
+        return key
+    }
+
+    /// Write all three artifact kinds for a key: plain snapshot, managed
+    /// archive, and an installed archive dir with one asset.
+    private func makeArtifacts(forKey key: String, fill: Int = 100) throws {
+        try Data(repeating: 0x61, count: fill)
+            .write(to: WebLibrary.snapshotPath(forKey: key))
+        try Data(repeating: 0x62, count: fill)
+            .write(to: WebLibrary.managedArchivePath(forKey: key))
+        let dir = WebLibrary.archiveDir(forKey: key)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data(repeating: 0x63, count: fill)
+            .write(to: dir.appendingPathComponent("snapshot.html"))
+    }
+
+    private func hasArtifacts(forKey key: String) -> Bool {
+        WebLibrary.hasLocalSnapshot(forKey: key)
+    }
+
+    private func cutoff(monthsAgo months: Int) -> Date {
+        Calendar.current.date(byAdding: .month, value: -months, to: .now) ?? .now
+    }
+
+    // MARK: - Explicit save
+
+    // Opening no longer saves; annotating does — and it must set savedAt so the
+    // library sort has a timestamp.
+    func testCreateAnnotationPromotesPageToSaved() async throws {
+        let url = "https://example.com/article"
+        let key = WebLibrary.pageKey(url)
+        let recordPath = WebLibrary.recordPath(forKey: key)
+        try WebLibrary.saveRecord(WebPageRecord(url: url), at: recordPath)
+        XCTAssertFalse(WebLibrary.loadRecord(at: recordPath)?.saved ?? true)
+
+        let io = WebDocumentIO(url: url, key: key, recordPath: recordPath)
+        _ = try await io.createAnnotation(
+            CreateAnnotationInput(type: .highlight, pageNumber: 1, content: "hi"),
+            storedHighlightColor: "#fde68a")
+
+        let record = WebLibrary.loadRecord(at: recordPath)
+        XCTAssertEqual(record?.saved, true, "annotating must promote the page to saved")
+        XCTAssertNotNil(record?.savedAt)
+        XCTAssertEqual(record?.annotations.count, 1)
+    }
+
+    func testCreateAnnotationKeepsExistingSavedAt() async throws {
+        let url = "https://example.com/already-saved"
+        let key = try makeRecord(url: url, saved: true, openedMonthsAgo: 2)
+        let recordPath = WebLibrary.recordPath(forKey: key)
+        let originalSavedAt = WebLibrary.loadRecord(at: recordPath)?.savedAt
+
+        let io = WebDocumentIO(url: url, key: key, recordPath: recordPath)
+        _ = try await io.createAnnotation(
+            CreateAnnotationInput(type: .note, pageNumber: 1, content: "note"),
+            storedHighlightColor: "#fde68a")
+
+        XCTAssertEqual(WebLibrary.loadRecord(at: recordPath)?.savedAt, originalSavedAt)
+    }
+
+    // MARK: - TTL eviction
+
+    func testEvictionRemovesOnlyStaleUnsavedArtifacts() throws {
+        let staleUnsaved = try makeRecord(
+            url: "https://example.com/stale", saved: false, openedMonthsAgo: 8)
+        let staleSaved = try makeRecord(
+            url: "https://example.com/saved", saved: true, openedMonthsAgo: 8)
+        let staleAnnotated = try makeRecord(
+            url: "https://example.com/annotated", saved: false, openedMonthsAgo: 8,
+            annotated: true)
+        let freshUnsaved = try makeRecord(
+            url: "https://example.com/fresh", saved: false, openedMonthsAgo: 1)
+        let staleOpenTab = try makeRecord(
+            url: "https://example.com/open-tab", saved: false, openedMonthsAgo: 8)
+        let noTimestamp = try makeRecord(
+            url: "https://example.com/no-stamp", saved: false, openedMonthsAgo: nil)
+        for key in [staleUnsaved, staleSaved, staleAnnotated, freshUnsaved, staleOpenTab, noTimestamp] {
+            try makeArtifacts(forKey: key)
+        }
+
+        WebLibrary.evictStaleUnsavedSnapshots(
+            olderThan: cutoff(monthsAgo: 6),
+            excludingUrls: ["https://example.com/open-tab"])
+
+        XCTAssertFalse(hasArtifacts(forKey: staleUnsaved), "stale + never kept → evicted")
+        XCTAssertTrue(hasArtifacts(forKey: staleSaved), "saved pages are never evicted")
+        XCTAssertTrue(hasArtifacts(forKey: staleAnnotated), "annotated pages are never evicted")
+        XCTAssertTrue(hasArtifacts(forKey: freshUnsaved), "recently opened pages survive")
+        XCTAssertTrue(hasArtifacts(forKey: staleOpenTab), "open tabs are excluded")
+        XCTAssertTrue(hasArtifacts(forKey: noTimestamp), "no parseable timestamp → never evict")
+
+        // Eviction only touches derived artifacts — the record (reading state)
+        // must survive for every page, including the evicted one.
+        XCTAssertNotNil(WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: staleUnsaved)))
+    }
+
+    // MARK: - Storage listing
+
+    func testListSnapshotStorageReportsArtifactSizesLargestFirst() throws {
+        let small = try makeRecord(
+            url: "https://example.com/small", saved: false, openedMonthsAgo: 1)
+        try makeArtifacts(forKey: small, fill: 10)
+        let big = try makeRecord(
+            url: "https://example.com/big", saved: true, openedMonthsAgo: 1)
+        try makeArtifacts(forKey: big, fill: 1000)
+        // Record with no artifacts must not appear at all.
+        try makeRecord(url: "https://example.com/bare", saved: false, openedMonthsAgo: 1)
+
+        let entries = WebLibrary.listSnapshotStorage()
+        XCTAssertEqual(entries.map(\.key), [big, small], "sorted by size descending")
+        // Three artifacts of `fill` bytes each (snapshot + archive + dir asset).
+        XCTAssertEqual(entries[0].byteSize, 3000)
+        XCTAssertEqual(entries[1].byteSize, 30)
+        XCTAssertEqual(entries[0].saved, true)
+        XCTAssertEqual(entries[1].saved, false)
+        XCTAssertNotNil(entries[0].lastOpened)
+    }
+
+    func testRemoveAllSnapshotArtifactsKeepsRecords() throws {
+        let a = try makeRecord(url: "https://example.com/a", saved: true, openedMonthsAgo: 1)
+        let b = try makeRecord(url: "https://example.com/b", saved: false, openedMonthsAgo: 1)
+        try makeArtifacts(forKey: a)
+        try makeArtifacts(forKey: b)
+
+        WebLibrary.removeAllSnapshotArtifacts()
+
+        XCTAssertFalse(hasArtifacts(forKey: a))
+        XCTAssertFalse(hasArtifacts(forKey: b))
+        XCTAssertTrue(WebLibrary.listSnapshotStorage().isEmpty)
+        XCTAssertNotNil(WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: a)))
+        XCTAssertNotNil(WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: b)))
+        // The saved flag is untouched — only bytes were removed.
+        XCTAssertEqual(WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: a))?.saved, true)
+    }
+
+    // MARK: - Timestamp parsing
+
+    func testParseRfc3339AcceptsWriterAndLegacyFormats() {
+        // Our own writer (6-digit fraction, +00:00 offset).
+        XCTAssertNotNil(WebLibrary.parseRfc3339("2026-07-14T10:20:30.123456+00:00"))
+        // ISO8601 with milliseconds and Z.
+        XCTAssertNotNil(WebLibrary.parseRfc3339("2026-07-14T10:20:30.123Z"))
+        // ISO8601 without fraction.
+        XCTAssertNotNil(WebLibrary.parseRfc3339("2026-07-14T10:20:30Z"))
+        XCTAssertNil(WebLibrary.parseRfc3339(nil))
+        XCTAssertNil(WebLibrary.parseRfc3339(""))
+        XCTAssertNil(WebLibrary.parseRfc3339("not a date"))
+    }
+}

--- a/Tests/WebStorageLocationTests.swift
+++ b/Tests/WebStorageLocationTests.swift
@@ -1,0 +1,295 @@
+import XCTest
+@testable import Vellum
+
+// Storage-location feature: layout resolution, pretty-name index, relocation
+// between layouts, and the legacy-fallback record read. Uses the same
+// scratch-dir seams as WebLibraryStorageTests plus `WebLibrary.layoutOverride`
+// to simulate a pretty (iCloud/custom-style) layout without touching real
+// UserDefaults or iCloud Drive.
+
+@MainActor
+final class WebStorageLocationTests: XCTestCase {
+    private var tempDir: URL!
+    private var storeDir: URL!
+    private var prettyRoot: URL!
+
+    override func setUp() async throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-webstorage-tests-\(UUID().uuidString)")
+        storeDir = tempDir.appendingPathComponent("appsupport-web", isDirectory: true)
+        prettyRoot = tempDir.appendingPathComponent("cloud/Vellum", isDirectory: true)
+        try FileManager.default.createDirectory(at: storeDir, withIntermediateDirectories: true)
+        WebLibrary.storeDirOverride = storeDir
+    }
+
+    override func tearDown() async throws {
+        WebLibrary.storeDirOverride = nil
+        WebLibrary.layoutOverride = nil
+        WebStorageSettings.modeOverride = nil
+        WebStorageSettings.customRootOverride = nil
+        WebStorageSettings.icloudDriveRootOverride = nil
+        WebStorageSettings.autoSavePagesOverride = nil
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+    }
+
+    private var localLayout: WebStorageLayout {
+        .local(storeDir: storeDir)
+    }
+
+    private var prettyLayout: WebStorageLayout {
+        .pretty(root: prettyRoot, recordsInRoot: true, localStoreDir: storeDir)
+    }
+
+    @discardableResult
+    private func makeLocalRecord(url: String, title: String?, saved: Bool = true) throws -> String {
+        let key = WebLibrary.pageKey(url)
+        var record = WebPageRecord(url: url)
+        record.title = title
+        record.saved = saved
+        record.savedAt = saved ? WebLibrary.rfc3339Now() : nil
+        try WebLibrary.saveRecord(record, at: storeDir.appendingPathComponent("\(key).json"))
+        return key
+    }
+
+    // MARK: - Layout resolution
+
+    func testEffectiveModeDegradesToLocalWhenRootsMissing() {
+        WebStorageSettings.modeOverride = .icloud
+        WebStorageSettings.icloudDriveRootOverride = tempDir.appendingPathComponent("nonexistent")
+        XCTAssertEqual(WebStorageSettings.effectiveMode, .local)
+        XCTAssertTrue(WebStorageSettings.modeIsDegraded)
+
+        WebStorageSettings.modeOverride = .custom
+        WebStorageSettings.customRootOverride = nil
+        XCTAssertEqual(WebStorageSettings.effectiveMode, .local)
+    }
+
+    func testPrettyLayoutDirectories() {
+        let layout = prettyLayout
+        XCTAssertEqual(layout.archivesDir.lastPathComponent, "Web Pages")
+        XCTAssertEqual(layout.recordsDir.lastPathComponent, "records")
+        XCTAssertEqual(layout.indexPath?.lastPathComponent, "index.json")
+        XCTAssertTrue(layout.recordsDir.path.contains("/.vellum/"))
+
+        // Custom-style: records stay in the local store.
+        let custom = WebStorageLayout.pretty(
+            root: prettyRoot, recordsInRoot: false, localStoreDir: storeDir)
+        XCTAssertEqual(custom.recordsDir, storeDir)
+    }
+
+    // MARK: - Pretty names
+
+    func testSanitizedBaseName() {
+        XCTAssertEqual(
+            WebArchiveIndex.sanitizedBaseName(title: "The Rust Book", url: "https://x.com"),
+            "The Rust Book")
+        XCTAssertEqual(
+            WebArchiveIndex.sanitizedBaseName(title: "a/b: c\\d", url: "https://x.com"),
+            "a-b- c-d")
+        XCTAssertEqual(
+            WebArchiveIndex.sanitizedBaseName(title: ".hidden", url: "https://x.com"),
+            "hidden")
+        XCTAssertEqual(
+            WebArchiveIndex.sanitizedBaseName(title: nil, url: "https://example.org/docs/intro"),
+            "example.org — intro")
+        // Foundation's lenient URL parser reads this as a host-less path; the
+        // path tail is used alone, with no dangling "—" separator.
+        XCTAssertEqual(
+            WebArchiveIndex.sanitizedBaseName(title: "  ", url: "not a url"),
+            "not a url")
+        XCTAssertEqual(
+            WebArchiveIndex.sanitizedBaseName(title: nil, url: ""),
+            "Web Page")
+        let long = String(repeating: "x", count: 200)
+        XCTAssertLessThanOrEqual(
+            WebArchiveIndex.sanitizedBaseName(title: long, url: "https://x.com").count, 80)
+    }
+
+    func testIndexAssignsStableUniqueNames() throws {
+        let layout = prettyLayout
+        let indexPath = try XCTUnwrap(layout.indexPath)
+        try FileManager.default.createDirectory(
+            at: layout.archivesDir, withIntermediateDirectories: true)
+
+        let nameA = WebArchiveIndex.assignFileName(
+            forKey: "key-a", title: "Same Title", url: "https://a.com",
+            at: indexPath, archivesDir: layout.archivesDir)
+        XCTAssertEqual(nameA, "Same Title.vellumweb")
+
+        // Same key again → same name, no churn.
+        XCTAssertEqual(
+            WebArchiveIndex.assignFileName(
+                forKey: "key-a", title: "Renamed Later", url: "https://a.com",
+                at: indexPath, archivesDir: layout.archivesDir),
+            nameA)
+
+        // Different key, same title → suffixed.
+        let nameB = WebArchiveIndex.assignFileName(
+            forKey: "key-b", title: "Same Title", url: "https://b.com",
+            at: indexPath, archivesDir: layout.archivesDir)
+        XCTAssertEqual(nameB, "Same Title 2.vellumweb")
+
+        // A file squatting on disk without an index entry is also avoided.
+        try Data("x".utf8).write(
+            to: layout.archivesDir.appendingPathComponent("Squatter.vellumweb"))
+        let nameC = WebArchiveIndex.assignFileName(
+            forKey: "key-c", title: "Squatter", url: "https://c.com",
+            at: indexPath, archivesDir: layout.archivesDir)
+        XCTAssertEqual(nameC, "Squatter 2.vellumweb")
+
+        WebArchiveIndex.removeEntry(forKey: "key-a", at: indexPath)
+        XCTAssertNil(WebArchiveIndex.fileName(forKey: "key-a", at: indexPath))
+        XCTAssertEqual(WebArchiveIndex.fileName(forKey: "key-b", at: indexPath), nameB)
+    }
+
+    func testManagedArchiveDestinationUsesRecordTitleInPrettyLayout() throws {
+        WebLibrary.layoutOverride = prettyLayout
+        let key = try makeLocalRecord(url: "https://example.com/guide", title: "A Fine Guide")
+        // Record still sits in the legacy store — destination resolution must
+        // find it through the fallback read.
+        let dest = WebLibrary.managedArchiveDestination(forKey: key)
+        XCTAssertEqual(dest.lastPathComponent, "A Fine Guide.vellumweb")
+        XCTAssertEqual(dest.deletingLastPathComponent(), prettyLayout.archivesDir)
+
+        WebLibrary.layoutOverride = localLayout
+        XCTAssertEqual(
+            WebLibrary.managedArchiveDestination(forKey: key),
+            storeDir.appendingPathComponent("\(key).vellumweb"))
+    }
+
+    // MARK: - Fallback record read
+
+    func testWithRecordFallsBackToLegacyLocalRecord() throws {
+        WebLibrary.layoutOverride = prettyLayout
+        let url = "https://example.com/annotated"
+        let key = try makeLocalRecord(url: url, title: "Kept", saved: true)
+
+        // Mutate through the pretty-layout primary path; the legacy record's
+        // contents (saved flag, title) must carry over, not be reset.
+        let primary = WebLibrary.recordPath(forKey: key)
+        XCTAssertNotEqual(primary, storeDir.appendingPathComponent("\(key).json"))
+        try WebLibrary.withRecord(url: url, recordPath: primary) { record in
+            record.lastPage = 4
+        }
+
+        let migrated = WebLibrary.loadRecord(at: primary)
+        XCTAssertEqual(migrated?.title, "Kept")
+        XCTAssertEqual(migrated?.saved, true)
+        XCTAssertEqual(migrated?.lastPage, 4)
+    }
+
+    // MARK: - Relocation
+
+    func testRelocateLocalToPrettyMovesRecordsAndRenamesArchives() throws {
+        let keyA = try makeLocalRecord(url: "https://example.com/a", title: "Alpha Article")
+        let keyB = try makeLocalRecord(url: "https://example.com/b", title: "Beta Piece", saved: false)
+        try Data(repeating: 1, count: 64)
+            .write(to: storeDir.appendingPathComponent("\(keyA).vellumweb"))
+        try Data(repeating: 2, count: 64)
+            .write(to: storeDir.appendingPathComponent("\(keyB).vellumweb"))
+        // Derived caches must NOT move.
+        try Data("html".utf8).write(to: storeDir.appendingPathComponent("\(keyA).snapshot.html"))
+
+        WebLibrary.layoutOverride = prettyLayout
+        XCTAssertTrue(WebStorageMigrator.relocate(from: localLayout, to: prettyLayout))
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(
+            atPath: prettyLayout.recordsDir.appendingPathComponent("\(keyA).json").path))
+        XCTAssertFalse(fm.fileExists(
+            atPath: storeDir.appendingPathComponent("\(keyA).json").path))
+        XCTAssertTrue(fm.fileExists(
+            atPath: prettyLayout.archivesDir.appendingPathComponent("Alpha Article.vellumweb").path))
+        XCTAssertTrue(fm.fileExists(
+            atPath: prettyLayout.archivesDir.appendingPathComponent("Beta Piece.vellumweb").path))
+        XCTAssertFalse(fm.fileExists(
+            atPath: storeDir.appendingPathComponent("\(keyA).vellumweb").path))
+        XCTAssertTrue(fm.fileExists(
+            atPath: storeDir.appendingPathComponent("\(keyA).snapshot.html").path),
+            "derived caches stay local")
+
+        // Library reads resolve to the new home.
+        XCTAssertEqual(
+            WebLibrary.existingManagedArchiveURL(forKey: keyA)?.lastPathComponent,
+            "Alpha Article.vellumweb")
+        XCTAssertTrue(WebLibrary.hasLocalSnapshot(forKey: keyB))
+        XCTAssertEqual(WebLibrary.listSaved().count, 1)
+
+        // Idempotent: running again with nothing to move is a clean no-op.
+        XCTAssertTrue(WebStorageMigrator.relocate(from: localLayout, to: prettyLayout))
+    }
+
+    func testRelocatePrettyBackToLocalRestoresHashedNames() throws {
+        let keyA = try makeLocalRecord(url: "https://example.com/a", title: "Alpha Article")
+        try Data(repeating: 1, count: 64)
+            .write(to: storeDir.appendingPathComponent("\(keyA).vellumweb"))
+        WebLibrary.layoutOverride = prettyLayout
+        XCTAssertTrue(WebStorageMigrator.relocate(from: localLayout, to: prettyLayout))
+
+        WebLibrary.layoutOverride = localLayout
+        XCTAssertTrue(WebStorageMigrator.relocate(from: prettyLayout, to: localLayout))
+
+        let fm = FileManager.default
+        XCTAssertTrue(fm.fileExists(atPath: storeDir.appendingPathComponent("\(keyA).json").path))
+        XCTAssertTrue(fm.fileExists(atPath: storeDir.appendingPathComponent("\(keyA).vellumweb").path))
+        // The pretty structure we created is cleaned up once empty.
+        XCTAssertFalse(fm.fileExists(atPath: prettyLayout.archivesDir.path))
+        XCTAssertFalse(fm.fileExists(atPath: prettyLayout.recordsDir.path))
+    }
+
+    func testRelocateMergesWhenBothCopiesExist() throws {
+        // Both locations hold a record: the destination (a session fallback-
+        // read wrote it there) and the legacy source, which an already-open
+        // session annotated AFTER the destination copy was created. Migration
+        // must merge — the late annotation survives — never just delete the
+        // source.
+        let url = "https://example.com/live"
+        let key = try makeLocalRecord(url: url, title: "Stale", saved: false)
+        let lateNote = Annotation(
+            id: "late-note", type: .note, pageNumber: 1, color: "#fde68a",
+            content: "written after the switch", positionData: nil,
+            createdAt: WebLibrary.rfc3339Now(), updatedAt: WebLibrary.rfc3339Now())
+        var source = try XCTUnwrap(
+            WebLibrary.loadRecord(at: storeDir.appendingPathComponent("\(key).json")))
+        source.annotations = [lateNote]
+        try WebLibrary.saveRecord(source, at: storeDir.appendingPathComponent("\(key).json"))
+
+        WebLibrary.layoutOverride = prettyLayout
+        var live = WebPageRecord(url: url)
+        live.title = "Live"
+        live.saved = true
+        try WebLibrary.saveRecord(live, at: WebLibrary.recordPath(forKey: key))
+
+        XCTAssertTrue(WebStorageMigrator.relocate(from: localLayout, to: prettyLayout))
+        let kept = WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: key))
+        XCTAssertEqual(kept?.title, "Live", "destination fields win on conflict")
+        XCTAssertEqual(kept?.saved, true)
+        XCTAssertEqual(
+            kept?.annotations.map(\.id), ["late-note"],
+            "annotations written to the source after the switch are merged in")
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: storeDir.appendingPathComponent("\(key).json").path),
+            "merged legacy copy is removed")
+    }
+
+    // MARK: - Removal in pretty layouts
+
+    func testRemoveLocalSnapshotsClearsPrettyArchiveAndIndexEntry() throws {
+        let key = try makeLocalRecord(url: "https://example.com/gone", title: "Going Away")
+        try Data(repeating: 1, count: 64)
+            .write(to: storeDir.appendingPathComponent("\(key).vellumweb"))
+        WebLibrary.layoutOverride = prettyLayout
+        XCTAssertTrue(WebStorageMigrator.relocate(from: localLayout, to: prettyLayout))
+        let indexPath = try XCTUnwrap(prettyLayout.indexPath)
+        XCTAssertNotNil(WebArchiveIndex.fileName(forKey: key, at: indexPath))
+
+        WebLibrary.removeLocalSnapshots(forKey: key)
+
+        XCTAssertFalse(WebLibrary.hasLocalSnapshot(forKey: key))
+        XCTAssertNil(WebArchiveIndex.fileName(forKey: key, at: indexPath))
+        XCTAssertNotNil(
+            WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: key)),
+            "record always survives removal")
+    }
+}

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -41,12 +41,14 @@
 		3472BAA39BF1973EDCE4D2C5 /* katex.min.js in Resources */ = {isa = PBXBuildFile; fileRef = DC887AD1DA9C8FD08D72104C /* katex.min.js */; };
 		369FF45FEAF108F46A582CF7 /* KaTeX_Size2-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = B06DA428592587D5CC42B840 /* KaTeX_Size2-Regular.woff2 */; };
 		36CA355A9BBDE3BB111BC559 /* ScratchpadImportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0D324F9CE4133DCC02BBD4 /* ScratchpadImportTests.swift */; };
+		3E033DAAAD3349E353641CD0 /* WebStorageLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30CC2363C63B98CDE69C7B5A /* WebStorageLocationTests.swift */; };
 		3F4C2E045464817FDB1ED160 /* PdfViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B22387C1A8E19F0316151E /* PdfViewerView.swift */; };
 		40D4C8C74B050905AF690FD5 /* PdfSessionBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F791F226FCC023AA19F7365 /* PdfSessionBackend.swift */; };
 		41BD8A6E46D11F7BC0BF6D13 /* WebViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FAA454DB63CD5DAEB44B17B /* WebViewerView.swift */; };
 		41EDFC3445164FFD63A268C8 /* OpenCodeZenClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39E1889C3B2C6F221C33BC9 /* OpenCodeZenClient.swift */; };
 		4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */; };
 		46937483DA3925D41C984167 /* KaTeX_SansSerif-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = F8BEC014138483BE0B9DC274 /* KaTeX_SansSerif-Regular.woff2 */; };
+		4B759FBB179307FE097DA861 /* StorageLocationChoiceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */; };
 		4E8BAA1F3AEC100D4C768AFA /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B863B676278E0E8D3C2EDB /* PaneTree.swift */; };
 		4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */; };
 		4FF972F2B1437D5D46AE6BA4 /* HighlightLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */; };
@@ -91,6 +93,7 @@
 		AF8BDBA91282CA03F019C0F5 /* ScratchpadPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287B357B7A7C9503C3C1199C /* ScratchpadPersistence.swift */; };
 		B127FEC17DDF285AD902A52B /* OpenRouterCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */; };
 		B1EA8A76FD9FE32930829528 /* SessionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7280818785023514C87C04C9 /* SessionService.swift */; };
+		B370CC64C56C8E29DC8A4C42 /* WebStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF653B1B8741B61DBE9B55EE /* WebStorage.swift */; };
 		BB776BF184FBD5A0469377E2 /* AiPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90963B42EE17356826E8DE90 /* AiPrompts.swift */; };
 		BF75A2925C8FCE36AD43F41B /* KaTeX_Typewriter-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = E8C9F22335B2DEA99AF5ABF5 /* KaTeX_Typewriter-Regular.woff2 */; };
 		C4998709FBAE647C23BF3E5A /* KaTeX_Size3-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 511B978E41D84CD3B0C24FCB /* KaTeX_Size3-Regular.woff2 */; };
@@ -153,6 +156,7 @@
 		2D0B4D5702156DFEC64496C9 /* SelectionPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionPopover.swift; sourceTree = "<group>"; };
 		2E0D324F9CE4133DCC02BBD4 /* ScratchpadImportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadImportTests.swift; sourceTree = "<group>"; };
 		2E923D872F0FF00E6DAB9BA8 /* PdfAtomicWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfAtomicWriter.swift; sourceTree = "<group>"; };
+		30CC2363C63B98CDE69C7B5A /* WebStorageLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebStorageLocationTests.swift; sourceTree = "<group>"; };
 		3180FE94F812DBF0B9C91ED5 /* KaTeX_Size1-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Size1-Regular.woff2"; sourceTree = "<group>"; };
 		35C068E934EF0FD9F7DAE0CD /* AiPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiPersistence.swift; sourceTree = "<group>"; };
 		3E954582457ABFF5574EC93C /* tool-descriptions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "tool-descriptions.md"; sourceTree = "<group>"; };
@@ -172,6 +176,7 @@
 		54417DBF142FD33E6B2F6672 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		5513F929B10D107AED515D1E /* PageTextCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextCache.swift; sourceTree = "<group>"; };
 		5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightLayer.swift; sourceTree = "<group>"; };
+		672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageLocationChoiceSheet.swift; sourceTree = "<group>"; };
 		6E72498058A69F542C2A4CCF /* ScratchpadPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadPanel.swift; sourceTree = "<group>"; };
 		6F5F272385E3E99333CFC6C1 /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
 		6F791F226FCC023AA19F7365 /* PdfSessionBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfSessionBackend.swift; sourceTree = "<group>"; };
@@ -254,6 +259,7 @@
 		F39E1889C3B2C6F221C33BC9 /* OpenCodeZenClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeZenClient.swift; sourceTree = "<group>"; };
 		F8BEC014138483BE0B9DC274 /* KaTeX_SansSerif-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_SansSerif-Regular.woff2"; sourceTree = "<group>"; };
 		FD01D08235008A4E602D0373 /* PaneTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeView.swift; sourceTree = "<group>"; };
+		FF653B1B8741B61DBE9B55EE /* WebStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -342,6 +348,7 @@
 				709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */,
 				DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */,
 				9BAF3F69842AC6333D1D9C38 /* WebProxyUrlTests.swift */,
+				30CC2363C63B98CDE69C7B5A /* WebStorageLocationTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -485,6 +492,7 @@
 			isa = PBXGroup;
 			children = (
 				54417DBF142FD33E6B2F6672 /* SettingsView.swift */,
+				672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -496,6 +504,7 @@
 				EEA75D024B6F4DEC807ABD97 /* WebLibrary.swift */,
 				03E209F0AEC418389859234E /* WebPageExtractor.swift */,
 				EC36411CEE83A332FBFA83A0 /* WebSessionBackend.swift */,
+				FF653B1B8741B61DBE9B55EE /* WebStorage.swift */,
 			);
 			path = Web;
 			sourceTree = "<group>";
@@ -779,6 +788,7 @@
 				2439956FEFA7E14A045B9289 /* SettingsView.swift in Sources */,
 				D0E1C1D4A6D6A54C194A3389 /* SpeechService.swift in Sources */,
 				7A22F35E2A3DE9629E53A11D /* StickyNoteOverlay.swift in Sources */,
+				4B759FBB179307FE097DA861 /* StorageLocationChoiceSheet.swift in Sources */,
 				6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */,
 				07AE67F8DC12B0AAD737C3FD /* TabDrag.swift in Sources */,
 				1F177B6D7BEF6B4E7C7620CE /* Theme.swift in Sources */,
@@ -792,6 +802,7 @@
 				5AA233123955997046F4F9EB /* WebNotePopovers.swift in Sources */,
 				75B9FA69511BBE233AAB665A /* WebPageExtractor.swift in Sources */,
 				25F3CB0EC3551FC76CD5AFAC /* WebSessionBackend.swift in Sources */,
+				B370CC64C56C8E29DC8A4C42 /* WebStorage.swift in Sources */,
 				41BD8A6E46D11F7BC0BF6D13 /* WebViewerView.swift in Sources */,
 				29224D491ACDF76C81E58473 /* WelcomeScreen.swift in Sources */,
 				776EFA95A94B0F3D994B8604 /* WorkspaceService.swift in Sources */,
@@ -812,6 +823,7 @@
 				FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */,
 				4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */,
 				51EFE28F82BCABBB7BDCB589 /* WebProxyUrlTests.swift in Sources */,
+				3E033DAAAD3349E353641CD0 /* WebStorageLocationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */; };
 		46937483DA3925D41C984167 /* KaTeX_SansSerif-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = F8BEC014138483BE0B9DC274 /* KaTeX_SansSerif-Regular.woff2 */; };
 		4E8BAA1F3AEC100D4C768AFA /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B863B676278E0E8D3C2EDB /* PaneTree.swift */; };
+		4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */; };
 		4FF972F2B1437D5D46AE6BA4 /* HighlightLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */; };
 		51EFE28F82BCABBB7BDCB589 /* WebProxyUrlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAF3F69842AC6333D1D9C38 /* WebProxyUrlTests.swift */; };
 		52FA425B6737E6A4717AEC4E /* PdfSelectionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1D02EF244DA61F5397D68B /* PdfSelectionBridge.swift */; };
@@ -239,6 +240,7 @@
 		D8C1E511D20D7A383214A940 /* TabDrag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabDrag.swift; sourceTree = "<group>"; };
 		D9D692FDA3FFA9D0B8F15A16 /* WorkspaceStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		D9E0BDD943EF88D3BD193D7B /* marked.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = marked.min.js; sourceTree = "<group>"; };
+		DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebLibraryStorageTests.swift; sourceTree = "<group>"; };
 		DC887AD1DA9C8FD08D72104C /* katex.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = katex.min.js; sourceTree = "<group>"; };
 		DF9C9C837F5B62D523BD8E97 /* AnnotationSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationSidebar.swift; sourceTree = "<group>"; };
 		E064C75923B5E7D98E256470 /* WebArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebArchive.swift; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 				A5003641A54B311693588C6C /* PdfPersistenceTests.swift */,
 				2E0D324F9CE4133DCC02BBD4 /* ScratchpadImportTests.swift */,
 				709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */,
+				DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */,
 				9BAF3F69842AC6333D1D9C38 /* WebProxyUrlTests.swift */,
 			);
 			path = Tests;
@@ -807,6 +810,7 @@
 				806EDA3BB34A3680F7B39E1B /* PdfPersistenceTests.swift in Sources */,
 				36CA355A9BBDE3BB111BC559 /* ScratchpadImportTests.swift in Sources */,
 				FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */,
+				4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */,
 				51EFE28F82BCABBB7BDCB589 /* WebProxyUrlTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -63,20 +63,26 @@ struct VellumApp: App {
             ContentView()
                 .frame(minWidth: 800, minHeight: 600)
                 .task {
-                    // Launch-time TTL eviction of the extracted-text cache
-                    // (issue #37 PR B). Time-based only — never because a source
-                    // file is missing. The open-paths snapshot excludes restored
-                    // tabs; a document opened AFTER it is still safe because the
-                    // cache actor serializes: its lookup either stamps lastOpened
-                    // first (excluding it by age) or re-extracts once after the
-                    // eviction — never corruption. Evict off-main at low priority.
+                    // Launch-time TTL eviction of derived data (issue #37 PR B /
+                    // issue #29): the extracted-text cache, plus web-snapshot
+                    // artifacts for pages the user never saved or annotated.
+                    // Time-based only — never because a source file is missing.
+                    // The open-documents snapshot excludes restored tabs; a
+                    // document opened AFTER it is still safe because the cache
+                    // actor serializes (its lookup either stamps lastOpened
+                    // first, excluding it by age, or re-extracts once after the
+                    // eviction) and the web store re-archives on the open
+                    // debounce. Evict off-main at low priority.
+                    let openDocuments = workspace.root.allLeaves()
+                        .flatMap { $0.app.tabs }.compactMap(\.document)
                     let openPaths = Set(
-                        workspace.root.allLeaves().flatMap { $0.app.tabs }.compactMap(\.document)
-                            .filter { $0.kind == .pdf }
-                            .map(\.pdfPath))
+                        openDocuments.filter { $0.kind == .pdf }.map(\.pdfPath))
+                    let openWebUrls = Set(
+                        openDocuments.filter { $0.kind == .web }.map(\.pdfPath))
                     let cutoff = Calendar.current.date(byAdding: .month, value: -6, to: .now) ?? .now
                     Task.detached(priority: .background) {
                         await PageTextCache.shared.evictStale(olderThan: cutoff, excludingPaths: openPaths)
+                        WebLibrary.evictStaleUnsavedSnapshots(olderThan: cutoff, excludingUrls: openWebUrls)
                     }
                 }
                 .environment(themeStore)

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -46,6 +46,7 @@ struct VellumApp: App {
     @NSApplicationDelegateAdaptor(VellumAppDelegate.self) private var appDelegate
     @State private var themeStore: ThemeStore
     @State private var workspace: WorkspaceStore
+    @State private var showStorageChoice = false
 
     init() {
         let theme = ThemeStore()
@@ -81,9 +82,18 @@ struct VellumApp: App {
                         openDocuments.filter { $0.kind == .web }.map(\.pdfPath))
                     let cutoff = Calendar.current.date(byAdding: .month, value: -6, to: .now) ?? .now
                     Task.detached(priority: .background) {
+                        // Finish any interrupted storage-location move and fold
+                        // legacy-local strays into the active layout before the
+                        // evictors walk the store.
+                        WebStorageMigrator.sweepAtLaunch()
                         await PageTextCache.shared.evictStale(olderThan: cutoff, excludingPaths: openPaths)
                         WebLibrary.evictStaleUnsavedSnapshots(olderThan: cutoff, excludingUrls: openWebUrls)
                     }
+                    showStorageChoice = WebStorageSettings.needsFirstLaunchChoice
+                }
+                .sheet(isPresented: $showStorageChoice) {
+                    StorageLocationChoiceSheet()
+                        .environment(\.palette, themeStore.palette)
                 }
                 .environment(themeStore)
                 .environment(workspace)

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -84,8 +84,10 @@ struct VellumApp: App {
                     Task.detached(priority: .background) {
                         // Finish any interrupted storage-location move and fold
                         // legacy-local strays into the active layout before the
-                        // evictors walk the store.
-                        WebStorageMigrator.sweepAtLaunch()
+                        // evictors walk the store. Routed through the relocator
+                        // so it can't run concurrently with a location change
+                        // the user makes in the first-launch sheet below.
+                        await WebStorageRelocator.sweepAtLaunch()
                         await PageTextCache.shared.evictStale(olderThan: cutoff, excludingPaths: openPaths)
                         WebLibrary.evictStaleUnsavedSnapshots(olderThan: cutoff, excludingUrls: openWebUrls)
                     }

--- a/Vellum/Services/Web/WebLibrary.swift
+++ b/Vellum/Services/Web/WebLibrary.swift
@@ -73,8 +73,13 @@ enum WebLibrary {
         return base.appendingPathComponent(bundleId, isDirectory: true)
     }
 
+    /// Test seam: point the whole web store at a scratch directory (mirrors
+    /// `ScratchpadAttachmentStore.directoryOverride`). Every path below derives
+    /// from `storeDir`, so overriding this redirects records and artifacts alike.
+    nonisolated(unsafe) static var storeDirOverride: URL?
+
     static var storeDir: URL {
-        appDataDir.appendingPathComponent("web", isDirectory: true)
+        storeDirOverride ?? appDataDir.appendingPathComponent("web", isDirectory: true)
     }
 
     static func recordPath(forKey key: String) -> URL {
@@ -196,18 +201,6 @@ enum WebLibrary {
 
     // MARK: - Saved-pages library
 
-    /// Mark a page saved without disturbing an existing `saved_at`. Used by
-    /// the automatic on-open archiver so opened pages land in the library.
-    static func markSavedIfAbsent(recordPath: URL, url: String) throws {
-        try withRecord(url: url, recordPath: recordPath) { record in
-            record.url = url
-            record.saved = true
-            if record.savedAt == nil {
-                record.savedAt = rfc3339Now()
-            }
-        }
-    }
-
     static func hasLocalSnapshot(forKey key: String) -> Bool {
         let fm = FileManager.default
         var isDir: ObjCBool = false
@@ -274,4 +267,133 @@ enum WebLibrary {
         }
         removeLocalSnapshots(forKey: key)
     }
+
+    // MARK: - Snapshot storage management (Settings ▸ Storage)
+
+    /// One page's on-disk snapshot footprint. Sizes cover only the derived
+    /// artifacts (plain snapshot, managed `.vellumweb`, installed archive dir),
+    /// never the sidecar record — that holds the user's annotations and reading
+    /// state and is not deletable from the Storage tab.
+    struct SnapshotStorageEntry: Identifiable, Sendable, Equatable {
+        var key: String
+        var url: String
+        var title: String?
+        var saved: Bool
+        var hasAnnotations: Bool
+        var lastOpened: Date?
+        var byteSize: Int64
+
+        var id: String { key }
+
+        var displayTitle: String {
+            if let title, !title.isEmpty { return title }
+            return url
+        }
+    }
+
+    /// Every page that currently has snapshot artifacts on disk, largest first.
+    static func listSnapshotStorage() -> [SnapshotStorageEntry] {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: storeDir.path) else {
+            return []
+        }
+        var out: [SnapshotStorageEntry] = []
+        for name in names where name.hasSuffix(".json") {
+            guard let record = loadRecord(at: storeDir.appendingPathComponent(name)) else { continue }
+            let key = pageKey(record.url)
+            let size = snapshotArtifactsSize(forKey: key)
+            guard size > 0 else { continue }
+            out.append(SnapshotStorageEntry(
+                key: key,
+                url: record.url,
+                title: record.title,
+                saved: record.saved,
+                hasAnnotations: !record.annotations.isEmpty,
+                lastOpened: parseRfc3339(record.openedAt) ?? parseRfc3339(record.savedAt),
+                byteSize: size))
+        }
+        out.sort { $0.byteSize > $1.byteSize }
+        return out
+    }
+
+    /// Launch-time TTL eviction of snapshot artifacts for pages the user never
+    /// kept: not saved, no annotations (annotating promotes to saved, so any
+    /// annotations mean "keep" defensively), not currently open, and last
+    /// opened before `cutoff`. Only ever deletes the derived artifacts — the
+    /// sidecar record (reading state) always survives, and a record with no
+    /// parseable timestamp is never evicted.
+    static func evictStaleUnsavedSnapshots(olderThan cutoff: Date, excludingUrls: Set<String>) {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: storeDir.path) else {
+            return
+        }
+        for name in names where name.hasSuffix(".json") {
+            guard let record = loadRecord(at: storeDir.appendingPathComponent(name)),
+                  !record.saved, record.annotations.isEmpty,
+                  !excludingUrls.contains(record.url),
+                  let opened = parseRfc3339(record.openedAt) ?? parseRfc3339(record.savedAt),
+                  opened < cutoff
+            else { continue }
+            removeLocalSnapshots(forKey: pageKey(record.url))
+        }
+    }
+
+    /// Delete every snapshot artifact in the store (records stay). Sweeps the
+    /// directory listing rather than the records so orphaned artifacts whose
+    /// record was lost are removed too.
+    static func removeAllSnapshotArtifacts() {
+        let fm = FileManager.default
+        try? fm.removeItem(at: storeDir.appendingPathComponent("archives", isDirectory: true))
+        guard let names = try? fm.contentsOfDirectory(atPath: storeDir.path) else { return }
+        for name in names where name.hasSuffix(".snapshot.html") || name.hasSuffix(".vellumweb") {
+            try? fm.removeItem(at: storeDir.appendingPathComponent(name))
+        }
+    }
+
+    private static func snapshotArtifactsSize(forKey key: String) -> Int64 {
+        let fm = FileManager.default
+        var total: Int64 = 0
+        for file in [snapshotPath(forKey: key), managedArchivePath(forKey: key)] {
+            let attributes = try? fm.attributesOfItem(atPath: file.path)
+            total += (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+        }
+        total += directorySize(at: archiveDir(forKey: key))
+        return total
+    }
+
+    private static func directorySize(at url: URL) -> Int64 {
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey, .isRegularFileKey],
+            options: [],
+            errorHandler: nil)
+        else { return 0 }
+        var total: Int64 = 0
+        for case let file as URL in enumerator {
+            guard let values = try? file.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+                  values.isRegularFile == true else { continue }
+            total += Int64(values.fileSize ?? 0)
+        }
+        return total
+    }
+
+    /// Lenient parse for record timestamps: our writer's 6-digit-fraction
+    /// RFC3339 first, then ISO8601 with/without fractional seconds (Tauri-era
+    /// chrono emitted variable fraction widths).
+    static func parseRfc3339(_ value: String?) -> Date? {
+        guard let value, !value.isEmpty else { return nil }
+        if let date = rfc3339Formatter.date(from: value) { return date }
+        if let date = iso8601Fractional.date(from: value) { return date }
+        return iso8601Plain.date(from: value)
+    }
+
+    nonisolated(unsafe) private static let iso8601Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    nonisolated(unsafe) private static let iso8601Plain: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
 }

--- a/Vellum/Services/Web/WebLibrary.swift
+++ b/Vellum/Services/Web/WebLibrary.swift
@@ -82,17 +82,90 @@ enum WebLibrary {
         storeDirOverride ?? appDataDir.appendingPathComponent("web", isDirectory: true)
     }
 
+    /// Test seam for the location feature itself; when only `storeDirOverride`
+    /// is set the layout is forced local so existing tests (and the test host's
+    /// real UserDefaults mode) can't leak a pretty layout into scratch dirs.
+    nonisolated(unsafe) static var layoutOverride: WebStorageLayout?
+
+    /// Where records and managed archives resolve for the user's chosen
+    /// storage location. Derived caches (plain snapshots, unpacked archive
+    /// dirs) always stay under `storeDir` regardless of layout.
+    static var activeLayout: WebStorageLayout {
+        if let layoutOverride { return layoutOverride }
+        if storeDirOverride != nil { return .local(storeDir: storeDir) }
+        return .resolve(mode: WebStorageSettings.effectiveMode, storeDir: storeDir)
+    }
+
     static func recordPath(forKey key: String) -> URL {
-        storeDir.appendingPathComponent("\(key).json")
+        activeLayout.recordsDir.appendingPathComponent("\(key).json")
+    }
+
+    /// Every place a record for `key` may live, primary first: the active
+    /// layout's records dir, then the legacy local store (files not yet picked
+    /// up by the migration sweep).
+    static func candidateRecordPaths(forKey key: String) -> [URL] {
+        var paths = [recordPath(forKey: key)]
+        let legacy = storeDir.appendingPathComponent("\(key).json")
+        if legacy != paths[0] { paths.append(legacy) }
+        return paths
+    }
+
+    /// Load a record wherever it currently lives, downloading an evicted
+    /// iCloud copy if needed (blocking; call off the main thread when the
+    /// active layout may be iCloud).
+    static func loadRecord(forKey key: String) -> WebPageRecord? {
+        for path in candidateRecordPaths(forKey: key) {
+            _ = WebICloud.materialize(at: path)
+            if let record = loadRecord(at: path) { return record }
+        }
+        return nil
     }
 
     static func snapshotPath(forKey key: String) -> URL {
         storeDir.appendingPathComponent("\(key).snapshot.html")
     }
 
-    /// Managed library path for a page's `.vellumweb` archive.
+    /// Legacy managed library path (`web/<key>.vellumweb`) — still the write
+    /// destination in local mode and the read fallback for archives the sweep
+    /// hasn't moved yet.
     static func managedArchivePath(forKey key: String) -> URL {
         storeDir.appendingPathComponent("\(key).vellumweb")
+    }
+
+    /// Where the next managed-archive write for this page should land. In
+    /// pretty layouts this assigns (or reuses) the title-based filename in
+    /// `Web Pages/`; in local mode it is the hashed legacy path.
+    static func managedArchiveDestination(forKey key: String) -> URL {
+        let layout = activeLayout
+        guard layout.pretty, let indexPath = layout.indexPath else {
+            return managedArchivePath(forKey: key)
+        }
+        let record = loadRecord(forKey: key)
+        let name = WebArchiveIndex.assignFileName(
+            forKey: key,
+            title: record?.title,
+            url: record?.url ?? "",
+            at: indexPath,
+            archivesDir: layout.archivesDir)
+        return layout.archivesDir.appendingPathComponent(name)
+    }
+
+    /// The managed archive that currently exists for this page, if any —
+    /// checks the pretty location (counting an evicted iCloud placeholder as
+    /// present), then the legacy hashed path.
+    static func existingManagedArchiveURL(forKey key: String) -> URL? {
+        let layout = activeLayout
+        if layout.pretty, let indexPath = layout.indexPath,
+           let name = WebArchiveIndex.fileName(forKey: key, at: indexPath) {
+            let url = layout.archivesDir.appendingPathComponent(name)
+            if WebICloud.itemExists(at: url) { return url }
+        }
+        let legacy = managedArchivePath(forKey: key)
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: legacy.path, isDirectory: &isDir), !isDir.boolValue {
+            return legacy
+        }
+        return nil
     }
 
     /// Installed self-contained snapshot dir (`web/archives/<key>/`).
@@ -172,6 +245,13 @@ enum WebLibrary {
     /// Read-modify-write on the sidecar (a corrupt/missing file is silently
     /// replaced by a fresh record, matching the Rust behavior). Serialized per
     /// record path so concurrent sessions for the same page never interleave.
+    ///
+    /// When the primary path has no file yet, the legacy local store is
+    /// consulted (and an evicted iCloud copy downloaded) before falling back
+    /// to a fresh record — so a page opened right after a storage-location
+    /// switch keeps its annotations even if the migration sweep hasn't reached
+    /// its file. The write always lands on the primary path; the stale source
+    /// copy is cleaned up by the next sweep.
     @discardableResult
     static func withRecord<T>(
         url: String, recordPath: URL, _ mutate: (inout WebPageRecord) -> T
@@ -179,10 +259,65 @@ enum WebLibrary {
         let lock = recordLock(for: recordPath)
         lock.lock()
         defer { lock.unlock() }
-        var record = loadRecord(at: recordPath) ?? WebPageRecord(url: url)
+        if !WebICloud.materialize(at: recordPath),
+           FileManager.default.fileExists(atPath: WebICloud.placeholderURL(for: recordPath).path) {
+            // The record exists in iCloud but its bytes couldn't be downloaded
+            // (offline?). Writing a fresh record here would overwrite the real
+            // one — highlights and notes — once iCloud reconnects. Refuse.
+            throw SessionServiceError.io(
+                "This page's reading data is in iCloud but hasn't downloaded yet — check your connection and try again")
+        }
+        var record = loadRecord(at: recordPath)
+            ?? loadRecord(forKey: pageKey(url))
+            ?? WebPageRecord(url: url)
         let out = mutate(&record)
         try saveRecord(record, at: recordPath)
         return out
+    }
+
+    /// Migration seam: carry a record file to its new home while holding both
+    /// paths' locks, so the sweep can't race a session's read-modify-write on
+    /// either side. When the destination already has a copy (a session
+    /// fallback-read wrote it there), the two are MERGED — annotations
+    /// unioned, saved-ness kept if either side had it — never blindly
+    /// discarded: an open session may have written to the source after the
+    /// destination copy was created. Returns false when the record could not
+    /// be moved or merged (caller must keep its resume marker).
+    static func adoptRecordFile(from source: URL, to destination: URL) -> Bool {
+        let first = source.path < destination.path ? source : destination
+        let second = source.path < destination.path ? destination : source
+        let lockA = recordLock(for: first)
+        let lockB = recordLock(for: second)
+        lockA.lock()
+        defer { lockA.unlock() }
+        lockB.lock()
+        defer { lockB.unlock() }
+        let fm = FileManager.default
+        if fm.fileExists(atPath: destination.path) {
+            guard var dest = loadRecord(at: destination) else { return false }
+            guard let src = loadRecord(at: source) else {
+                // Unreadable source: don't delete it — leave it for inspection.
+                return false
+            }
+            WebArchive.mergeAnnotations(&dest.annotations, incoming: src.annotations)
+            dest.saved = dest.saved || src.saved
+            dest.savedAt = dest.savedAt ?? src.savedAt
+            dest.title = dest.title ?? src.title
+            dest.pageCount = dest.pageCount ?? src.pageCount
+            dest.lastPage = dest.lastPage ?? src.lastPage
+            dest.openedAt = dest.openedAt ?? src.openedAt
+            guard (try? saveRecord(dest, at: destination)) != nil else { return false }
+            try? fm.removeItem(at: source)
+            return true
+        }
+        do {
+            try fm.createDirectory(
+                at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try fm.moveItem(at: source, to: destination)
+            return true
+        } catch {
+            return false
+        }
     }
 
     /// Matches chrono `Utc::now().to_rfc3339()` closely enough to sort and
@@ -207,7 +342,7 @@ enum WebLibrary {
         if fm.fileExists(atPath: snapshotPath(forKey: key).path, isDirectory: &isDir), !isDir.boolValue {
             return true
         }
-        if fm.fileExists(atPath: managedArchivePath(forKey: key).path, isDirectory: &isDir), !isDir.boolValue {
+        if existingManagedArchiveURL(forKey: key) != nil {
             return true
         }
         let installed = archiveDir(forKey: key).appendingPathComponent("snapshot.html")
@@ -217,23 +352,64 @@ enum WebLibrary {
         return false
     }
 
-    /// Delete all locally cached snapshot artifacts for a page.
+    /// Delete all locally cached snapshot artifacts for a page — including a
+    /// pretty-named (possibly evicted) managed archive and its index entry.
     static func removeLocalSnapshots(forKey key: String) {
         let fm = FileManager.default
         try? fm.removeItem(at: snapshotPath(forKey: key))
+        if let managed = existingManagedArchiveURL(forKey: key) {
+            WebICloud.removeItem(at: managed)
+        }
         try? fm.removeItem(at: managedArchivePath(forKey: key))
+        if let indexPath = activeLayout.indexPath {
+            WebArchiveIndex.removeEntry(forKey: key, at: indexPath)
+        }
         try? fm.removeItem(at: archiveDir(forKey: key))
     }
 
-    static func listSaved() -> [WebLibraryEntry] {
-        let fm = FileManager.default
-        guard let names = try? fm.contentsOfDirectory(atPath: storeDir.path) else {
+    /// Record filenames in a directory — including ones iCloud has evicted to
+    /// a `.<name>.json.icloud` placeholder, reported under their real name so
+    /// migration and listings never silently skip an evicted record.
+    static func recordFileNames(inDir dir: URL) -> [String] {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else {
             return []
         }
+        var out = Set<String>()
+        for name in names {
+            if name.hasSuffix(".json") {
+                out.insert(name)
+            } else if name.hasPrefix("."), name.hasSuffix(".json.icloud") {
+                out.insert(String(name.dropFirst().dropLast(".icloud".count)))
+            }
+        }
+        return out.sorted()
+    }
+
+    /// Every record file across the active layout and the legacy local store,
+    /// deduplicated by filename with the active location winning (a stale
+    /// legacy copy the sweep hasn't collected must not shadow the live one).
+    static func allRecordFiles() -> [URL] {
+        var seen = Set<String>()
+        var out: [URL] = []
+        var dirs = [activeLayout.recordsDir]
+        if storeDir != activeLayout.recordsDir { dirs.append(storeDir) }
+        for dir in dirs {
+            for name in recordFileNames(inDir: dir) {
+                guard seen.insert(name).inserted else { continue }
+                out.append(dir.appendingPathComponent(name))
+            }
+        }
+        return out
+    }
+
+    static func listSaved() -> [WebLibraryEntry] {
         var out: [WebLibraryEntry] = []
-        for name in names where name.hasSuffix(".json") {
-            guard let record = loadRecord(at: storeDir.appendingPathComponent(name)),
-                  record.saved else { continue }
+        for file in allRecordFiles() {
+            guard let record = loadRecord(at: file) else {
+                WebICloud.requestDownload(at: file)
+                continue
+            }
+            guard record.saved else { continue }
             let key = pageKey(record.url)
             out.append(WebLibraryEntry(
                 url: record.url,
@@ -258,12 +434,14 @@ enum WebLibrary {
     static func removeSaved(rawUrl: String) throws {
         let url = try WebUrl.normalize(rawUrl)
         let key = pageKey(url)
-        let path = recordPath(forKey: key)
-        // Un-save (keep annotations in case the page is reopened later).
-        if var record = loadRecord(at: path) {
-            record.saved = false
-            record.savedAt = nil
-            try saveRecord(record, at: path)
+        // Un-save (keep annotations in case the page is reopened later) —
+        // through withRecord so the un-migrated/evicted copy is found too and
+        // the page can't reappear in the library from a stale legacy record.
+        if loadRecord(forKey: key) != nil {
+            try withRecord(url: url, recordPath: recordPath(forKey: key)) { record in
+                record.saved = false
+                record.savedAt = nil
+            }
         }
         removeLocalSnapshots(forKey: key)
     }
@@ -293,12 +471,14 @@ enum WebLibrary {
 
     /// Every page that currently has snapshot artifacts on disk, largest first.
     static func listSnapshotStorage() -> [SnapshotStorageEntry] {
-        guard let names = try? FileManager.default.contentsOfDirectory(atPath: storeDir.path) else {
-            return []
-        }
         var out: [SnapshotStorageEntry] = []
-        for name in names where name.hasSuffix(".json") {
-            guard let record = loadRecord(at: storeDir.appendingPathComponent(name)) else { continue }
+        for file in allRecordFiles() {
+            guard let record = loadRecord(at: file) else {
+                // Evicted iCloud record: request the bytes in the background so
+                // the page shows up on the next refresh instead of blocking now.
+                WebICloud.requestDownload(at: file)
+                continue
+            }
             let key = pageKey(record.url)
             let size = snapshotArtifactsSize(forKey: key)
             guard size > 0 else { continue }
@@ -322,11 +502,10 @@ enum WebLibrary {
     /// sidecar record (reading state) always survives, and a record with no
     /// parseable timestamp is never evicted.
     static func evictStaleUnsavedSnapshots(olderThan cutoff: Date, excludingUrls: Set<String>) {
-        guard let names = try? FileManager.default.contentsOfDirectory(atPath: storeDir.path) else {
-            return
-        }
-        for name in names where name.hasSuffix(".json") {
-            guard let record = loadRecord(at: storeDir.appendingPathComponent(name)),
+        for file in allRecordFiles() {
+            // An unreadable (e.g. evicted) record is never grounds for
+            // eviction — loadRecord returning nil skips the page entirely.
+            guard let record = loadRecord(at: file),
                   !record.saved, record.annotations.isEmpty,
                   !excludingUrls.contains(record.url),
                   let opened = parseRfc3339(record.openedAt) ?? parseRfc3339(record.savedAt),
@@ -337,23 +516,35 @@ enum WebLibrary {
     }
 
     /// Delete every snapshot artifact in the store (records stay). Sweeps the
-    /// directory listing rather than the records so orphaned artifacts whose
-    /// record was lost are removed too.
+    /// directory listings rather than the records so orphaned artifacts whose
+    /// record was lost are removed too — both the legacy local store and the
+    /// active layout's `Web Pages/` folder (evicted placeholders included).
     static func removeAllSnapshotArtifacts() {
         let fm = FileManager.default
         try? fm.removeItem(at: storeDir.appendingPathComponent("archives", isDirectory: true))
-        guard let names = try? fm.contentsOfDirectory(atPath: storeDir.path) else { return }
-        for name in names where name.hasSuffix(".snapshot.html") || name.hasSuffix(".vellumweb") {
-            try? fm.removeItem(at: storeDir.appendingPathComponent(name))
+        if let names = try? fm.contentsOfDirectory(atPath: storeDir.path) {
+            for name in names where name.hasSuffix(".snapshot.html") || name.hasSuffix(".vellumweb") {
+                try? fm.removeItem(at: storeDir.appendingPathComponent(name))
+            }
+        }
+        let layout = activeLayout
+        if layout.pretty, let names = try? fm.contentsOfDirectory(atPath: layout.archivesDir.path) {
+            for name in names where name.hasSuffix(".vellumweb") || name.hasSuffix(".vellumweb.icloud") {
+                try? fm.removeItem(at: layout.archivesDir.appendingPathComponent(name))
+            }
+            if let indexPath = layout.indexPath {
+                try? fm.removeItem(at: indexPath)
+            }
         }
     }
 
     private static func snapshotArtifactsSize(forKey key: String) -> Int64 {
         let fm = FileManager.default
         var total: Int64 = 0
-        for file in [snapshotPath(forKey: key), managedArchivePath(forKey: key)] {
-            let attributes = try? fm.attributesOfItem(atPath: file.path)
-            total += (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+        let attributes = try? fm.attributesOfItem(atPath: snapshotPath(forKey: key).path)
+        total += (attributes?[.size] as? NSNumber)?.int64Value ?? 0
+        if let managed = existingManagedArchiveURL(forKey: key) {
+            total += WebICloud.size(ofItemAt: managed)
         }
         total += directorySize(at: archiveDir(forKey: key))
         return total

--- a/Vellum/Services/Web/WebLibrary.swift
+++ b/Vellum/Services/Web/WebLibrary.swift
@@ -113,12 +113,33 @@ enum WebLibrary {
     /// Load a record wherever it currently lives, downloading an evicted
     /// iCloud copy if needed (blocking; call off the main thread when the
     /// active layout may be iCloud).
-    static func loadRecord(forKey key: String) -> WebPageRecord? {
+    static func loadRecord(forKey key: String, timeout: TimeInterval = 10) -> WebPageRecord? {
         for path in candidateRecordPaths(forKey: key) {
-            _ = WebICloud.materialize(at: path)
+            _ = WebICloud.materialize(at: path, timeout: timeout)
             if let record = loadRecord(at: path) { return record }
         }
         return nil
+    }
+
+    /// Record read for the page-serving path, which must not stall on iCloud.
+    /// A local copy resolves with no wait at all; only an evicted record waits,
+    /// and then briefly and on a dedicated thread — `WebICloud.materialize`
+    /// blocks with `Thread.sleep`, which must never happen on a cooperative
+    /// (async) thread. The record still has to be read rather than skipped: it
+    /// carries `saved` and the pinned-snapshot loading policy, so treating an
+    /// evicted one as absent would silently serve a live page in place of an
+    /// imported archive's snapshot.
+    static func loadRecordForServing(forKey key: String) async -> WebPageRecord? {
+        let paths = candidateRecordPaths(forKey: key)
+        for path in paths {
+            if let record = loadRecord(at: path) { return record }
+        }
+        guard paths.contains(where: { WebICloud.itemExists(at: $0) }) else { return nil }
+        return await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: loadRecord(forKey: key, timeout: 2))
+            }
+        }
     }
 
     static func snapshotPath(forKey key: String) -> URL {

--- a/Vellum/Services/Web/WebPageExtractor.swift
+++ b/Vellum/Services/Web/WebPageExtractor.swift
@@ -892,7 +892,7 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
         // Sidecar state drives snapshot refresh and the loading policy.
         let key = WebLibrary.pageKey(pageUrl)
         let snapshotFile = WebLibrary.snapshotPath(forKey: key)
-        let record = WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: key))
+        let record = WebLibrary.loadRecord(forKey: key)
         let recordSaved = record?.saved ?? false
         let snapshotOnly = record?.loadingPolicy == "snapshot-only"
 
@@ -918,8 +918,7 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
                     }
                 } else {
                     let effectiveKey = WebLibrary.pageKey(effectiveUrl)
-                    let effectiveRecord = WebLibrary.loadRecord(
-                        at: WebLibrary.recordPath(forKey: effectiveKey))
+                    let effectiveRecord = WebLibrary.loadRecord(forKey: effectiveKey)
                     if effectiveRecord?.saved == true {
                         WebFetch.writeSnapshotAtomic(
                             path: WebLibrary.snapshotPath(forKey: effectiveKey), html: html)
@@ -1002,7 +1001,7 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
         guard !key.isEmpty, key.allSatisfy({ $0.isASCII && $0.isHexDigit }) else {
             return .html(404, "<h1>Snapshot not found</h1>")
         }
-        let record = WebLibrary.loadRecord(at: WebLibrary.recordPath(forKey: key))
+        let record = WebLibrary.loadRecord(forKey: key)
         let pageUrl = record?.url ?? ""
         if let response = serveInstalledSnapshot(key: key, pageUrl: pageUrl) {
             return response

--- a/Vellum/Services/Web/WebPageExtractor.swift
+++ b/Vellum/Services/Web/WebPageExtractor.swift
@@ -858,7 +858,7 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
             return serveArchiveAsset(rest: String(url.path.dropFirst()))
         }
         if host == snapshotHost {
-            return serveSnapshotFallback(key: String(url.path.dropFirst()))
+            return await serveSnapshotFallback(key: String(url.path.dropFirst()))
         }
 
         // Everything else is the page authority: map the truthful proxy URL
@@ -892,7 +892,7 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
         // Sidecar state drives snapshot refresh and the loading policy.
         let key = WebLibrary.pageKey(pageUrl)
         let snapshotFile = WebLibrary.snapshotPath(forKey: key)
-        let record = WebLibrary.loadRecord(forKey: key)
+        let record = await WebLibrary.loadRecordForServing(forKey: key)
         let recordSaved = record?.saved ?? false
         let snapshotOnly = record?.loadingPolicy == "snapshot-only"
 
@@ -918,7 +918,7 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
                     }
                 } else {
                     let effectiveKey = WebLibrary.pageKey(effectiveUrl)
-                    let effectiveRecord = WebLibrary.loadRecord(forKey: effectiveKey)
+                    let effectiveRecord = await WebLibrary.loadRecordForServing(forKey: effectiveKey)
                     if effectiveRecord?.saved == true {
                         WebFetch.writeSnapshotAtomic(
                             path: WebLibrary.snapshotPath(forKey: effectiveKey), html: html)
@@ -997,11 +997,11 @@ final class VellumWebSchemeHandler: NSObject, WKURLSchemeHandler {
     /// Explicit snapshot request (navigation-failure fallback): installed
     /// archive snapshot first, then the plain saved snapshot, else Vellum's
     /// own error page — the webview must never end up on WebKit's native one.
-    private static func serveSnapshotFallback(key: String) -> WebProxyResponse {
+    private static func serveSnapshotFallback(key: String) async -> WebProxyResponse {
         guard !key.isEmpty, key.allSatisfy({ $0.isASCII && $0.isHexDigit }) else {
             return .html(404, "<h1>Snapshot not found</h1>")
         }
-        let record = WebLibrary.loadRecord(forKey: key)
+        let record = await WebLibrary.loadRecordForServing(forKey: key)
         let pageUrl = record?.url ?? ""
         if let response = serveInstalledSnapshot(key: key, pageUrl: pageUrl) {
             return response

--- a/Vellum/Services/Web/WebSessionBackend.swift
+++ b/Vellum/Services/Web/WebSessionBackend.swift
@@ -117,16 +117,19 @@ final class WebDocumentSession: DocumentSession {
     /// Normalized page URL — the document identity.
     let url: String
     private let key: String
-    private let recordPath: URL
     private let snapshotPath: URL
     /// DocumentInfo captured at open time (mirrors the Rust command's return).
     private let openInfo: DocumentInfo
     private let io: WebDocumentIO
 
+    /// Resolved per operation, NOT cached: a storage-location switch mid-
+    /// session must not leave this session writing to (and resurrecting) the
+    /// old location after the migration sweep moved its record.
+    private var recordPath: URL { WebLibrary.recordPath(forKey: key) }
+
     init(url: String, record: WebPageRecord) {
         self.url = url
         key = WebLibrary.pageKey(url)
-        recordPath = WebLibrary.recordPath(forKey: key)
         snapshotPath = WebLibrary.snapshotPath(forKey: key)
         openInfo = DocumentInfo(
             kind: .web,
@@ -134,7 +137,7 @@ final class WebDocumentSession: DocumentSession {
             title: record.title,
             pageCount: record.pageCount,
             lastPage: record.lastPage)
-        io = WebDocumentIO(url: url, key: key, recordPath: recordPath)
+        io = WebDocumentIO(url: url, key: key)
     }
 
     var info: DocumentInfo { openInfo }
@@ -193,16 +196,35 @@ final class WebDocumentSession: DocumentSession {
     /// Automatic on-open archiver: writes the managed `.vellumweb` so the page
     /// reloads offline and the AI can read it. Deliberately does NOT mark the
     /// page saved — saving is an explicit user action (toolbar toggle) or an
-    /// implicit one (annotating promotes, see `WebDocumentIO.createAnnotation`);
-    /// artifacts for never-saved pages are TTL-evicted at launch.
+    /// implicit one (annotating promotes, see `WebDocumentIO.createAnnotation`)
+    /// — unless the user opted into Settings ▸ Storage ▸ "Automatically save
+    /// every page", which restores the old open-means-keep behavior; artifacts
+    /// for never-saved pages are TTL-evicted at launch.
     /// Returns false when the tab navigated away during the debounce.
     func archiveDefault(pages: [WebPageText], expectedUrl: String) async throws -> Bool {
         let expectedNormalized = (try? WebUrl.normalize(expectedUrl)) ?? expectedUrl
         if expectedNormalized != url {
             return false
         }
-        let dest = WebLibrary.managedArchivePath(forKey: key)
+        let localKey = key
+        // Resolve after the record exists (openWebDocument already wrote it),
+        // so the pretty filename can come from the page title; do it off-main —
+        // it may read the record and touch the index file.
+        let dest = await Task.detached(priority: .userInitiated) {
+            WebLibrary.managedArchiveDestination(forKey: localKey)
+        }.value
         _ = try await writeWebArchive(pages: pages, dest: dest)
+        if WebStorageSettings.autoSavePages {
+            let localUrl = url
+            let localRecordPath = recordPath
+            try await Task.detached(priority: .userInitiated) {
+                try WebLibrary.withRecord(url: localUrl, recordPath: localRecordPath) { record in
+                    guard !record.saved else { return }
+                    record.saved = true
+                    record.savedAt = record.savedAt ?? WebLibrary.rfc3339Now()
+                }
+            }.value
+        }
         return true
     }
 
@@ -306,16 +328,18 @@ final class WebDocumentSession: DocumentSession {
 actor WebDocumentIO {
     let url: String
     let key: String
-    let recordPath: URL
 
-    init(url: String, key: String, recordPath: URL) {
+    /// Resolved per operation so a storage-location switch mid-session
+    /// redirects the very next write instead of resurrecting the old path.
+    private var recordPath: URL { WebLibrary.recordPath(forKey: key) }
+
+    init(url: String, key: String) {
         self.url = url
         self.key = key
-        self.recordPath = recordPath
     }
 
     func annotations(pageNumber: Int?) -> [Annotation] {
-        let record = WebLibrary.loadRecord(at: recordPath) ?? WebPageRecord(url: url)
+        let record = WebLibrary.loadRecord(forKey: key) ?? WebPageRecord(url: url)
         guard let pageNumber else { return record.annotations }
         return record.annotations.filter { $0.pageNumber == pageNumber }
     }
@@ -406,6 +430,6 @@ actor WebDocumentIO {
     }
 
     func isSaved() -> Bool {
-        WebLibrary.loadRecord(at: recordPath)?.saved ?? false
+        WebLibrary.loadRecord(forKey: key)?.saved ?? false
     }
 }

--- a/Vellum/Services/Web/WebSessionBackend.swift
+++ b/Vellum/Services/Web/WebSessionBackend.swift
@@ -190,8 +190,11 @@ final class WebDocumentSession: DocumentSession {
         try await writeWebArchive(pages: pages, dest: URL(fileURLWithPath: destPath))
     }
 
-    /// Automatic on-open archiver: writes the managed `.vellumweb` and marks
-    /// the record saved-if-absent so opened pages land in the library.
+    /// Automatic on-open archiver: writes the managed `.vellumweb` so the page
+    /// reloads offline and the AI can read it. Deliberately does NOT mark the
+    /// page saved — saving is an explicit user action (toolbar toggle) or an
+    /// implicit one (annotating promotes, see `WebDocumentIO.createAnnotation`);
+    /// artifacts for never-saved pages are TTL-evicted at launch.
     /// Returns false when the tab navigated away during the debounce.
     func archiveDefault(pages: [WebPageText], expectedUrl: String) async throws -> Bool {
         let expectedNormalized = (try? WebUrl.normalize(expectedUrl)) ?? expectedUrl
@@ -200,7 +203,6 @@ final class WebDocumentSession: DocumentSession {
         }
         let dest = WebLibrary.managedArchivePath(forKey: key)
         _ = try await writeWebArchive(pages: pages, dest: dest)
-        try await io.markSavedIfAbsent()
         return true
     }
 
@@ -337,6 +339,13 @@ actor WebDocumentIO {
             updatedAt: now)
         try WebLibrary.withRecord(url: url, recordPath: recordPath) { record in
             record.annotations.append(annotation)
+            // Annotating is user investment: promote the page into the saved
+            // library so explicit-save semantics can never strand highlights or
+            // notes on a page whose snapshots are eligible for TTL eviction.
+            if !record.saved {
+                record.saved = true
+                record.savedAt = record.savedAt ?? WebLibrary.rfc3339Now()
+            }
         }
         return annotation
     }
@@ -398,9 +407,5 @@ actor WebDocumentIO {
 
     func isSaved() -> Bool {
         WebLibrary.loadRecord(at: recordPath)?.saved ?? false
-    }
-
-    func markSavedIfAbsent() throws {
-        try WebLibrary.markSavedIfAbsent(recordPath: recordPath, url: url)
     }
 }

--- a/Vellum/Services/Web/WebStorage.swift
+++ b/Vellum/Services/Web/WebStorage.swift
@@ -1,0 +1,526 @@
+import Foundation
+
+// Where the web library lives on disk (issue #29 follow-up): the user picks a
+// storage location once — iCloud Drive (everything syncs: offline copies AND
+// records with highlights/notes/reading position), a custom folder (offline
+// copies only; records stay in Application Support and do not sync), or this
+// Mac (the pre-existing layout, everything under Application Support).
+//
+// iCloud is plain-folder iCloud Drive (`~/Library/Mobile Documents/
+// com~apple~CloudDocs/Vellum/`), not an app ubiquity container — the app is
+// ad-hoc signed with no entitlements, so `url(forUbiquityContainerIdentifier:)`
+// is unavailable. Being unsandboxed, FileManager can write there directly and
+// the iCloud daemon syncs it like any Finder-managed iCloud Drive folder
+// (the Obsidian-vault approach). Swapping to a real container later only
+// changes `WebStorageSettings.icloudVellumRoot`.
+//
+// User-facing layout under the chosen root ("pretty" modes):
+//   Web Pages/<Title>.vellumweb    one self-contained archive per page
+//   .vellum/index.json             page-key → filename map
+//   .vellum/records/<key>.json     records (iCloud mode only)
+// Derived caches (plain snapshots, unpacked archive dirs) always stay in
+// Application Support — they're rebuildable and would be sync noise.
+
+// MARK: - Mode + preferences
+
+enum WebStorageMode: String, CaseIterable, Sendable {
+    case local
+    case icloud
+    case custom
+}
+
+enum WebStorageSettings {
+    static let modeKey = "web.storage.mode"
+    static let customPathKey = "web.storage.customPath"
+    static let autoSaveKey = "web.storage.autoSavePages"
+    static let pendingRelocationKey = "web.storage.pendingRelocationFrom"
+
+    // Test seams (same idiom as WebLibrary.storeDirOverride).
+    nonisolated(unsafe) static var modeOverride: WebStorageMode?
+    nonisolated(unsafe) static var customRootOverride: URL?
+    nonisolated(unsafe) static var icloudDriveRootOverride: URL?
+    nonisolated(unsafe) static var autoSavePagesOverride: Bool?
+
+    /// Nil until the user has made the first-launch choice.
+    static var chosenMode: WebStorageMode? {
+        if let modeOverride { return modeOverride }
+        guard let raw = UserDefaults.standard.string(forKey: modeKey) else { return nil }
+        return WebStorageMode(rawValue: raw)
+    }
+
+    /// What path resolution actually uses: the chosen mode, degraded to
+    /// `.local` when its root is unusable (iCloud Drive signed out, custom
+    /// folder deleted) so the app keeps working instead of writing into a void.
+    static var effectiveMode: WebStorageMode {
+        switch chosenMode {
+        case .icloud: return icloudVellumRoot != nil ? .icloud : .local
+        case .custom: return customRoot != nil ? .custom : .local
+        default: return .local
+        }
+    }
+
+    /// The chosen mode exists but its root is currently unusable (Settings
+    /// surfaces this as a warning instead of failing silently).
+    static var modeIsDegraded: Bool {
+        guard let chosenMode else { return false }
+        return chosenMode != effectiveMode
+    }
+
+    static var needsFirstLaunchChoice: Bool { chosenMode == nil }
+
+    static func setMode(_ mode: WebStorageMode, customPath: String? = nil) {
+        let defaults = UserDefaults.standard
+        defaults.set(mode.rawValue, forKey: modeKey)
+        if mode == .custom, let customPath {
+            defaults.set(customPath, forKey: customPathKey)
+        }
+    }
+
+    /// iCloud Drive's real on-disk root, nil when iCloud Drive is off. The
+    /// test override goes through the same existence check so degraded-mode
+    /// behavior is testable.
+    static var icloudDriveRoot: URL? {
+        let root = icloudDriveRootOverride
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Library/Mobile Documents/com~apple~CloudDocs", isDirectory: true)
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDir),
+              isDir.boolValue else { return nil }
+        return root
+    }
+
+    static var icloudVellumRoot: URL? {
+        icloudDriveRoot?.appendingPathComponent("Vellum", isDirectory: true)
+    }
+
+    static var customRoot: URL? {
+        if let customRootOverride { return customRootOverride }
+        guard let path = UserDefaults.standard.string(forKey: customPathKey),
+              !path.isEmpty else { return nil }
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir),
+              isDir.boolValue else { return nil }
+        return url
+    }
+
+    /// Root for the *chosen* mode even when degraded — used by the migrator so
+    /// an interrupted relocation can still name its source.
+    static func root(for mode: WebStorageMode) -> URL? {
+        switch mode {
+        case .icloud: return icloudVellumRoot
+        case .custom: return customRoot
+        case .local: return nil
+        }
+    }
+
+    /// Settings ▸ Storage: mark every opened page saved (pre-explicit-save
+    /// behavior, now opt-in). Off by default.
+    static var autoSavePages: Bool {
+        if let autoSavePagesOverride { return autoSavePagesOverride }
+        return UserDefaults.standard.bool(forKey: autoSaveKey)
+    }
+
+    static func setAutoSavePages(_ on: Bool) {
+        UserDefaults.standard.set(on, forKey: autoSaveKey)
+    }
+}
+
+// MARK: - Resolved layout
+
+/// The concrete directories the active mode resolves to. Everything in
+/// WebLibrary that touches records or managed archives goes through this.
+struct WebStorageLayout: Equatable, Sendable {
+    /// Where `<key>.json` records live.
+    var recordsDir: URL
+    /// Where managed `.vellumweb` archives live.
+    var archivesDir: URL
+    /// Pretty modes name archives after the page title (via the index);
+    /// the local mode keeps the legacy `<key>.vellumweb` hashed names.
+    var pretty: Bool
+    /// `.vellum/index.json` next to the archives (pretty modes only).
+    var indexPath: URL?
+
+    static func local(storeDir: URL) -> WebStorageLayout {
+        WebStorageLayout(recordsDir: storeDir, archivesDir: storeDir, pretty: false, indexPath: nil)
+    }
+
+    static func pretty(root: URL, recordsInRoot: Bool, localStoreDir: URL) -> WebStorageLayout {
+        let internalDir = root.appendingPathComponent(".vellum", isDirectory: true)
+        return WebStorageLayout(
+            recordsDir: recordsInRoot
+                ? internalDir.appendingPathComponent("records", isDirectory: true)
+                : localStoreDir,
+            archivesDir: root.appendingPathComponent("Web Pages", isDirectory: true),
+            pretty: true,
+            indexPath: internalDir.appendingPathComponent("index.json"))
+    }
+
+    static func resolve(mode: WebStorageMode, storeDir: URL) -> WebStorageLayout {
+        switch mode {
+        case .icloud:
+            guard let root = WebStorageSettings.icloudVellumRoot else { return .local(storeDir: storeDir) }
+            return .pretty(root: root, recordsInRoot: true, localStoreDir: storeDir)
+        case .custom:
+            guard let root = WebStorageSettings.customRoot else { return .local(storeDir: storeDir) }
+            return .pretty(root: root, recordsInRoot: false, localStoreDir: storeDir)
+        case .local:
+            return .local(storeDir: storeDir)
+        }
+    }
+}
+
+// MARK: - Pretty-name index
+
+/// Maps page keys to the human-named `.vellumweb` files in `Web Pages/`.
+/// Names are assigned once and kept stable across title changes (renames would
+/// be iCloud sync churn). A missing entry just means a fresh name is assigned
+/// on the next archive write — the index is a convenience, not a source of
+/// truth, so losing it (e.g. an iCloud conflict) is never data loss.
+enum WebArchiveIndex {
+    struct Contents: Codable {
+        var version: Int
+        var entries: [String: String]
+
+        init() {
+            version = 1
+            entries = [:]
+        }
+    }
+
+    private static let lock = NSLock()
+
+    static func load(at path: URL) -> Contents {
+        guard let data = try? Data(contentsOf: path),
+              let contents = try? JSONDecoder().decode(Contents.self, from: data)
+        else { return Contents() }
+        return contents
+    }
+
+    private static func save(_ contents: Contents, at path: URL) {
+        try? FileManager.default.createDirectory(
+            at: path.deletingLastPathComponent(), withIntermediateDirectories: true)
+        guard let data = try? WebLibrary.jsonEncoderPretty.encode(contents) else { return }
+        let tmp = path.appendingPathExtension("tmp")
+        guard (try? data.write(to: tmp)) != nil else { return }
+        if rename(tmp.path, path.path) != 0 {
+            try? FileManager.default.removeItem(at: tmp)
+        }
+    }
+
+    static func fileName(forKey key: String, at path: URL) -> String? {
+        lock.lock()
+        defer { lock.unlock() }
+        _ = WebICloud.materialize(at: path, timeout: 5)
+        return load(at: path).entries[key]
+    }
+
+    /// Existing name for the key, or assign one derived from the title —
+    /// unique against both the index and whatever is already on disk.
+    static func assignFileName(forKey key: String, title: String?, url: String, at path: URL, archivesDir: URL) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        // An evicted index read as empty would re-assign names that are
+        // already taken and overwrite other pages' archives — download it
+        // first, and treat evicted archives as occupying their filename.
+        _ = WebICloud.materialize(at: path, timeout: 5)
+        var contents = load(at: path)
+        if let existing = contents.entries[key] { return existing }
+        let base = sanitizedBaseName(title: title, url: url)
+        var candidate = "\(base).vellumweb"
+        var counter = 2
+        let taken = Set(contents.entries.values)
+        while taken.contains(candidate)
+            || WebICloud.itemExists(at: archivesDir.appendingPathComponent(candidate)) {
+            candidate = "\(base) \(counter).vellumweb"
+            counter += 1
+        }
+        contents.entries[key] = candidate
+        save(contents, at: path)
+        return candidate
+    }
+
+    static func removeEntry(forKey key: String, at path: URL) {
+        lock.lock()
+        defer { lock.unlock() }
+        _ = WebICloud.materialize(at: path, timeout: 5)
+        var contents = load(at: path)
+        guard contents.entries.removeValue(forKey: key) != nil else { return }
+        save(contents, at: path)
+    }
+
+    /// Filesystem-safe display name: strip path separators and control chars,
+    /// collapse whitespace, trim leading dots (hidden files), cap the length.
+    /// Falls back to the URL's host+path when the title is empty.
+    static func sanitizedBaseName(title: String?, url: String) -> String {
+        var source = (title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if source.isEmpty {
+            // Lenient Foundation URL parsing can yield a path but no host —
+            // never emit a dangling "host — " / "— tail" fragment.
+            let parsed = URL(string: url)
+            let host = parsed?.host ?? ""
+            let tail = parsed?.path.split(separator: "/").last.map(String.init) ?? ""
+            switch (host.isEmpty, tail.isEmpty) {
+            case (false, false): source = "\(host) — \(tail)"
+            case (false, true): source = host
+            case (true, _): source = tail
+            }
+        }
+        if source.isEmpty { source = "Web Page" }
+        var cleaned = ""
+        for scalar in source.unicodeScalars {
+            if scalar == "/" || scalar == ":" || scalar == "\\" {
+                cleaned.append("-")
+            } else if scalar.properties.generalCategory == .control {
+                continue
+            } else {
+                cleaned.unicodeScalars.append(scalar)
+            }
+        }
+        cleaned = cleaned.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        while cleaned.hasPrefix(".") { cleaned.removeFirst() }
+        if cleaned.count > 80 {
+            cleaned = String(cleaned.prefix(80)).trimmingCharacters(in: .whitespaces)
+        }
+        return cleaned.isEmpty ? "Web Page" : cleaned
+    }
+}
+
+// MARK: - iCloud materialization
+
+/// iCloud Drive evicts files it thinks are cold, leaving a `.<name>.icloud`
+/// placeholder where the real file was. Anything that reads library files from
+/// a pretty root must cope with that.
+enum WebICloud {
+    /// The dataless-placeholder path iCloud Drive uses for an evicted file.
+    static func placeholderURL(for url: URL) -> URL {
+        url.deletingLastPathComponent()
+            .appendingPathComponent(".\(url.lastPathComponent).icloud")
+    }
+
+    /// True when the item exists in the library — either materialized or as an
+    /// evicted placeholder.
+    static func itemExists(at url: URL) -> Bool {
+        let fm = FileManager.default
+        return fm.fileExists(atPath: url.path)
+            || fm.fileExists(atPath: placeholderURL(for: url).path)
+    }
+
+    /// Ensure the real bytes are local, triggering a download for an evicted
+    /// item and polling until it lands or the timeout passes. Blocking — call
+    /// off the main thread only. Returns false when the file neither exists
+    /// nor could be downloaded in time (e.g. offline).
+    static func materialize(at url: URL, timeout: TimeInterval = 10) -> Bool {
+        let fm = FileManager.default
+        if fm.fileExists(atPath: url.path) { return true }
+        guard fm.fileExists(atPath: placeholderURL(for: url).path) else { return false }
+        try? fm.startDownloadingUbiquitousItem(at: url)
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if fm.fileExists(atPath: url.path) { return true }
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        return false
+    }
+
+    /// Fire-and-forget download request for an evicted item — used by listing
+    /// paths that must not block on the network.
+    static func requestDownload(at url: URL) {
+        guard FileManager.default.fileExists(atPath: placeholderURL(for: url).path) else { return }
+        try? FileManager.default.startDownloadingUbiquitousItem(at: url)
+    }
+
+    /// Delete an item that may currently be evicted (removing the placeholder
+    /// removes the item from iCloud too).
+    static func removeItem(at url: URL) {
+        let fm = FileManager.default
+        try? fm.removeItem(at: url)
+        try? fm.removeItem(at: placeholderURL(for: url))
+    }
+
+    static func size(ofItemAt url: URL) -> Int64 {
+        let fm = FileManager.default
+        if let attributes = try? fm.attributesOfItem(atPath: url.path) {
+            return (attributes[.size] as? NSNumber)?.int64Value ?? 0
+        }
+        // Evicted: report the true size recorded on the placeholder so the
+        // Storage tab reflects what deleting would reclaim in iCloud.
+        let placeholder = placeholderURL(for: url)
+        if let data = try? Data(contentsOf: placeholder),
+           let plist = try? PropertyListSerialization.propertyList(from: data, format: nil),
+           let dict = plist as? [String: Any],
+           let size = dict["NSURLFileSizeKey"] as? NSNumber {
+            return size.int64Value
+        }
+        return 0
+    }
+}
+
+// MARK: - Migration
+
+/// Moves the store between layouts: on the first-launch choice, on a Settings
+/// location change, and as an idempotent launch sweep that finishes interrupted
+/// moves and collects strays (e.g. records written by a still-open tab after a
+/// mid-session switch). Every step is per-file and skip-if-done, so it is safe
+/// to re-run at any time.
+enum WebStorageMigrator {
+    /// Remember the source of an in-flight relocation (mode plus, for custom,
+    /// the concrete folder — the preference may already point elsewhere) so an
+    /// interrupted move resumes at next launch.
+    static func recordPendingRelocation(mode: WebStorageMode, customPath: String?) {
+        let marker = mode == .custom ? "\(mode.rawValue)|\(customPath ?? "")" : mode.rawValue
+        UserDefaults.standard.set(marker, forKey: WebStorageSettings.pendingRelocationKey)
+    }
+
+    static func clearPendingRelocation() {
+        UserDefaults.standard.removeObject(forKey: WebStorageSettings.pendingRelocationKey)
+    }
+
+    /// Launch-time pass: resume any interrupted relocation, then fold whatever
+    /// still sits in the legacy local store into the active layout.
+    static func sweepAtLaunch() {
+        let active = WebLibrary.activeLayout
+        if let source = pendingRelocationSource(), relocate(from: source, to: active) {
+            clearPendingRelocation()
+        }
+        let localLayout = WebStorageLayout.local(storeDir: WebLibrary.storeDir)
+        if active != localLayout {
+            _ = relocate(from: localLayout, to: active)
+        }
+    }
+
+    /// The layout an interrupted relocation should resume FROM. Returns nil —
+    /// keeping the marker for a later launch — when the source root is
+    /// currently unreachable (iCloud signed out, external folder unmounted):
+    /// resolving a degraded source to the local layout would make the resume
+    /// a local→local no-op that clears the marker and strands the real files.
+    private static func pendingRelocationSource() -> WebStorageLayout? {
+        guard let raw = UserDefaults.standard.string(forKey: WebStorageSettings.pendingRelocationKey) else {
+            return nil
+        }
+        let parts = raw.split(separator: "|", maxSplits: 1).map(String.init)
+        guard let mode = WebStorageMode(rawValue: parts[0]) else { return nil }
+        switch mode {
+        case .custom:
+            guard parts.count == 2, !parts[1].isEmpty else { return nil }
+            let root = URL(fileURLWithPath: parts[1], isDirectory: true)
+            guard FileManager.default.fileExists(atPath: root.path) else { return nil }
+            return .pretty(root: root, recordsInRoot: false, localStoreDir: WebLibrary.storeDir)
+        case .icloud:
+            guard let root = WebStorageSettings.icloudVellumRoot else { return nil }
+            return .pretty(root: root, recordsInRoot: true, localStoreDir: WebLibrary.storeDir)
+        case .local:
+            return .local(storeDir: WebLibrary.storeDir)
+        }
+    }
+
+    /// Move records and managed archives from one layout to another. Returns
+    /// true when nothing was skipped (an evicted iCloud file that could not be
+    /// downloaded stays put and is retried at the next sweep). Derived caches
+    /// (plain snapshots, unpacked archive dirs) never move — they live in the
+    /// local store regardless of mode.
+    @discardableResult
+    static func relocate(from source: WebStorageLayout, to dest: WebStorageLayout) -> Bool {
+        guard source != dest else { return true }
+        let fm = FileManager.default
+        var clean = true
+
+        do {
+            try fm.createDirectory(at: dest.recordsDir, withIntermediateDirectories: true)
+            try fm.createDirectory(at: dest.archivesDir, withIntermediateDirectories: true)
+        } catch {
+            return false
+        }
+
+        // Records first, so archive naming below can read titles from their
+        // final location. `recordFileNames` reports evicted records under
+        // their real name so they are downloaded and moved, not skipped.
+        if source.recordsDir != dest.recordsDir {
+            for name in WebLibrary.recordFileNames(inDir: source.recordsDir) {
+                let src = source.recordsDir.appendingPathComponent(name)
+                let dst = dest.recordsDir.appendingPathComponent(name)
+                if !WebICloud.materialize(at: src) {
+                    if WebICloud.itemExists(at: src) { clean = false }
+                    continue
+                }
+                if !WebLibrary.adoptRecordFile(from: src, to: dst) {
+                    clean = false
+                }
+            }
+        }
+
+        // Managed archives: resolve each record's key to a source archive and
+        // move it to the destination's naming scheme.
+        for name in WebLibrary.recordFileNames(inDir: dest.recordsDir) {
+            let key = String(name.dropLast(".json".count))
+            guard let src = archiveURL(forKey: key, in: source), WebICloud.itemExists(at: src) else { continue }
+            let recordFile = dest.recordsDir.appendingPathComponent(name)
+            _ = WebICloud.materialize(at: recordFile)
+            let record = WebLibrary.loadRecord(at: recordFile)
+            let dst = destinationArchiveURL(
+                forKey: key, title: record?.title, url: record?.url ?? "", in: dest)
+            guard src != dst else { continue }
+            if !WebICloud.materialize(at: src) {
+                clean = false
+                continue
+            }
+            if fm.fileExists(atPath: dst.path) {
+                WebICloud.removeItem(at: src)
+            } else {
+                try? fm.createDirectory(
+                    at: dst.deletingLastPathComponent(), withIntermediateDirectories: true)
+                if (try? fm.moveItem(at: src, to: dst)) == nil {
+                    clean = false
+                    if let indexPath = dest.indexPath {
+                        WebArchiveIndex.removeEntry(forKey: key, at: indexPath)
+                    }
+                    continue
+                }
+            }
+            if let sourceIndex = source.indexPath {
+                WebArchiveIndex.removeEntry(forKey: key, at: sourceIndex)
+            }
+        }
+
+        if clean, source.pretty {
+            cleanUpEmptyPrettyDirs(of: source)
+        }
+        return clean
+    }
+
+    private static func archiveURL(forKey key: String, in layout: WebStorageLayout) -> URL? {
+        if layout.pretty {
+            guard let indexPath = layout.indexPath,
+                  let name = WebArchiveIndex.fileName(forKey: key, at: indexPath) else { return nil }
+            return layout.archivesDir.appendingPathComponent(name)
+        }
+        return layout.archivesDir.appendingPathComponent("\(key).vellumweb")
+    }
+
+    private static func destinationArchiveURL(
+        forKey key: String, title: String?, url: String, in layout: WebStorageLayout
+    ) -> URL {
+        if layout.pretty, let indexPath = layout.indexPath {
+            let name = WebArchiveIndex.assignFileName(
+                forKey: key, title: title, url: url, at: indexPath, archivesDir: layout.archivesDir)
+            return layout.archivesDir.appendingPathComponent(name)
+        }
+        return layout.archivesDir.appendingPathComponent("\(key).vellumweb")
+    }
+
+    /// After a full move out of a pretty root, remove the now-empty structure
+    /// we created (never the user's own folder or anything with content).
+    private static func cleanUpEmptyPrettyDirs(of layout: WebStorageLayout) {
+        let fm = FileManager.default
+        if let indexPath = layout.indexPath,
+           WebArchiveIndex.load(at: indexPath).entries.isEmpty {
+            try? fm.removeItem(at: indexPath)
+        }
+        for dir in [layout.archivesDir, layout.recordsDir, layout.indexPath?.deletingLastPathComponent()].compactMap({ $0 }) {
+            if let contents = try? fm.contentsOfDirectory(atPath: dir.path),
+               contents.filter({ $0 != ".DS_Store" }).isEmpty {
+                try? fm.removeItem(at: dir)
+            }
+        }
+    }
+}

--- a/Vellum/Services/Web/WebStorage.swift
+++ b/Vellum/Services/Web/WebStorage.swift
@@ -516,11 +516,24 @@ enum WebStorageMigrator {
            WebArchiveIndex.load(at: indexPath).entries.isEmpty {
             try? fm.removeItem(at: indexPath)
         }
-        for dir in [layout.archivesDir, layout.recordsDir, layout.indexPath?.deletingLastPathComponent()].compactMap({ $0 }) {
-            if let contents = try? fm.contentsOfDirectory(atPath: dir.path),
-               contents.filter({ $0 != ".DS_Store" }).isEmpty {
-                try? fm.removeItem(at: dir)
+        // A custom layout's records dir IS the shared local store — home to
+        // derived caches for every mode, not something this migration created.
+        // Never a removal candidate, even when it happens to be empty.
+        var dirs = [layout.archivesDir]
+        if layout.recordsDir != WebLibrary.storeDir { dirs.append(layout.recordsDir) }
+        if let internalDir = layout.indexPath?.deletingLastPathComponent() {
+            dirs.append(internalDir) // last: it contains the two above in iCloud mode
+        }
+        for dir in dirs {
+            if (try? fm.contentsOfDirectory(atPath: dir.path)) == [".DS_Store"] {
+                try? fm.removeItem(at: dir.appendingPathComponent(".DS_Store"))
             }
+            // rmdir, not removeItem: it is atomic and only succeeds while the
+            // directory is still empty at the syscall itself. A check-then-
+            // remove would recursively delete a record a still-open tab wrote
+            // in between (the same concurrency this migration handles
+            // elsewhere via `adoptRecordFile`).
+            _ = rmdir(dir.path)
         }
     }
 }

--- a/Vellum/Views/PDF/ToolbarView.swift
+++ b/Vellum/Views/PDF/ToolbarView.swift
@@ -343,6 +343,9 @@ private struct OverflowMenu: View {
     /// Serializes save/remove so a rapid Remove can't finish before a slow
     /// Save's archive write and get its deletion undone by it.
     @State private var saveToggleTask: Task<Void, Never>?
+    /// Identifies the newest queued toggle, so a superseded one's failure can't
+    /// revert the toolbar to a state the user has already toggled away from.
+    @State private var saveToggleGeneration = 0
 
     private var isWeb: Bool { appStore.document?.kind == .web }
     private var hasDocument: Bool { appStore.document != nil }
@@ -458,6 +461,8 @@ private struct OverflowMenu: View {
             .sorted { $0.key < $1.key }
             .map { WebPageText(number: $0.key, text: $0.value) }
         let prior = saveToggleTask
+        saveToggleGeneration += 1
+        let generation = saveToggleGeneration
         saveToggleTask = Task {
             await prior?.value
             do {
@@ -470,7 +475,11 @@ private struct OverflowMenu: View {
                         sessionId: sessionId, pages: pages, expectedUrl: expectedUrl)
                 }
             } catch {
-                if appStore.activeTabId == sessionId { pageSaved = !next }
+                // Only the newest toggle owns the button: an older one failing
+                // behind a queued newer one must not resurrect its own state.
+                if appStore.activeTabId == sessionId, generation == saveToggleGeneration {
+                    pageSaved = !next
+                }
             }
         }
     }

--- a/Vellum/Views/PDF/ToolbarView.swift
+++ b/Vellum/Views/PDF/ToolbarView.swift
@@ -340,6 +340,9 @@ private struct OverflowMenu: View {
     @State private var updateChecker = UpdateChecker()
     @State private var pageSaved = false
     @State private var exporting = false
+    /// Serializes save/remove so a rapid Remove can't finish before a slow
+    /// Save's archive write and get its deletion undone by it.
+    @State private var saveToggleTask: Task<Void, Never>?
 
     private var isWeb: Bool { appStore.document?.kind == .web }
     private var hasDocument: Bool { appStore.document != nil }
@@ -369,11 +372,12 @@ private struct OverflowMenu: View {
                 Section {
                     Button(action: toggleSavedPage) {
                         Label(
-                            pageSaved ? "Remove from Library" : "Save Page to Library",
-                            systemImage: pageSaved ? "archivebox.fill" : "archivebox")
+                            pageSaved ? "Remove Offline Copy" : "Save for Offline Use",
+                            systemImage: pageSaved ? "arrow.down.circle.fill" : "arrow.down.circle")
                     }
+                    .accessibilityIdentifier("toolbar.saveForOffline")
                     Button(action: exportVellumweb) {
-                        Label("Export as .vellumweb…", systemImage: "square.and.arrow.up")
+                        Label("Export a Copy…", systemImage: "square.and.arrow.up")
                     }
                     .disabled(exporting)
                 }
@@ -441,13 +445,30 @@ private struct OverflowMenu: View {
         }
     }
 
+    /// Save = mark the page kept AND make sure its offline copy exists (the
+    /// re-archive covers a copy the user deleted from Settings ▸ Storage).
+    /// Remove = un-keep and delete the offline copy; the record — highlights,
+    /// notes, reading position — always survives.
     private func toggleSavedPage() {
         guard let sessionId = appStore.activeTabId else { return }
         let next = !pageSaved
         pageSaved = next
-        Task {
+        let expectedUrl = appStore.document?.pdfPath ?? ""
+        let pages = aiStore.pageTexts
+            .sorted { $0.key < $1.key }
+            .map { WebPageText(number: $0.key, text: $0.value) }
+        let prior = saveToggleTask
+        saveToggleTask = Task {
+            await prior?.value
             do {
                 try await appStore.sessions.setWebpageSaved(sessionId: sessionId, saved: next)
+                if next {
+                    // Best-effort: membership is saved even if the archive
+                    // write fails (offline, no snapshot yet) — the copy is
+                    // rewritten on the next open of the page.
+                    _ = try? await appStore.sessions.archiveWebpageDefault(
+                        sessionId: sessionId, pages: pages, expectedUrl: expectedUrl)
+                }
             } catch {
                 if appStore.activeTabId == sessionId { pageSaved = !next }
             }

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -237,6 +237,11 @@ private struct StorageSettingsTab: View {
     @State private var pendingDelete: PageTextCacheEntry?
     @State private var confirmingEraseAll = false
 
+    @State private var webEntries: [WebLibrary.SnapshotStorageEntry] = []
+    @State private var isLoadingWeb = true
+    @State private var pendingWebDelete: WebLibrary.SnapshotStorageEntry?
+    @State private var confirmingWebRemoveAll = false
+
     var body: some View {
         Form {
             Section {
@@ -274,6 +279,42 @@ private struct StorageSettingsTab: View {
             } header: {
                 Text("Cached documents")
             }
+
+            Section {
+                LabeledContent("Total size") {
+                    Text(webTotalBytes.formatted(.byteCount(style: .file)))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+                Button("Remove all…", role: .destructive) {
+                    confirmingWebRemoveAll = true
+                }
+                .disabled(webEntries.isEmpty)
+                .accessibilityIdentifier("storage.webRemoveAll")
+            } header: {
+                Text("Downloaded web pages")
+            } footer: {
+                Text("Vellum keeps an offline copy of each web page you open so it loads without a connection and the AI can read it. Copies of pages you never saved or annotated are removed automatically after six months. Removing a copy never affects your saved-pages list, highlights, or notes.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                if isLoadingWeb {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, alignment: .center)
+                } else if webEntries.isEmpty {
+                    Text("No downloaded pages")
+                        .foregroundStyle(.secondary)
+                        .id("storage.webEmpty")
+                } else {
+                    ForEach(webEntries) { entry in
+                        WebStorageRow(entry: entry) { pendingWebDelete = entry }
+                    }
+                }
+            } header: {
+                Text("Pages with offline copies")
+            }
         }
         .formStyle(.grouped)
         .frame(height: 460)
@@ -303,10 +344,39 @@ private struct StorageSettingsTab: View {
         } message: {
             Text("This clears the extracted-text cache for every document. Your notes, highlights, and AI conversations are not affected — only cached text is removed, and it's rebuilt automatically the next time you open each document.")
         }
+        .confirmationDialog(
+            pendingWebDelete.map { "Remove the offline copy of \"\($0.displayTitle)\"?" } ?? "",
+            isPresented: webDeleteDialogBinding,
+            presenting: pendingWebDelete
+        ) { entry in
+            Button("Remove Offline Copy", role: .destructive) {
+                deleteWeb(entry)
+            }
+            .accessibilityIdentifier("storage.confirmWebDelete")
+            Button("Cancel", role: .cancel) {}
+        } message: { _ in
+            Text("This removes only the downloaded offline copy — your saved-pages list, highlights, and notes are not affected. Vellum downloads a fresh copy the next time you open this page.")
+        }
+        .confirmationDialog(
+            "Remove all offline copies?",
+            isPresented: $confirmingWebRemoveAll
+        ) {
+            Button("Remove All Offline Copies", role: .destructive) {
+                removeAllWeb()
+            }
+            .accessibilityIdentifier("storage.confirmWebRemoveAll")
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the downloaded copy of every web page. Your saved-pages list, highlights, and notes are not affected — pages just load from the network (and re-download) the next time you open them.")
+        }
     }
 
     private var totalBytes: Int64 {
         entries.reduce(0) { $0 + $1.byteSize }
+    }
+
+    private var webTotalBytes: Int64 {
+        webEntries.reduce(0) { $0 + $1.byteSize }
     }
 
     /// Drive the per-row dialog off `pendingDelete`: dismiss clears the pending
@@ -318,10 +388,28 @@ private struct StorageSettingsTab: View {
         )
     }
 
+    private var webDeleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { pendingWebDelete != nil },
+            set: { if !$0 { pendingWebDelete = nil } }
+        )
+    }
+
     private func reload() async {
         isLoading = true
         entries = await PageTextCache.shared.listEntries()
         isLoading = false
+        isLoadingWeb = true
+        webEntries = await Self.listWebStorage()
+        isLoadingWeb = false
+    }
+
+    /// WebLibrary's listing walks the store directory and stats archive dirs —
+    /// keep it off the main thread (same reason PageTextCache is an actor).
+    private static func listWebStorage() async -> [WebLibrary.SnapshotStorageEntry] {
+        await Task.detached(priority: .userInitiated) {
+            WebLibrary.listSnapshotStorage()
+        }.value
     }
 
     // Optimistic local removal for immediate feedback, then a reload once the
@@ -340,6 +428,26 @@ private struct StorageSettingsTab: View {
         Task {
             await PageTextCache.shared.deleteAll()
             entries = await PageTextCache.shared.listEntries()
+        }
+    }
+
+    private func deleteWeb(_ entry: WebLibrary.SnapshotStorageEntry) {
+        webEntries.removeAll { $0.key == entry.key }
+        Task {
+            await Task.detached(priority: .userInitiated) {
+                WebLibrary.removeLocalSnapshots(forKey: entry.key)
+            }.value
+            webEntries = await Self.listWebStorage()
+        }
+    }
+
+    private func removeAllWeb() {
+        webEntries = []
+        Task {
+            await Task.detached(priority: .userInitiated) {
+                WebLibrary.removeAllSnapshotArtifacts()
+            }.value
+            webEntries = await Self.listWebStorage()
         }
     }
 }
@@ -398,5 +506,49 @@ private struct StorageCacheRow: View {
                     .foregroundStyle(palette.gold)
             }
         }
+    }
+}
+
+/// One downloaded web page: title (or URL), last-opened recency, whether the
+/// user saved it, artifact size, and a destructive per-row remove. Mirrors
+/// `StorageCacheRow` so the Storage tab reads as one system.
+private struct WebStorageRow: View {
+    let entry: WebLibrary.SnapshotStorageEntry
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.displayTitle)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text(statusText)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(entry.byteSize.formatted(.byteCount(style: .file)))
+                .font(.callout)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("webStorageRow.size.\(entry.key)")
+
+            Button(role: .destructive, action: onDelete) {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .help("Remove offline copy")
+            .accessibilityLabel("Remove offline copy of \(entry.displayTitle)")
+            .accessibilityIdentifier("webStorageRow.delete.\(entry.key)")
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("webStorageRow.\(entry.key)")
+    }
+
+    private var statusText: String {
+        let opened = entry.lastOpened?.formatted(.relative(presentation: .named)) ?? "—"
+        return "\(opened) · \(entry.saved ? "Saved" : "Not saved")"
     }
 }

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// App settings window (⌘, / Vellum ▸ Settings…). A durable macOS preferences
@@ -242,8 +243,13 @@ private struct StorageSettingsTab: View {
     @State private var pendingWebDelete: WebLibrary.SnapshotStorageEntry?
     @State private var confirmingWebRemoveAll = false
 
+    @State private var storageMode: WebStorageMode = .local
+    @State private var autoSavePages = false
+
     var body: some View {
         Form {
+            storageLocationSection
+
             Section {
                 LabeledContent("Total cache size") {
                     Text(totalBytes.formatted(.byteCount(style: .file)))
@@ -281,6 +287,8 @@ private struct StorageSettingsTab: View {
             }
 
             Section {
+                Toggle("Automatically save every page for offline use", isOn: autoSaveBinding)
+                    .accessibilityIdentifier("storage.autoSavePages")
                 LabeledContent("Total size") {
                     Text(webTotalBytes.formatted(.byteCount(style: .file)))
                         .foregroundStyle(.secondary)
@@ -294,7 +302,7 @@ private struct StorageSettingsTab: View {
             } header: {
                 Text("Downloaded web pages")
             } footer: {
-                Text("Vellum keeps an offline copy of each web page you open so it loads without a connection and the AI can read it. Copies of pages you never saved or annotated are removed automatically after six months. Removing a copy never affects your saved-pages list, highlights, or notes.")
+                Text("Vellum keeps an offline copy of each web page you open so it loads without a connection and the AI can read it. Copies of pages you never saved or annotated are removed automatically after six months — with automatic saving on, every page you open is kept until you remove it. Removing a copy never affects your saved-pages list, highlights, or notes.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }
@@ -318,7 +326,10 @@ private struct StorageSettingsTab: View {
         }
         .formStyle(.grouped)
         .frame(height: 460)
-        .task { await reload() }
+        .task {
+            refreshStorageSettings()
+            await reload()
+        }
         .confirmationDialog(
             pendingDelete.map { "Delete cached text for \"\($0.displayTitle)\"?" } ?? "",
             isPresented: deleteDialogBinding,
@@ -369,6 +380,119 @@ private struct StorageSettingsTab: View {
         } message: {
             Text("This removes the downloaded copy of every web page. Your saved-pages list, highlights, and notes are not affected — pages just load from the network (and re-download) the next time you open them.")
         }
+    }
+
+    // MARK: - Storage location
+
+    @ViewBuilder
+    private var storageLocationSection: some View {
+        Section {
+            Picker("Location", selection: locationBinding) {
+                Text("iCloud Drive").tag(WebStorageMode.icloud)
+                Text("Custom Folder").tag(WebStorageMode.custom)
+                Text("This Mac").tag(WebStorageMode.local)
+            }
+            .accessibilityIdentifier("storage.locationPicker")
+
+            if storageMode != .local, let path = currentLocationPath {
+                LabeledContent("Folder") {
+                    Text(path)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Button("Show in Finder") {
+                    NSWorkspace.shared.activateFileViewerSelecting(
+                        [URL(fileURLWithPath: path, isDirectory: true)])
+                }
+                .accessibilityIdentifier("storage.showInFinder")
+            }
+            if storageMode == .custom {
+                Button("Change Folder…") {
+                    guard let path = WebStorageRelocator.pickCustomFolder() else { return }
+                    WebStorageRelocator.apply(mode: .custom, customPath: path)
+                    refreshStorageSettings()
+                }
+                .accessibilityIdentifier("storage.changeFolder")
+            }
+        } header: {
+            Text("Storage location")
+        } footer: {
+            Text(locationFooterText)
+                .font(.footnote)
+                .foregroundStyle(WebStorageSettings.modeIsDegraded ? .orange : Color.secondary)
+        }
+    }
+
+    private var currentLocationPath: String? {
+        switch storageMode {
+        case .icloud: return WebStorageSettings.icloudVellumRoot?.path
+        case .custom: return UserDefaults.standard.string(forKey: WebStorageSettings.customPathKey)
+        case .local: return nil
+        }
+    }
+
+    private var locationFooterText: String {
+        if WebStorageSettings.modeIsDegraded {
+            switch storageMode {
+            case .icloud:
+                return "iCloud Drive isn't available right now (signed out, or iCloud Drive is off). Vellum is storing everything on this Mac until it comes back."
+            case .custom:
+                return "The chosen folder can't be found. Vellum is storing everything on this Mac until you pick a folder again."
+            case .local:
+                return ""
+            }
+        }
+        switch storageMode {
+        case .icloud:
+            return "Everything — offline copies, highlights, notes, and reading positions — lives in iCloud Drive ▸ Vellum and syncs across your Macs."
+        case .custom:
+            return "Offline copies live in your folder. iCloud syncing is not available for a custom folder: highlights, notes, and reading positions stay on this Mac."
+        case .local:
+            return "Everything stays in Vellum's private app folder on this Mac. No syncing."
+        }
+    }
+
+    private var locationBinding: Binding<WebStorageMode> {
+        Binding(
+            get: { storageMode },
+            set: { newMode in
+                guard newMode != storageMode else { return }
+                switch newMode {
+                case .custom:
+                    // Cancelling the folder picker leaves the mode unchanged.
+                    guard let path = WebStorageRelocator.pickCustomFolder() else { return }
+                    WebStorageRelocator.apply(mode: .custom, customPath: path)
+                case .icloud:
+                    guard WebStorageSettings.icloudVellumRoot != nil else { return }
+                    WebStorageRelocator.apply(mode: .icloud)
+                case .local:
+                    WebStorageRelocator.apply(mode: .local)
+                }
+                refreshStorageSettings()
+                // The move runs in the background; refresh the listings once
+                // it has had a moment to relocate the artifacts.
+                Task {
+                    try? await Task.sleep(for: .seconds(1))
+                    await reload()
+                }
+            }
+        )
+    }
+
+    private var autoSaveBinding: Binding<Bool> {
+        Binding(
+            get: { autoSavePages },
+            set: { on in
+                autoSavePages = on
+                WebStorageSettings.setAutoSavePages(on)
+            }
+        )
+    }
+
+    private func refreshStorageSettings() {
+        storageMode = WebStorageSettings.chosenMode ?? .local
+        autoSavePages = WebStorageSettings.autoSavePages
     }
 
     private var totalBytes: Int64 {

--- a/Vellum/Views/Settings/StorageLocationChoiceSheet.swift
+++ b/Vellum/Views/Settings/StorageLocationChoiceSheet.swift
@@ -1,0 +1,182 @@
+import AppKit
+import SwiftUI
+
+// First-launch storage-location choice (and the shared apply/relocate runner
+// Settings reuses). The choice is explicit about the tradeoff: iCloud syncs
+// everything (offline copies AND highlights/notes/reading positions); a custom
+// folder holds only the offline copies while reading state stays local; This
+// Mac keeps the pre-existing Application Support layout.
+
+/// Applies a storage-location change: persist the preference, then move the
+/// store in the background. The pending-relocation marker makes an interrupted
+/// move resume at next launch.
+@MainActor
+enum WebStorageRelocator {
+    /// Back-to-back changes chain (each move awaits the previous one), and
+    /// only the newest change may clear the shared resume marker.
+    private static var relocationChain: Task<Void, Never>?
+    private static var relocationGeneration = 0
+
+    static func apply(mode: WebStorageMode, customPath: String? = nil) {
+        let previous = WebStorageSettings.chosenMode ?? .local
+        let previousCustomPath = UserDefaults.standard.string(forKey: WebStorageSettings.customPathKey)
+        let source = WebStorageLayout.resolve(mode: previous, storeDir: WebLibrary.storeDir)
+        let sourceReachable = previous == .local || WebStorageSettings.root(for: previous) != nil
+
+        WebStorageMigrator.recordPendingRelocation(mode: previous, customPath: previousCustomPath)
+        WebStorageSettings.setMode(mode, customPath: customPath)
+        // Capture the destination now, from the mode just set — resolving it
+        // inside the task could pick up a newer change's mode.
+        let destination = WebLibrary.activeLayout
+
+        guard sourceReachable else {
+            // Nothing can move while the old root is unreachable (iCloud
+            // signed out, folder unmounted). Keep the marker: the launch
+            // sweep migrates the stranded files when the root comes back.
+            return
+        }
+
+        relocationGeneration += 1
+        let generation = relocationGeneration
+        let prior = relocationChain
+        relocationChain = Task.detached(priority: .utility) {
+            await prior?.value
+            let clean = WebStorageMigrator.relocate(from: source, to: destination)
+            if clean {
+                await MainActor.run {
+                    if generation == relocationGeneration {
+                        WebStorageMigrator.clearPendingRelocation()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Folder picker for the custom mode; returns the chosen path or nil.
+    static func pickCustomFolder() -> String? {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Choose"
+        panel.message = "Vellum will keep offline copies of your web pages in this folder."
+        guard panel.runModal() == .OK, let url = panel.url else { return nil }
+        return url.path
+    }
+}
+
+/// One-time sheet shown at first launch after updating to (or installing) a
+/// build with configurable storage.
+struct StorageLocationChoiceSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.palette) private var palette
+
+    private var icloudAvailable: Bool { WebStorageSettings.icloudVellumRoot != nil }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Where should Vellum keep your library?")
+                    .font(.title2.weight(.semibold))
+                Text("Vellum stores offline copies of web pages, plus your highlights, notes, and reading positions. You can change this anytime in Settings ▸ Storage.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            choiceCard(
+                title: "Use iCloud Drive",
+                badge: icloudAvailable ? "Recommended" : nil,
+                systemImage: "icloud",
+                description: icloudAvailable
+                    ? "Everything — offline copies, highlights, notes, and reading positions — lives in iCloud Drive ▸ Vellum and syncs across your Macs."
+                    : "iCloud Drive isn't available on this Mac. Sign in to iCloud and enable iCloud Drive to use this option.",
+                disabled: !icloudAvailable,
+                identifier: "storageChoice.icloud"
+            ) {
+                WebStorageRelocator.apply(mode: .icloud)
+                dismiss()
+            }
+
+            choiceCard(
+                title: "Choose a Folder…",
+                badge: nil,
+                systemImage: "folder",
+                description: "Offline copies go in a folder you pick. Your highlights, notes, and reading positions stay on this Mac and won't sync.",
+                disabled: false,
+                identifier: "storageChoice.custom"
+            ) {
+                guard let path = WebStorageRelocator.pickCustomFolder() else { return }
+                WebStorageRelocator.apply(mode: .custom, customPath: path)
+                dismiss()
+            }
+
+            choiceCard(
+                title: "Keep on This Mac",
+                badge: nil,
+                systemImage: "internaldrive",
+                description: "Everything stays in Vellum's private app folder, like before. No syncing.",
+                disabled: false,
+                identifier: "storageChoice.local"
+            ) {
+                WebStorageRelocator.apply(mode: .local)
+                dismiss()
+            }
+        }
+        .padding(24)
+        .frame(width: 480)
+        // .contain keeps each option button its own AX element with its own
+        // identifier — without it the container id shadows all three buttons
+        // (same gotcha as the Storage rows in SettingsView).
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("storageChoice.sheet")
+    }
+
+    private func choiceCard(
+        title: String,
+        badge: String?,
+        systemImage: String,
+        description: String,
+        disabled: Bool,
+        identifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.title3)
+                    .foregroundStyle(disabled ? AnyShapeStyle(.tertiary) : AnyShapeStyle(palette.primary))
+                    .frame(width: 26)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 8) {
+                        Text(title)
+                            .font(.body.weight(.medium))
+                        if let badge {
+                            Text(badge)
+                                .font(.caption2.weight(.semibold))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(palette.primary.opacity(0.15), in: Capsule())
+                                .foregroundStyle(palette.primary)
+                        }
+                    }
+                    Text(description)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 10))
+            .contentShape(RoundedRectangle(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .opacity(disabled ? 0.55 : 1)
+        .accessibilityIdentifier(identifier)
+    }
+}

--- a/Vellum/Views/Settings/StorageLocationChoiceSheet.swift
+++ b/Vellum/Views/Settings/StorageLocationChoiceSheet.swift
@@ -10,12 +10,36 @@ import SwiftUI
 /// Applies a storage-location change: persist the preference, then move the
 /// store in the background. The pending-relocation marker makes an interrupted
 /// move resume at next launch.
+///
+/// Every relocation in the app — the launch sweep and each user change — goes
+/// through here, because they all move the same files and share one resume
+/// marker. Two passes running at once would race on both.
 @MainActor
 enum WebStorageRelocator {
-    /// Back-to-back changes chain (each move awaits the previous one), and
+    /// Back-to-back moves chain (each awaits the previous one), and
     /// only the newest change may clear the shared resume marker.
     private static var relocationChain: Task<Void, Never>?
     private static var relocationGeneration = 0
+
+    /// Queue relocation work behind whatever is already in flight.
+    @discardableResult
+    private static func enqueue(_ work: @escaping @Sendable () async -> Void) -> Task<Void, Never> {
+        let prior = relocationChain
+        let task = Task.detached(priority: .utility) {
+            await prior?.value
+            await work()
+        }
+        relocationChain = task
+        return task
+    }
+
+    /// Launch pass: resume an interrupted move and fold in legacy-local strays.
+    /// Awaits its turn on the chain — the first-launch sheet can hand us a new
+    /// destination while this is still queued — and awaits completion, since
+    /// callers go on to walk the store this sweep is still moving.
+    static func sweepAtLaunch() async {
+        await enqueue { WebStorageMigrator.sweepAtLaunch() }.value
+    }
 
     static func apply(mode: WebStorageMode, customPath: String? = nil) {
         let previous = WebStorageSettings.chosenMode ?? .local
@@ -38,15 +62,11 @@ enum WebStorageRelocator {
 
         relocationGeneration += 1
         let generation = relocationGeneration
-        let prior = relocationChain
-        relocationChain = Task.detached(priority: .utility) {
-            await prior?.value
-            let clean = WebStorageMigrator.relocate(from: source, to: destination)
-            if clean {
-                await MainActor.run {
-                    if generation == relocationGeneration {
-                        WebStorageMigrator.clearPendingRelocation()
-                    }
+        enqueue {
+            guard WebStorageMigrator.relocate(from: source, to: destination) else { return }
+            await MainActor.run {
+                if generation == relocationGeneration {
+                    WebStorageMigrator.clearPendingRelocation()
                 }
             }
         }

--- a/Vellum/Views/Settings/StorageLocationChoiceSheet.swift
+++ b/Vellum/Views/Settings/StorageLocationChoiceSheet.swift
@@ -116,7 +116,7 @@ struct StorageLocationChoiceSheet: View {
                 title: "Keep on This Mac",
                 badge: nil,
                 systemImage: "internaldrive",
-                description: "Everything stays in Vellum's private app folder, like before. No syncing.",
+                description: "Everything stays in Vellum's private app folder. No syncing.",
                 disabled: false,
                 identifier: "storageChoice.local"
             ) {

--- a/plans/storage-design.html
+++ b/plans/storage-design.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Vellum Storage Architecture — Design (Issue #29)</title>
+<style>
+  :root {
+    --bg: #ffffff; --fg: #1c1c1e; --muted: #6e6e73; --accent: #b4530a;
+    --card: #f6f5f2; --border: #e2e0da; --code-bg: #f0efe9; --good: #2f7d32;
+    --bad: #b3261e; --warn: #9a6b00; --th-bg: #ece9e2;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #131313; --fg: #e8e6e1; --muted: #9a988f; --accent: #e8955c;
+      --card: #1d1c1a; --border: #33312c; --code-bg: #232220; --good: #7cc47f;
+      --bad: #e08c86; --warn: #d9b45b; --th-bg: #262521;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0 auto; max-width: 880px; padding: 3rem 1.5rem 6rem;
+    background: var(--bg); color: var(--fg);
+    font: 16px/1.65 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  h1 { font-size: 1.9rem; line-height: 1.25; margin: 0 0 .3rem; letter-spacing: -.01em; }
+  .subtitle { color: var(--muted); margin-bottom: 2.2rem; }
+  h2 { font-size: 1.35rem; margin: 3rem 0 .8rem; padding-top: 1.2rem; border-top: 1px solid var(--border); letter-spacing: -.01em; }
+  h3 { font-size: 1.08rem; margin: 1.8rem 0 .5rem; }
+  p, li { max-width: 74ch; }
+  code, pre { font: 13px/1.55 ui-monospace, "SF Mono", Menlo, monospace; }
+  code { background: var(--code-bg); padding: .12em .38em; border-radius: 4px; }
+  pre { background: var(--code-bg); padding: 1rem 1.2rem; border-radius: 8px; overflow-x: auto; border: 1px solid var(--border); }
+  pre code { background: none; padding: 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0 1.5rem; font-size: .92rem; }
+  th, td { text-align: left; padding: .5rem .7rem; border: 1px solid var(--border); vertical-align: top; }
+  th { background: var(--th-bg); font-weight: 600; }
+  .tldr { background: var(--card); border: 1px solid var(--border); border-left: 4px solid var(--accent); border-radius: 8px; padding: 1.1rem 1.4rem; margin: 1.5rem 0 2rem; }
+  .tldr strong { color: var(--accent); }
+  .good { color: var(--good); font-weight: 600; }
+  .bad { color: var(--bad); font-weight: 600; }
+  .warn { color: var(--warn); font-weight: 600; }
+  .pill { display: inline-block; font-size: .72rem; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; padding: .1em .55em; border-radius: 99px; border: 1px solid var(--border); color: var(--muted); margin-right: .4em; }
+  .note { color: var(--muted); font-size: .9rem; }
+  .decision { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: .9rem 1.2rem; margin: 1rem 0; }
+  .decision .label { font-size: .75rem; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; color: var(--accent); }
+  ul { padding-left: 1.3rem; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+
+<h1>Vellum Storage Architecture</h1>
+<div class="subtitle">Design for Issue #29 · accounts for scratchpad (PR #44), ai-experience (PR #41), on-demand retrieval (PR #46 / Issue #37) · July 11, 2026 · <strong>revised July 14</strong> after #41/#44/#45/#46/#48 merged to main</div>
+
+<div class="decision"><span class="label">Revision status — July 14, 2026</span><br>
+All feature branches this plan accounted for have <strong>merged to main</strong>, and PR #48 shipped two pieces of this plan early, in slightly different form than designed:
+<ul>
+  <li><span class="good">Shipped:</span> <strong>the persistent page-text cache</strong> (<code>PageTextCache.swift</code>, at <code>App Support/text-cache/</code>) — including this plan's key insight, hash-as-<em>validator</em>-not-key, refreshed after Vellum's own rewrites so annotating doesn't nuke the cache. Deviation: it keys by <code>sha256(path)</code> rather than a stable <code>DocumentID</code> (§3/§5 below, updated).</li>
+  <li><span class="good">Shipped:</span> <strong>Storage settings tab v1</strong> — cache-only: total size, per-document rows with size/recency/completeness, per-row delete + erase-all, the exact "notes and conversations are NOT affected" copy, a never-auto-delete "original file not found" hint, and launch-time 6-month TTL eviction.</li>
+  <li><span class="good">Shipped:</span> conversations got a <strong>write-behind cache</strong> (in-memory entries, coalesced 200 ms background flush, awaited on quit) fixing the worst of the blob-rewrite cost — though still in UserDefaults, still path-keyed. Messages now also persist per-response token/cost <code>usage</code>.</li>
+  <li><span class="warn">Unchanged:</span> scratchpad storage merged exactly as analyzed (UserDefaults blob, path keys, flat attachment pool, non-atomic writes); auto-archive still silently saves every opened page; no <code>DocumentID</code> anywhere.</li>
+</ul>
+§7's build plan is re-sequenced accordingly; the biggest remaining storage-growth hole is now the <strong>web archives</strong> (no size UI, no TTL, opening = permanent saving).
+</div>
+
+<div class="tldr">
+<strong>TL;DR.</strong> Vellum's best storage idea is already shipped: <em>annotations live inside the document</em>, so sharing a PDF shares the work. The problem is that everything the three in-flight branches add — scratchpad markdown, attachment images, AI conversations, extracted page text — is keyed by a <em>raw file path</em> and stored in UserDefaults or a flat app directory, so none of it survives a rename, move, or share. The fix is three moves, no backend, no accounts:
+<ol>
+  <li><strong>One document identity</strong> — a <code>/VellumDocId</code> UUID stamped into the PDF's Info dictionary (the app already writes custom Info keys), so identity travels with the file. Web docs keep their existing URL hash.</li>
+  <li><strong>A per-document folder</strong> under a relocatable library root — <code>documents/&lt;docId&gt;/</code> holding <code>scratchpad.md</code>, <code>attachments/</code>, <code>conversations.json</code>, <code>meta.json</code> — replacing the UserDefaults blobs. Derived data (page-text cache, auto-archives) moves to <code>~/Library/Caches</code> where eviction is guilt-free.</li>
+  <li><strong>A <code>.vellum</code> export bundle</strong> — document + its folder zipped with the existing MiniZip/manifest machinery — for "share with notes." A bare PDF share still carries annotations for free.</li>
+  <li><strong>A Settings → Storage pane</strong> governed by one rule — <em>nothing invisible</em>: every persisted byte is either visible in its document's context or listed here with a delete button. Per-document size rows (notes / chat / cache / archive), safe "clear all caches," TTL eviction, and an orphaned-data section. Needed because auto-archiving currently grows storage ~2× per page ever opened.</li>
+</ol>
+This is the issue thread's Option C (local-first, user-relocatable, iCloud-ready later), extended to cover the new features and made rename/move/share-proof.
+</div>
+
+<h2>1 · Where every byte lives today</h2>
+<p>Complete inventory across <code>main</code> and the three feature branches (verified in source, July 2026):</p>
+
+<table>
+<tr><th>Data</th><th>Branch</th><th>Location</th><th>Keyed by</th><th>Portable?</th></tr>
+<tr><td>PDF annotations, bookmarks, last page</td><td>main</td><td><strong>Inside the PDF</strong> (<code>/Annots</code>, <code>/Outlines</code>, <code>/Info</code>) via <code>PdfAnnotationCodec</code> + atomic rewrite</td><td>— (they <em>are</em> the file)</td><td class="good">Yes</td></tr>
+<tr><td>Web annotations + page record</td><td>main</td><td><code>App Support/web/&lt;key&gt;.json</code> sidecar</td><td><code>sha256(normalized URL)</code></td><td class="warn">Via .vellumweb export only</td></tr>
+<tr><td>.vellumweb archives (manifest, snapshot, assets, text, annotations)</td><td>main</td><td>Export path, or managed copy in <code>web/</code></td><td>URL in manifest; sha256 per part (integrity only)</td><td class="good">Yes — designed for it</td></tr>
+<tr><td>Recents (8 entries)</td><td>main</td><td>UserDefaults <code>vellum.recent-pdfs</code></td><td>raw path / URL</td><td class="bad">No</td></tr>
+<tr><td>AI conversations (25 docs × 120 msgs × 12K chars; per-message token <code>usage</code> since #48)</td><td>main / #41 / #48</td><td>UserDefaults <code>research-reader-ai-conversations-v1</code>, hand-serialized JSON string; since #48 fronted by an in-memory cache with a coalesced 200 ms background flush awaited on quit</td><td><code>DocumentInfo.pdfPath</code> raw string</td><td class="bad">No</td></tr>
+<tr><td>API keys + ChatGPT OAuth tokens</td><td>#41</td><td>macOS Keychain (<code>com.vellum.ai</code>), migrated out of plaintext UserDefaults</td><td>provider name</td><td>Correctly not portable</td></tr>
+<tr><td>AI settings (provider, models, pins), OpenRouter catalog cache</td><td>#41</td><td>UserDefaults</td><td>app-global</td><td>Fine as-is</td></tr>
+<tr><td>Scratchpad markdown (200 docs × 200K chars)</td><td>#44</td><td>UserDefaults <code>vellum.scratchpad.notes.v1</code> — <strong>one JSON blob for all documents</strong></td><td><code>DocumentInfo.pdfPath</code> raw string</td><td class="bad">No</td></tr>
+<tr><td>Scratchpad attachments (region snapshots, dropped images)</td><td>#44</td><td><code>App Support/scratchpad-attachments/&lt;uuid&gt;.&lt;ext&gt;</code> — flat pool, no per-doc namespace, O(n) dir-scan lookup</td><td>random UUID via <code>vellum-scratchpad://</code> refs</td><td class="bad">No</td></tr>
+<tr><td>Extracted page text (<code>pageTexts</code>)</td><td>#46 / <strong>#48: now persistent</strong></td><td><code>App Support/text-cache/&lt;pathKey&gt;.json</code> + <code>index.json</code> (<code>PageTextCache</code>): atomic writes, 6-month launch-time TTL, Settings UI. PDFs only; web docs load text up front</td><td><code>sha256(path)</code> key + partial content hash (size + first/last 4 MB) as validator, refreshed on in-app rewrites</td><td>n/a (derived)</td></tr>
+</table>
+
+<h3>The identity problem underneath everything</h3>
+<p>The app uses <strong>three inconsistent identity schemes</strong>: PDFs are their canonicalized filesystem path (<code>realpath</code>), web docs are <code>sha256(normalized URL)</code>, and every sidecar store (conversations, scratchpad, recents) keys on the raw <code>DocumentInfo.pdfPath</code> string. Nothing is content-addressed. Consequences:</p>
+<ul>
+  <li>Rename or move a PDF → its scratchpad, conversation history, and recents entry are silently orphaned. The data still exists, unreachable, counting against the 200/25-document eviction caps.</li>
+  <li>Share a PDF with someone (or with yourself on another Mac) → annotations arrive (embedded), but the scratchpad and chat stay behind — and could never re-attach anyway, because the recipient's path differs.</li>
+  <li>PR B's planned page-text cache wants content-hash keying — a <em>fourth</em> scheme — and a naive full-file hash breaks under Vellum's own design: every highlight atomically rewrites the whole PDF, so the hash churns on every annotation.</li>
+</ul>
+
+<h3>The efficiency problem</h3>
+<ul>
+  <li>PR #44's scratchpad debounce re-encodes <strong>every document's note</strong> into one blob and rewrites it through CFPreferences on each 400 ms save. At the design caps that's a ~40 MB value serialized per keystroke-pause. Same pattern as conversations (which additionally hand-roll JSON key ordering to fake LRU semantics — ~30 lines of byte-scanning workaround that exists only because UserDefaults was the wrong container).</li>
+  <li>Attachment resolution is a directory scan per image load; GC is a global scan of all notes on every tab switch.</li>
+  <li><span class="good">Fixed in #48:</span> a 900-page PDF used to re-extract its text every open; <code>PageTextCache</code> now restores it from disk. Remaining alignment items: it keys by path (rename = orphaned cache entry until TTL sweeps it) and lives in App Support rather than Caches — both cheap to fix once <code>DocumentID</code> exists, since all keying funnels through one <code>pathKey()</code> function.</li>
+  <li>Derived, re-creatable data (auto-archived <code>.vellumweb</code> copies, future text cache) sits in Application Support next to irreplaceable user data, so nothing can ever be safely evicted and backups/sync carry dead weight.</li>
+</ul>
+
+<h2>2 · Data taxonomy — four classes, four homes</h2>
+<p>Every current and future piece of state falls into one of four classes. The rule: <em>class determines home; no exceptions.</em></p>
+<table>
+<tr><th>Class</th><th>Examples</th><th>Home</th><th>Properties</th></tr>
+<tr><td><strong>A. Document-embedded</strong></td><td>PDF annotations, bookmarks, last page, <code>/VellumDocId</code>; .vellumweb contents</td><td>The document file itself</td><td>Travels with the file, zero effort. Keep exactly as-is.</td></tr>
+<tr><td><strong>B. Document-adjacent user data</strong></td><td>Scratchpad text + attachments, AI conversations, web sidecar records, per-doc metadata</td><td><code>&lt;libraryRoot&gt;/documents/&lt;docId&gt;/</code></td><td>Irreplaceable. Syncable. Exportable in a bundle. One folder per document.</td></tr>
+<tr><td><strong>C. Derived / re-creatable</strong></td><td>Page-text cache (PR B), managed auto-archives, OpenRouter catalog, future OCR/RAG indexes</td><td><code>~/Library/Caches/com.vellum.app/</code></td><td>Evictable without loss. Never synced, never exported, TTL cleanup guilt-free.</td></tr>
+<tr><td><strong>D. Device-scoped</strong></td><td>API keys, OAuth tokens → Keychain; theme, font size, provider/model prefs, recents → UserDefaults</td><td>Keychain / UserDefaults</td><td>Small scalars and secrets only. Never document data, never blobs.</td></tr>
+</table>
+<p>PR #41 already put class D right (Keychain migration — keep it verbatim). PR #44 put class B data in class D's home; PR B would put class C data in class B's home unless redirected. This taxonomy is the one-line review criterion for every future feature: <em>"which class is this, and is it in that class's home?"</em></p>
+
+<h2>3 · Document identity: <code>DocumentID</code></h2>
+<div class="decision"><span class="label">Decision</span><br>
+A single <code>DocumentID</code> string used by every class-B and class-C store, resolved per document kind:
+<ul>
+  <li><strong>Web</strong>: the existing <code>sha256(normalized URL)</code> — unchanged, byte-compatible with the Tauri-era library, nothing re-keys.</li>
+  <li><strong>PDF</strong>: a UUID stamped once into the Info dictionary as <code>/VellumDocId</code> — the same mechanism as the existing <code>/VellumLastPage</code>. The ID lives <em>in the file</em>, so move/rename/copy/AirDrop all preserve it, and a recipient's Vellum recognizes the document.</li>
+  <li><strong>Read-only PDF fallback</strong> (no write permission / locked): <code>sha256</code> of file bytes. Safe precisely because Vellum can't rewrite a file it can't write to, so the hash is stable. Final fallback: canonical path (today's behavior).</li>
+</ul>
+</div>
+<h3>Stamp lazily — never touch a file the user hasn't invested in</h3>
+<p>Do <strong>not</strong> stamp on open. Stamp on the first write Vellum was going to make anyway — first annotation, first metadata save — or on the first creation of class-B data (first scratchpad keystroke, first AI message). Until then, nothing needs a durable identity. This avoids "I opened a PDF and the app modified it," avoids an extra multi-MB atomic rewrite on every open, and piggybacks the stamp on an existing rewrite so it costs nothing.</p>
+<h3>Copies share an ID — that's a feature</h3>
+<p>Duplicating a PDF duplicates its ID, so both copies resolve to the same <code>documents/&lt;docId&gt;/</code> folder: your notes follow the document, not the path. This is the behavior a user who reorganizes folders actually wants. (If true fork-the-notes semantics are ever needed, "Duplicate as new document" can re-stamp — don't build it until asked for.)</p>
+<h3>Cache keying: half of this shipped in #48</h3>
+<p>The design called for the text cache to be keyed by <code>DocumentID</code> (stable under Vellum's own annotation rewrites) with a content hash used only as a <em>validation stamp</em>, refreshed when Vellum itself rewrites the PDF and invalidating only on external edits. The shipped <code>PageTextCache</code> implements the stamp mechanism exactly (partial hash over size + first/last 4 MB; <code>refreshHash</code> called by <code>PdfDocumentIO</code> after in-app writes) — independently arriving at the same reasoning, documented in its header comment. What it lacks is the stable key: it keys by <code>sha256(path)</code>, so a renamed PDF orphans its cache entry (shown as "original file not found" in Settings, swept by TTL, rebuilt from scratch at the new path). When <code>DocumentID</code> lands, re-keying is mechanical: all keying funnels through <code>PageTextCache.pathKey()</code>, and the validator logic transfers unchanged.</p>
+
+<h2>4 · Library layout</h2>
+<pre><code>&lt;libraryRoot&gt;/                      # default: ~/Library/Application Support/com.vellum.app/
+                                    # user-relocatable via Settings (Dropbox/iCloud Drive/syncthing)
+├── documents/
+│   └── &lt;docId&gt;/
+│       ├── meta.json               # kind, title, last-known path/URL(s), lastOpened, schema version
+│       ├── scratchpad.md           # plain markdown; image refs are RELATIVE: ![x](attachments/&lt;id&gt;.jpg)
+│       ├── attachments/
+│       │   └── &lt;uuid&gt;.jpg|png|gif  # region snapshots + dropped images, scoped to this document
+│       ├── conversations.json      # AI chat history for this document
+│       └── record.json             # (web docs) the sidecar record — later unification, see §7
+├── ai/
+│   ├── USER.md                     # agent memory (issue #37 follow-up): app-level, size-capped,
+│   └── SOUL.md                     #   user-editable, syncs with the library
+└── web/                            # existing store, unchanged initially (Tauri-compatible keys)
+
+~/Library/Caches/com.vellum.app/    # class C — never synced, evictable, TTL-cleaned
+├── text/&lt;docId&gt;.json               # PR B page-text cache: pages, scanned-page markers,
+│                                   #   completion flag, validation stamp; incremental/resumable
+└── archives/&lt;key&gt;/…                # managed auto-archives move here (user-SAVED pages stay in web/)
+</code></pre>
+<p>Why files, per document, instead of one database or one blob:</p>
+<ul>
+  <li><strong>Write cost is proportional to the edit.</strong> A scratchpad keystroke rewrites one small <code>scratchpad.md</code>, not an all-documents blob through CFPreferences. Use the existing tmp-file + <code>rename(2)</code> pattern (<code>WebLibrary.saveRecord</code> already does this) — PR #44's plain <code>Data.write</code> attachment saves should adopt it too.</li>
+  <li><strong>Sync conflict granularity = one document.</strong> Two Macs editing different documents never conflict; same document → last-writer-wins on a per-file basis, which is the acceptable worst case the issue thread already accepted for annotations.</li>
+  <li><strong>Human-legible and tool-friendly.</strong> <code>scratchpad.md</code> with <em>relative</em> image paths opens in Obsidian/any editor; the folder is greppable and Spotlight-indexable. (The editor's <code>vellum-scratchpad://</code> scheme handler becomes a load/save-time rewrite to relative paths, or resolves relative paths directly — implementation detail, but persist the portable form.)</li>
+  <li><strong>GC becomes trivial and correct.</strong> Attachments are scoped per document: prune = scan one note, not all 200; delete a document's data = delete one folder. The O(n) global directory scan and cross-document GC in PR #44 disappear.</li>
+  <li><strong>Eviction caps become unnecessary.</strong> The 25-conversation / 200-note LRU caps exist because a single plist value can't grow unbounded. Per-document files can just… exist. Settings can show per-document sizes (PR B already planned this UI for the cache — same list, one more column).</li>
+</ul>
+<h3>The auto-archive catch: today, opening = saving</h3>
+<p>The layout above assumes a distinction between pages the user chose to keep (<code>web/</code>) and archives created as a side effect (Caches). That distinction <strong>does not exist today</strong>: 1.5 s after any webpage loads, <code>archiveDefault</code> (<code>WebSessionBackend.swift:225</code>, triggered from <code>WebViewerView.swift:896</code>) re-fetches the page, writes the <code>.vellumweb</code> <em>and</em> the unpacked <code>archives/&lt;key&gt;/</code> mirror (~2× the bytes), and calls <code>markSavedIfAbsent</code> — so every page ever opened is silently promoted to "saved" and its archives are permanent. A user who reads widely accumulates storage they never asked for and can only shed one page at a time.</p>
+<div class="decision"><span class="label">Recommendation</span><br>
+Make saving explicit (a save button/toggle, as the sidecar's <code>saved</code> flag was clearly designed for) and demote on-open archives to class C: they live in Caches, still give instant offline reload and AI text, but are TTL-evictable and deletable in bulk from the Storage pane. Explicitly saved pages get the durable <code>web/</code> treatment. Annotating a page should auto-promote it to saved — annotations are user investment. If instead "everything I open is my library" is the intended UX, the Storage pane below still keeps it manageable — but the default should not be <em>permanent</em> either way.</div>
+
+<h2>5 · Portability: three tiers of sharing</h2>
+<table>
+<tr><th>Tier</th><th>What the user does</th><th>What travels</th><th>Cost to build</th></tr>
+<tr><td><strong>1. Share the file</strong></td><td>AirDrop / email the PDF or .vellumweb as-is</td><td>Annotations, bookmarks, reading position, <code>/VellumDocId</code></td><td class="good">Already works today</td></tr>
+<tr><td><strong>2. <code>.vellum</code> bundle</strong> — "Export with notes…"</td><td>One zip: the document + <code>manifest.json</code> + <code>scratchpad.md</code> + <code>attachments/</code> + (opt-in checkbox) <code>conversations.json</code></td><td>Everything</td><td>Small — reuse <code>MiniZip</code>, the manifest/sha256-verification pattern, and zip-slip guards from <code>WebArchive.swift</code> wholesale</td></tr>
+<tr><td><strong>3. Synced library</strong></td><td>Point <code>libraryRoot</code> at iCloud Drive / Dropbox in Settings</td><td>All class-B data across the user's Macs, continuously</td><td>Settings picker + one-time copy migration (the issue thread's Option C, ~150 lines)</td></tr>
+</table>
+<p>On import of a <code>.vellum</code> bundle: verify hashes, write the document where the user chooses, unpack the sidecar into <code>documents/&lt;docId&gt;/</code> (merge-prompt if the ID already exists locally). Because identity is embedded in the PDF, the recipient's app links everything with zero configuration. Conversations default to <em>excluded</em> from export — they're chat logs, often semi-private, and the checkbox makes sharing intent explicit.</p>
+<p class="note">Considered and rejected — embedding the scratchpad inside the PDF itself (PDF <code>/EmbeddedFiles</code> attachments): maximal portability, but every debounced scratchpad save would atomically rewrite the entire (possibly 500 MB) PDF, images bloat the document permanently, other viewers surface mystery attachments, and web documents have no equivalent. Wrong write-amplification trade for live data; tier 2 gets the same result at export time only.</p>
+
+<h2>6 · Sync &amp; backend posture</h2>
+<p>Local-first, no accounts, no server — confirming the issue thread's recommendation, now with more evidence:</p>
+<ul>
+  <li><strong>Supabase/backend: rejected.</strong> The document model is file-embedded by design; a central annotation database fights the architecture's best property. Accounts are friction for a reader app; you'd be hosting user data for no feature gain. Revisit only if collaboration/multi-user ever becomes a goal.</li>
+  <li><strong>SQLite/Core Data: rejected for class B.</strong> A single DB file is the worst possible sync-conflict unit, is opaque to users, and buys nothing at this scale (a power user has hundreds of documents, not millions of rows). Class C caches may use whatever format is convenient — they're disposable.</li>
+  <li><strong>iCloud: deferred, path preserved.</strong> Tier 3 gives motivated users sync now with any provider. When native sync is worth the entitlement + testing overhead, swap <code>libraryRoot</code> for the ubiquity container and add <code>NSFilePresenter</code> observation — the per-document-folder layout is exactly what iCloud Drive syncs well. Nothing in this design has to be redone.</li>
+</ul>
+
+<h2>7 · Migration &amp; sequencing <span class="note">(re-sequenced July 14 — all feature PRs merged; PR B + Storage tab v1 shipped in #48)</span></h2>
+<h3>Storage PR 0 — web-archive management + explicit save <span class="pill">new · next up</span></h3>
+<p>With the text cache shipped and UI-managed, the web archives are now the only storage surface that grows unbounded with zero visibility: every opened page permanently stores a <code>.vellumweb</code> + an unpacked mirror (~2×) and is silently marked saved. Independent of <code>DocumentID</code>, so it can ship first:</p>
+<ul>
+  <li>Decide the §4 question (recommendation: explicit save; annotating auto-promotes; on-open archives become evictable, TTL'd like the text cache).</li>
+  <li>Extend the shipped Storage tab with a <em>Web pages</em> section: per-page rows (title, size of record + archives, last opened, saved vs auto), row delete, bulk "remove archives older than…". Reuses the exact row/dialog/TTL patterns <code>StorageSettingsTab</code> and <code>PageTextCache.evictStale</code> just established.</li>
+</ul>
+<h3>Storage PR 1 — identity + document store (the core)</h3>
+<ul>
+  <li><code>DocumentID</code> resolver (web hash / <code>/VellumDocId</code> read + lazy stamp / byte-hash fallback / path fallback).</li>
+  <li><code>DocumentDataStore</code>: the <code>documents/&lt;docId&gt;/</code> layout, atomic writes, one facade API that <code>ScratchpadStore</code>/<code>ScratchpadPersistence</code> and <code>AiPersistence</code> retarget to. Both already isolate persistence behind small enums, so this is a backend swap, not a refactor. Preserve #48's semantics in the swap: the in-memory-cache + coalesced-flush + await-on-quit contract for conversations (simpler now — flushing one document writes one small file, not the cross-document blob), and round-trip the new per-message <code>usage</code> field.</li>
+  <li>Re-key <code>PageTextCache</code> from <code>sha256(path)</code> to <code>DocumentID</code> (single <code>pathKey()</code> chokepoint; validator untouched) and optionally relocate <code>text-cache/</code> to <code>~/Library/Caches</code> per the §2 taxonomy — a one-time move, since a cold cache just rebuilds.</li>
+  <li>Cleanups inherited from the merged scratchpad PR: tmp+rename for attachment writes; persist markdown image refs as relative <code>attachments/…</code> paths (so a document's folder is portable standard Markdown).</li>
+  <li><strong>Lazy migration</strong>, not big-bang: legacy UserDefaults blobs stay as a read-fallback. When a document is opened and acquires its ID, its scratchpad + conversation entries migrate into the folder and are removed from the blobs. No mass PDF-stamping pass, no touching files at migration time. After ~a release cycle, an idle-time sweep migrates leftovers whose paths still resolve; truly orphaned entries surface in Settings for export-or-delete.</li>
+  <li>Attachment ownership for migration: the markdown refs in each note identify which document owns which attachment — move files into the owning folder during that document's lazy migration.</li>
+  <li>Recents gain a <code>docId</code> field beside the path: when the path 404s, re-resolve by ID before giving up (fixes the silent dead-recent today).</li>
+</ul>
+<h3><s>Storage PR 2 — PR B lands in Caches</s> <span class="pill">shipped in #48</span></h3>
+<p class="note">The page-text cache, TTL eviction, and the cache section of the Storage pane all shipped in PR #48 (see revision status at top). The two deviations from this plan — path keying and the App Support location — are absorbed into Storage PR 1 above as small alignment items. The archive sections originally scoped here moved up to Storage PR 0.</p>
+<h3>Storage PR 3 — portability surface</h3>
+<ul>
+  <li>Relocatable <code>libraryRoot</code> setting + copy-migration (the issue thread's Option C sketch, applied to <code>documents/</code> + <code>ai/</code> + <code>web/</code>).</li>
+  <li><code>.vellum</code> bundle export/import (tier 2).</li>
+  <li><strong>Storage pane v2</strong>: the per-document user-data list and the orphans/relink section of §8 (needs PR 1's <code>DocumentID</code> + <code>meta.json</code> to exist and lazy migration to have run for a while).</li>
+  <li>Later, separately: unify <code>web/&lt;key&gt;.json</code> into <code>documents/&lt;docId&gt;/record.json</code> (web <code>docId</code> = the same sha256 key, so this is a file move, not a re-key). Keep it out of PR 1 to avoid destabilizing Tauri-era compatibility while the identity layer beds in.</li>
+</ul>
+<p class="note">The original "review checklist for in-flight PRs" is obsolete — all merged. Its asks are folded into Storage PR 1 above. One durable observation survives: every store kept its identity logic behind a single <code>documentKey()</code>/<code>pathKey()</code> chokepoint (scratchpad, conversations, text cache alike), so the <code>DocumentID</code> swap remains a four-call-site change.</p>
+
+<h2>8 · Storage management UI — the "nothing invisible" rule</h2>
+<p>Guiding principle (owner decision, July 11 2026): <strong>the app must not persist anything the user cannot see and delete.</strong> Storage that only ever grows, in places only Finder archaeology can find, is a bug even when each individual write is justified. Two consequences:</p>
+<ul>
+  <li><strong>Delete means delete.</strong> The chat panel's clear button already hard-deletes the persisted conversation — <code>clearConversation()</code> (<code>AiStore.swift:135</code>) saves an empty list and <code>AiPersistence</code> removes the entry outright. The new <code>DocumentDataStore</code> must preserve this as a contract: clearing chat deletes <code>conversations.json</code>; clearing the scratchpad deletes <code>scratchpad.md</code> and its now-unreferenced attachments; a folder with no remaining files is removed. Same for the Storage pane's row actions.</li>
+  <li><strong>No invisible hoards.</strong> Today's design violates the rule twice: conversations are retained for up to 25 documents but <em>no UI lists them</em> — only the active document's history is ever visible — and path-keyed entries orphaned by a rename can never be seen again by anyone. The <code>DocumentID</code> layer fixes the orphaning; the Storage pane fixes the visibility.</li>
+</ul>
+<h3>Settings → Storage pane</h3>
+<p>One pane covering all four data classes. <strong>v1 shipped in #48</strong> (<code>StorageSettingsTab</code>): the extracted-text-cache sections — total size, per-document rows with size/recency/completeness, per-row delete and erase-all with exactly the reassurance copy specified below, a "original file not found" hint that never auto-deletes, and a fixed 6-month launch-time TTL. The table below is the target end state; unshipped parts are the summary tiles, the <em>web archives</em> section (→ Storage PR 0), the per-document <em>user data</em> breakdown and orphans/relink (→ Storage PR 3, needs <code>DocumentID</code>), and making the TTL user-adjustable.</p>
+<table>
+<tr><th>Section</th><th>Shows</th><th>Actions</th></tr>
+<tr><td><strong>Summary tiles</strong></td><td>Three totals: <em>Your data</em> (documents/ + web/ sidecars), <em>Web archives</em>, <em>Caches</em> — with one line of copy each stating what is irreplaceable vs re-creatable</td><td>"Clear all caches" (always safe); "Remove archives older than…" bulk action</td></tr>
+<tr><td><strong>Per-document list</strong></td><td>One row per <code>documents/&lt;docId&gt;/</code> ∪ cache entry ∪ web record: title, kind, last opened (own stamp from <code>meta.json</code>, not filesystem atime), total size, expandable breakdown — notes+attachments / chat / text cache / archive</td><td>Row-level: delete chat · delete notes · delete cache · remove archive · <em>delete everything for this document</em>. Sort by size / last opened. Active document's cache excluded from bulk eviction (per PR B plan)</td></tr>
+<tr><td><strong>Orphans &amp; unlinked</strong></td><td>Entries whose source file no longer resolves at its last-known path (from <code>meta.json</code>), plus legacy path-keyed blobs left after lazy migration</td><td>Relink (pick the moved file — ID re-verifies it) · export bundle · delete. Never auto-deleted: a missing path may be an unplugged drive or offloaded cloud file, per PR B's own caution</td></tr>
+<tr><td><strong>Housekeeping</strong></td><td>TTL settings: text-cache eviction (~6 months unopened, PR B default) and — if the §4 recommendation is adopted — on-open archive retention</td><td>Toggle/adjust; "run cleanup now"</td></tr>
+</table>
+<p>Copy rules for every destructive control: state exactly what is lost and what is not (PR B's planned "notes, highlights and conversations are NOT affected" warning generalizes: cache/archive deletions reassure; chat/notes deletions warn). Deleting derived data never asks twice; deleting user data always confirms with the document title in the prompt.</p>
+<p class="note">Everything the pane needs is already in the design: sizes from <code>FileManager</code> over per-document folders, recency from <code>meta.json</code>'s own stamp, identity from <code>DocumentID</code>. No index or database required — the directory layout <em>is</em> the data model.</p>
+
+<h2>9 · Open questions</h2>
+<ul>
+  <li><strong>Explicit save vs. everything-saved for webpages</strong> — §4's recommendation (explicit save; on-open archives become evictable cache; annotating auto-promotes). Owner call on the UX; the Storage pane works under either.</li>
+  <li><strong>Conversations in bundles</strong> — default-off checkbox proposed above; confirm.</li>
+  <li><strong>Sandboxing</strong> — the app is currently unsandboxed (no entitlements file), which is why bare paths work. If Mac App Store distribution ever matters, recents/meta.json paths need security-scoped bookmarks; the <code>DocumentID</code> layer makes that an additive change, but decide before building tier-3 sync UI.</li>
+  <li><strong>.vellumweb v2</strong> — fold <code>scratchpad.md</code> + attachments into the archive itself (bump manifest <code>version</code>) vs. always using the <code>.vellum</code> wrapper for web docs too. Wrapper-always is simpler; one format fewer to version.</li>
+  <li><strong>USER.md / SOUL.md caps</strong> — the Hermes-style bounded-write policy from issue #37 (per-write character budget, app-level file) — spec when that feature is picked up; the layout already reserves <code>ai/</code>.</li>
+</ul>
+
+<p class="note" style="margin-top:3rem">Sources: source-verified inventories of branch <code>storage</code> (= main), PR #44 (<code>scratchpad</code>), PR #41 (<code>ai-experience</code>), PR #46 (<code>ai-ondemand-retrieval</code>); issue #29 thread (matrix-hermes Options A/B/C analysis); issue #37 decision comments and cost audit.</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Introduces a one-time storage-location picker at launch (iCloud Drive, custom folder, or this Mac), also reachable in Settings ▸ Storage
- iCloud Drive layout stores offline copies in a human-navigable `Web Pages/` folder using page titles as filenames (`<Title>.vellumweb`); reading state (highlights, notes, positions) stays local and does not sync for the custom-folder option
- Background migration moves existing libraries between layouts; interrupted moves resume at next launch with merge semantics (destination fields win on conflict, but annotations written to the source after the switch are preserved)
- Adds `WebStorage.swift` (`WebStorageLayout`, `WebStorageSettings`, `WebStorageMigrator`, `WebArchiveIndex`) and `StorageLocationChoiceSheet.swift` as new source files
- Offline saving is now explicit: pages are no longer saved on open; the web toolbar collapses its two save actions into a single **Save for Offline Use / Remove Offline Copy** toggle; "Export a Copy…" remains for portable archives
- New opt-in in Settings ▸ Storage to auto-save every visited page (off by default); auto-saved pages are exempt from the six-month TTL cleanup
- Annotating a page promotes it to saved (sets `saved = true` and stamps `savedAt`), ensuring annotated pages are never evicted
- Launch-time eviction now also sweeps web-snapshot artifacts for pages that were never saved or annotated, in addition to the existing page-text cache sweep
- Drops "like before" from the Keep on This Mac copy for clarity
- Adds `WebLibraryStorageTests` (explicit-save semantics, TTL eviction, storage listing) and `WebStorageLocationTests` (layout resolution, pretty-name index, relocation, merge, removal) — 496 lines of new tests

## Testing

- [ ] First launch after install shows the storage-location choice sheet; selecting iCloud Drive and confirming migrates the existing library and creates `iCloud Drive/Vellum/Web Pages/`
- [ ] Switching location in Settings ▸ Storage triggers migration; files appear at the new path and are removed from the old one
- [ ] Interrupting a migration mid-way (force-quit) and relaunching resumes and completes without corruption
- [ ] Two records present in both source and destination locations are merged correctly (destination wins on field conflicts, late annotations from source are preserved)
- [ ] Saving a page via the toolbar toggle writes a `.vellumweb` file named after the page title in the active archives directory; removing it deletes the file but leaves highlights, notes, and reading position intact
- [ ] Annotating a previously unsaved page sets `saved = true` and prevents it from being evicted at next launch
- [ ] Pages last opened more than six months ago with `saved = false` and no annotations have their snapshot artifacts removed on launch; their records (reading state) survive
- [ ] Auto-save toggle in Settings ▸ Storage saves every opened page and marks those pages as TTL-exempt
- [ ] `WebLibraryStorageTests` and `WebStorageLocationTests` pass (`⌘U` in Xcode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time launch flow to choose where downloaded web pages are stored (iCloud Drive, a custom folder, or this Mac).
  * New Storage UI for downloaded web pages, including per-page details, sizes, and controls to remove individual or all offline copies.
  * Optional setting to auto-save every web page for offline reading.
* **Improvements**
  * Offline pages are saved as human-readable `.vellumweb` files per page in a visible **Web Pages** folder.
  * The offline-copy toolbar control is now a single toggle that saves or removes the offline copy while preserving your highlights/notes and reading position.
  * Adding highlights/notes and creating annotations now ensures the page is saved; stale unsaved offline snapshots are cleaned up automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->