### PR TITLE
Add pin-to-top for annotations in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ conflict markers, leaving `main` uncompilable), landing the final
 
 ### Added
 
+- **Pin any annotation to the top of the list.** Highlights, notes, and
+  bookmarks can be pinned from the annotations sidebar (pin button on hover,
+  or the row context menu). Pinned items float above the rest, stay pinned
+  across reopen, and work for both PDFs (embedded `/VellumPinned`) and web
+  pages (`is_pinned` in the JSON sidecar).
 - **Your notes now follow the document, not its path.** Vellum stamps a
   durable identity (`/VellumDocId`) into a PDF the first time it writes to it
   — never just for opening — so renaming, moving, or copying a file no

--- a/Tests/PdfPersistenceTests.swift
+++ b/Tests/PdfPersistenceTests.swift
@@ -423,6 +423,76 @@ final class PdfPersistenceTests: XCTestCase {
         XCTAssertFalse(missing)
     }
 
+    /// Pinning a highlight (or note) stamps /VellumPinned, survives reopen,
+    /// floats the annotation to the front of the list, and can be cleared.
+    func testPinHighlightPersistsAndSortsFirst() async throws {
+        let path = makeTestPdf(name: "pin-highlight")
+        let session = try await openSession(path)
+        let early = try await session.createAnnotation(CreateAnnotationInput(
+            type: .highlight,
+            pageNumber: 1,
+            color: "#fef08a",
+            content: nil,
+            positionData: position(AnnotationRect(x: 72, y: 100, width: 100, height: 16))))
+        let late = try await session.createAnnotation(CreateAnnotationInput(
+            type: .note,
+            pageNumber: 2,
+            color: nil,
+            content: "later note",
+            positionData: position(AnnotationRect(x: 40, y: 40, width: 0, height: 0))))
+
+        var annotations = try await session.annotations(pageNumber: nil)
+        XCTAssertEqual(annotations.map(\.id), [early.id, late.id], "unpinned order is page then create")
+
+        let pinned = try await session.updateAnnotation(UpdateAnnotationInput(
+            id: late.id, color: nil, content: nil, positionData: nil, isPinned: true))
+        XCTAssertTrue(pinned)
+
+        // Raw key on the note annotation.
+        let dictionary = try XCTUnwrap(rawAnnotation(path, page: 2, nm: late.id))
+        XCTAssertEqual(CgPdf.integer(dictionary, "VellumPinned"), 1)
+
+        // Fresh session: pin survives and sorts first.
+        annotations = try await openSession(path).annotations(pageNumber: nil)
+        XCTAssertEqual(annotations.map(\.id), [late.id, early.id])
+        let read = try XCTUnwrap(annotations.first { $0.id == late.id })
+        XCTAssertTrue(read.pinned)
+
+        // Unpin restores page/create order.
+        let unpinned = try await openSession(path).updateAnnotation(UpdateAnnotationInput(
+            id: late.id, color: nil, content: nil, positionData: nil, isPinned: false))
+        XCTAssertTrue(unpinned)
+        annotations = try await openSession(path).annotations(pageNumber: nil)
+        XCTAssertEqual(annotations.map(\.id), [early.id, late.id])
+        XCTAssertFalse(try XCTUnwrap(annotations.first { $0.id == late.id }).pinned)
+    }
+
+    /// Outline bookmarks also accept pin updates (via the incremental path
+    /// PDFKit cannot take for custom outline keys).
+    func testPinBookmarkPersistsAndSortsFirst() async throws {
+        let path = makeTestPdf(name: "pin-bookmark")
+        let session = try await openSession(path)
+        let page2 = try await session.createAnnotation(CreateAnnotationInput(
+            type: .bookmark, pageNumber: 2, color: nil, content: nil, positionData: nil))
+        let page1 = try await session.createAnnotation(CreateAnnotationInput(
+            type: .bookmark, pageNumber: 1, color: nil, content: nil, positionData: nil))
+
+        var annotations = try await session.annotations(pageNumber: nil)
+        XCTAssertEqual(annotations.map(\.id), [page1.id, page2.id])
+
+        let pinned = try await session.updateAnnotation(UpdateAnnotationInput(
+            id: page2.id, color: nil, content: nil, positionData: nil, isPinned: true))
+        XCTAssertTrue(pinned)
+
+        let items = rawOutlineItems(path)
+        let item = try XCTUnwrap(items.first { CgPdf.string($0, "VellumNM") == page2.id })
+        XCTAssertEqual(CgPdf.integer(item, "VellumPinned"), 1)
+
+        annotations = try await openSession(path).annotations(pageNumber: nil)
+        XCTAssertEqual(annotations.map(\.id), [page2.id, page1.id])
+        XCTAssertTrue(try XCTUnwrap(annotations.first { $0.id == page2.id }).pinned)
+    }
+
     func testDeleteHighlight() async throws {
         let path = makeTestPdf(name: "delete")
         let session = try await openSession(path)

--- a/Tests/PdfPersistenceTests.swift
+++ b/Tests/PdfPersistenceTests.swift
@@ -491,6 +491,19 @@ final class PdfPersistenceTests: XCTestCase {
         annotations = try await openSession(path).annotations(pageNumber: nil)
         XCTAssertEqual(annotations.map(\.id), [page2.id, page1.id])
         XCTAssertTrue(try XCTUnwrap(annotations.first { $0.id == page2.id }).pinned)
+
+        // Unpin runs the same incremental outline rewrite in reverse.
+        let unpinned = try await openSession(path).updateAnnotation(UpdateAnnotationInput(
+            id: page2.id, color: nil, content: nil, positionData: nil, isPinned: false))
+        XCTAssertTrue(unpinned)
+
+        let clearedItems = rawOutlineItems(path)
+        let cleared = try XCTUnwrap(clearedItems.first { CgPdf.string($0, "VellumNM") == page2.id })
+        XCTAssertEqual(CgPdf.integer(cleared, "VellumPinned"), 0)
+
+        annotations = try await openSession(path).annotations(pageNumber: nil)
+        XCTAssertEqual(annotations.map(\.id), [page1.id, page2.id], "unpin restores page order")
+        XCTAssertFalse(try XCTUnwrap(annotations.first { $0.id == page2.id }).pinned)
     }
 
     func testDeleteHighlight() async throws {

--- a/Tests/WebLibraryStorageTests.swift
+++ b/Tests/WebLibraryStorageTests.swift
@@ -110,6 +110,37 @@ final class WebLibraryStorageTests: XCTestCase {
         XCTAssertEqual(WebLibrary.loadRecord(at: recordPath)?.savedAt, originalSavedAt)
     }
 
+    /// Pinning a web annotation writes `is_pinned` into the JSON sidecar and
+    /// floats it to the front of getAnnotations order.
+    func testPinAnnotationPersistsAndSortsFirst() async throws {
+        let url = "https://example.com/pin-me"
+        let key = WebLibrary.pageKey(url)
+        try WebLibrary.saveRecord(WebPageRecord(url: url), at: WebLibrary.recordPath(forKey: key))
+        let io = WebDocumentIO(url: url, key: key)
+
+        let first = try await io.createAnnotation(
+            CreateAnnotationInput(type: .highlight, pageNumber: 1, content: "a"),
+            storedHighlightColor: "#fde68a")
+        let second = try await io.createAnnotation(
+            CreateAnnotationInput(type: .note, pageNumber: 2, content: "b"),
+            storedHighlightColor: "#fde68a")
+
+        var list = await io.annotations(pageNumber: nil)
+        XCTAssertEqual(list.map(\.id), [first.id, second.id])
+
+        let updated = try await io.updateAnnotation(UpdateAnnotationInput(
+            id: second.id, color: nil, content: nil, positionData: nil, isPinned: true))
+        XCTAssertTrue(updated)
+
+        list = await io.annotations(pageNumber: nil)
+        XCTAssertEqual(list.map(\.id), [second.id, first.id])
+        XCTAssertTrue(try XCTUnwrap(list.first).pinned)
+
+        let record = try XCTUnwrap(WebLibrary.loadRecord(forKey: key))
+        let stored = try XCTUnwrap(record.annotations.first { $0.id == second.id })
+        XCTAssertEqual(stored.isPinned, true)
+    }
+
     // MARK: - TTL eviction
 
     func testEvictionRemovesOnlyStaleUnsavedArtifacts() throws {

--- a/Tests/WebLibraryStorageTests.swift
+++ b/Tests/WebLibraryStorageTests.swift
@@ -139,6 +139,14 @@ final class WebLibraryStorageTests: XCTestCase {
         let record = try XCTUnwrap(WebLibrary.loadRecord(forKey: key))
         let stored = try XCTUnwrap(record.annotations.first { $0.id == second.id })
         XCTAssertEqual(stored.isPinned, true)
+
+        // The decoded model round-trips through the same coding keys, so pin
+        // the literal snake_case name other clients read.
+        let data = try Data(contentsOf: WebLibrary.recordPath(forKey: key))
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let rawAnnotations = try XCTUnwrap(json["annotations"] as? [[String: Any]])
+        let raw = try XCTUnwrap(rawAnnotations.first { ($0["id"] as? String) == second.id })
+        XCTAssertEqual(raw["is_pinned"] as? Bool, true)
     }
 
     // MARK: - TTL eviction

--- a/Vellum/Models/Models.swift
+++ b/Vellum/Models/Models.swift
@@ -54,6 +54,9 @@ struct Annotation: Codable, Equatable, Identifiable, Sendable {
     var positionData: PositionData?
     var createdAt: String
     var updatedAt: String
+    /// Pinned annotations float to the top of the sidebar list. Optional so
+    /// records written before pinning existed decode cleanly (missing → false).
+    var isPinned: Bool? = nil
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -64,6 +67,29 @@ struct Annotation: Codable, Equatable, Identifiable, Sendable {
         case positionData = "position_data"
         case createdAt = "created_at"
         case updatedAt = "updated_at"
+        case isPinned = "is_pinned"
+    }
+
+    /// True when the user has pinned this annotation.
+    var pinned: Bool { isPinned == true }
+
+    /// Sidebar / backend list order: pinned first, then page, then created_at.
+    /// `enumerated` keeps relative order stable when the sort keys tie.
+    static func sortedForDisplay(_ annotations: [Annotation]) -> [Annotation] {
+        annotations.enumerated()
+            .sorted { left, right in
+                if left.element.pinned != right.element.pinned {
+                    return left.element.pinned && !right.element.pinned
+                }
+                if left.element.pageNumber != right.element.pageNumber {
+                    return left.element.pageNumber < right.element.pageNumber
+                }
+                if left.element.createdAt != right.element.createdAt {
+                    return left.element.createdAt < right.element.createdAt
+                }
+                return left.offset < right.offset
+            }
+            .map(\.element)
     }
 }
 
@@ -88,6 +114,8 @@ struct UpdateAnnotationInput: Sendable {
     /// Web highlight resizes can cross a virtual page break; PDF annotations
     /// never move pages, so the PDF backend ignores this.
     var pageNumber: Int? = nil
+    /// When set, pin or unpin the annotation in the sidebar list.
+    var isPinned: Bool? = nil
 }
 
 enum DocumentKind: String, Codable, Sendable {

--- a/Vellum/Services/Pdf/PdfAnnotationCodec.swift
+++ b/Vellum/Services/Pdf/PdfAnnotationCodec.swift
@@ -150,6 +150,7 @@ enum PdfAnnotationReader {
         let now = PdfDates.rfc3339Now()
         let createdAt = CgPdf.string(dictionary, "VellumCreatedAt") ?? now
         let updatedAt = CgPdf.string(dictionary, "VellumUpdatedAt") ?? now
+        let isPinned = CgPdf.integer(dictionary, "VellumPinned") == 1 ? true : nil
 
         return Annotation(
             id: id,
@@ -159,7 +160,8 @@ enum PdfAnnotationReader {
             content: content,
             positionData: position,
             createdAt: createdAt,
-            updatedAt: updatedAt)
+            updatedAt: updatedAt,
+            isPinned: isPinned)
     }
 
     /// read_position: highlights from /QuadPoints (one UI rect per quad,

--- a/Vellum/Services/Pdf/PdfBookmarks.swift
+++ b/Vellum/Services/Pdf/PdfBookmarks.swift
@@ -48,6 +48,7 @@ enum PdfBookmarks {
                    pageNumber == nil || pageNumber == page
                 {
                     let now = PdfDates.rfc3339Now()
+                    let isPinned = CgPdf.integer(current, "VellumPinned") == 1 ? true : nil
                     bookmarks.append(Annotation(
                         id: id,
                         type: .bookmark,
@@ -56,7 +57,8 @@ enum PdfBookmarks {
                         content: nil,
                         positionData: nil,
                         createdAt: CgPdf.string(current, "VellumCreatedAt") ?? now,
-                        updatedAt: CgPdf.string(current, "VellumUpdatedAt") ?? now))
+                        updatedAt: CgPdf.string(current, "VellumUpdatedAt") ?? now,
+                        isPinned: isPinned))
                 }
                 walk(CgPdf.dictionary(current, "First"))
                 item = CgPdf.dictionary(current, "Next")
@@ -174,6 +176,36 @@ enum PdfBookmarks {
         adjustOutlineCount(&root, delta: 1)
         increment.setObject(outlinesNumber, source: root.sourceBytes)
 
+        return increment.appended()
+    }
+
+    // MARK: - Update (incremental update)
+
+    /// Patch pin state on an outline bookmark. Returns nil when no Vellum
+    /// bookmark carries the id. PDFKit cannot write custom keys on outline
+    /// items, so this rewrites the outline object in place.
+    static func updateBookmarkIncrement(
+        normalizedData: Data,
+        id: String,
+        isPinned: Bool,
+        now: String
+    ) throws -> Data? {
+        let file = try ClassicPdfFile(data: normalizedData)
+        guard let catalogNumber = file.rootNumber, let catalog = file.objectSource(catalogNumber),
+              let outlinesNumber = catalog.reference(forKey: "Outlines"),
+              let root = file.objectSource(outlinesNumber)
+        else { return nil }
+
+        guard let bookmarkNumber = findBookmarkObject(
+            in: file, rootNumber: outlinesNumber, root: root, id: id),
+              var bookmark = file.objectSource(bookmarkNumber)
+        else { return nil }
+
+        bookmark.setInteger(forKey: "VellumPinned", to: isPinned ? 1 : 0)
+        bookmark.setValue(forKey: "VellumUpdatedAt", raw: PdfTextString.encode(now))
+
+        var increment = PdfIncrement(file: file)
+        increment.setObject(bookmarkNumber, source: bookmark.sourceBytes)
         return increment.appended()
     }
 

--- a/Vellum/Services/Pdf/PdfBookmarks.swift
+++ b/Vellum/Services/Pdf/PdfBookmarks.swift
@@ -181,6 +181,17 @@ enum PdfBookmarks {
 
     // MARK: - Update (incremental update)
 
+    /// Walk catalog → /Outlines → outline tree for the Vellum bookmark
+    /// carrying this id, returning its object number. nil when the document
+    /// has no outline or no item matches.
+    private static func findBookmarkNumber(in file: ClassicPdfFile, id: String) -> Int? {
+        guard let catalogNumber = file.rootNumber, let catalog = file.objectSource(catalogNumber),
+              let outlinesNumber = catalog.reference(forKey: "Outlines"),
+              let root = file.objectSource(outlinesNumber)
+        else { return nil }
+        return findBookmarkObject(in: file, rootNumber: outlinesNumber, root: root, id: id)
+    }
+
     /// Patch pin state on an outline bookmark. Returns nil when no Vellum
     /// bookmark carries the id. PDFKit cannot write custom keys on outline
     /// items, so this rewrites the outline object in place.
@@ -191,13 +202,7 @@ enum PdfBookmarks {
         now: String
     ) throws -> Data? {
         let file = try ClassicPdfFile(data: normalizedData)
-        guard let catalogNumber = file.rootNumber, let catalog = file.objectSource(catalogNumber),
-              let outlinesNumber = catalog.reference(forKey: "Outlines"),
-              let root = file.objectSource(outlinesNumber)
-        else { return nil }
-
-        guard let bookmarkNumber = findBookmarkObject(
-            in: file, rootNumber: outlinesNumber, root: root, id: id),
+        guard let bookmarkNumber = findBookmarkNumber(in: file, id: id),
               var bookmark = file.objectSource(bookmarkNumber)
         else { return nil }
 
@@ -216,14 +221,7 @@ enum PdfBookmarks {
     /// Vellum bookmark carries the id.
     static func deleteBookmarkIncrement(normalizedData: Data, id: String) throws -> Data? {
         let file = try ClassicPdfFile(data: normalizedData)
-        guard let catalogNumber = file.rootNumber, let catalog = file.objectSource(catalogNumber),
-              let outlinesNumber = catalog.reference(forKey: "Outlines"),
-              let root = file.objectSource(outlinesNumber)
-        else { return nil }
-
-        guard let bookmarkNumber = findBookmarkObject(
-            in: file, rootNumber: outlinesNumber, root: root, id: id)
-        else { return nil }
+        guard let bookmarkNumber = findBookmarkNumber(in: file, id: id) else { return nil }
 
         guard let bookmark = file.objectSource(bookmarkNumber) else {
             throw SessionServiceError.invalidDocument("Failed to read PDF bookmark: missing object")

--- a/Vellum/Services/Pdf/PdfSessionBackend.swift
+++ b/Vellum/Services/Pdf/PdfSessionBackend.swift
@@ -264,18 +264,8 @@ actor PdfDocumentIO {
         }
         annotations.append(contentsOf: PdfBookmarks.readBookmarks(document: document, pageNumber: pageNumber))
 
-        // Stable sort: page_number asc, then created_at as a plain string.
-        return annotations.enumerated()
-            .sorted { left, right in
-                if left.element.pageNumber != right.element.pageNumber {
-                    return left.element.pageNumber < right.element.pageNumber
-                }
-                if left.element.createdAt != right.element.createdAt {
-                    return left.element.createdAt < right.element.createdAt
-                }
-                return left.offset < right.offset
-            }
-            .map(\.element)
+        // Pinned first, then page_number asc, then created_at as a plain string.
+        return Annotation.sortedForDisplay(annotations)
     }
 
     /// create_annotation: embed a /Highlight or /Text annotation, or divert
@@ -331,41 +321,62 @@ actor PdfDocumentIO {
     }
 
     /// update_annotation: matches /NM or derived ids (third-party annotations
-    /// included; un-NM'd ones get stamped with their derived id). Never
-    /// matches outline bookmarks. Only provided fields change; /M and
-    /// /VellumUpdatedAt always refresh.
+    /// included; un-NM'd ones get stamped with their derived id). Outline
+    /// bookmarks are updated via a separate incremental path (PDFKit cannot
+    /// write custom keys on outline items). Only provided fields change; /M
+    /// and /VellumUpdatedAt always refresh on page annotations.
     func updateAnnotation(_ input: UpdateAnnotationInput) async throws -> Bool {
         let (document, raw) = try PdfDocumentLoader.loadForMutation(path: path)
-        guard let (pageIndex, annotation) = Self.findAnnotation(id: input.id, in: document, raw: raw) else {
-            return false
-        }
 
-        PdfAnnotationWriter.setText(annotation, "NM", input.id)
-        PdfAnnotationWriter.setText(annotation, "M", PdfDates.pdfDateNow())
-        PdfAnnotationWriter.setText(annotation, "VellumUpdatedAt", PdfDates.rfc3339Now())
+        if let (pageIndex, annotation) = Self.findAnnotation(id: input.id, in: document, raw: raw) {
+            PdfAnnotationWriter.setText(annotation, "NM", input.id)
+            PdfAnnotationWriter.setText(annotation, "M", PdfDates.pdfDateNow())
+            PdfAnnotationWriter.setText(annotation, "VellumUpdatedAt", PdfDates.rfc3339Now())
 
-        if let color = input.color {
-            annotation.color = PdfColor.annotationColor(fromHex: color)
-        }
-        if let content = input.content {
-            annotation.contents = content
-        }
-        if let position = input.positionData {
-            guard let pageDictionary = raw.page(at: pageIndex + 1)?.dictionary else {
-                throw SessionServiceError.invalidDocument("Failed to read PDF page: missing page dictionary")
+            if let color = input.color {
+                annotation.color = PdfColor.annotationColor(fromHex: color)
             }
-            let geometry = try PageGeometry(pageDictionary: pageDictionary)
-            let isHighlight = annotation.type == "Highlight"
-            try PdfAnnotationWriter.applyPosition(
-                annotation, geometry: geometry, position: position, isHighlight: isHighlight)
-            if let selectedText = position.selectedText {
-                PdfAnnotationWriter.setText(annotation, "VellumSelectedText", selectedText)
+            if let content = input.content {
+                annotation.contents = content
             }
+            if let isPinned = input.isPinned {
+                PdfAnnotationWriter.setValue(annotation, "VellumPinned", (isPinned ? 1 : 0) as NSNumber)
+            }
+            if let position = input.positionData {
+                guard let pageDictionary = raw.page(at: pageIndex + 1)?.dictionary else {
+                    throw SessionServiceError.invalidDocument("Failed to read PDF page: missing page dictionary")
+                }
+                let geometry = try PageGeometry(pageDictionary: pageDictionary)
+                let isHighlight = annotation.type == "Highlight"
+                try PdfAnnotationWriter.applyPosition(
+                    annotation, geometry: geometry, position: position, isHighlight: isHighlight)
+                if let selectedText = position.selectedText {
+                    PdfAnnotationWriter.setText(annotation, "VellumSelectedText", selectedText)
+                }
+            }
+
+            let data = try serialize(document)
+            try await writeAndRefreshCache(data)
+            return true
         }
 
-        let data = try serialize(document)
-        try await writeAndRefreshCache(data)
-        return true
+        // Outline bookmarks: pin only — color/position/content don't apply
+        // here. PDFKit can't mutate outline custom keys, so this is an
+        // incremental byte rewrite of the outline item.
+        if PdfBookmarks.containsBookmark(document: raw, id: input.id) {
+            guard let isPinned = input.isPinned else { return false }
+            let normalized = try serialize(document)
+            guard let patched = try PdfBookmarks.updateBookmarkIncrement(
+                normalizedData: normalized,
+                id: input.id,
+                isPinned: isPinned,
+                now: PdfDates.rfc3339Now())
+            else { return false }
+            try await saveThroughPdfKit(patched)
+            return true
+        }
+
+        return false
     }
 
     /// delete_annotation: outline bookmarks first, then page annotations;

--- a/Vellum/Services/Web/WebSessionBackend.swift
+++ b/Vellum/Services/Web/WebSessionBackend.swift
@@ -346,8 +346,13 @@ actor WebDocumentIO {
 
     func annotations(pageNumber: Int?) -> [Annotation] {
         let record = WebLibrary.loadRecord(forKey: key) ?? WebPageRecord(url: url)
-        guard let pageNumber else { return record.annotations }
-        return record.annotations.filter { $0.pageNumber == pageNumber }
+        let list: [Annotation]
+        if let pageNumber {
+            list = record.annotations.filter { $0.pageNumber == pageNumber }
+        } else {
+            list = record.annotations
+        }
+        return Annotation.sortedForDisplay(list)
     }
 
     func createAnnotation(_ input: CreateAnnotationInput, storedHighlightColor: String) throws -> Annotation {
@@ -393,6 +398,12 @@ actor WebDocumentIO {
             }
             if let positionData = input.positionData {
                 record.annotations[index].positionData = positionData
+            }
+            if let pageNumber = input.pageNumber {
+                record.annotations[index].pageNumber = pageNumber
+            }
+            if let isPinned = input.isPinned {
+                record.annotations[index].isPinned = isPinned
             }
             record.annotations[index].updatedAt = WebLibrary.rfc3339Now()
             return true

--- a/Vellum/Stores/AnnotationStore.swift
+++ b/Vellum/Stores/AnnotationStore.swift
@@ -75,7 +75,7 @@ final class AnnotationStore {
         do {
             let loaded = try await sessions.getAnnotations(sessionId: sessionId, pageNumber: nil)
             if app.activeTabId == sessionId {
-                annotations = loaded
+                annotations = Annotation.sortedForDisplay(loaded)
                 isLoading = false
                 selectedAnnotationId = nil
             }
@@ -134,21 +134,34 @@ final class AnnotationStore {
         await addBookmark(pageNumber: app.currentPage)
     }
 
+    /// Pin or unpin an annotation so it floats to (or leaves) the top of the
+    /// sidebar list. Works for highlights, notes, and bookmarks.
+    func togglePin(id: String) async {
+        guard let annotation = annotations.first(where: { $0.id == id }) else { return }
+        await updateAnnotation(UpdateAnnotationInput(
+            id: id,
+            color: nil,
+            content: nil,
+            positionData: nil,
+            isPinned: !annotation.pinned))
+    }
+
     func updateAnnotation(_ input: UpdateAnnotationInput) async {
         guard let sessionId = app.activeTabId else { return }
         // The backend persists the client-assigned id, so update waits for a
         // matching optimistic create rather than trying to mutate a temp id.
         // Optimistic update
-        annotations = annotations.map { annotation in
+        annotations = Annotation.sortedForDisplay(annotations.map { annotation in
             guard annotation.id == input.id else { return annotation }
             var next = annotation
             if let color = input.color { next.color = color }
             if let content = input.content { next.content = content }
             if let positionData = input.positionData { next.positionData = positionData }
             if let pageNumber = input.pageNumber { next.pageNumber = pageNumber }
+            if let isPinned = input.isPinned { next.isPinned = isPinned }
             next.updatedAt = ISO8601DateFormatter.recentTimestamp.string(from: Date())
             return next
-        }
+        })
         // Ensure a still-pending optimistic create for this id has landed in the
         // backend before we try to update it, or the update races to "not found".
         await awaitPendingCreate(input.id)

--- a/Vellum/Views/Annotations/AnnotationSidebar.swift
+++ b/Vellum/Views/Annotations/AnnotationSidebar.swift
@@ -34,6 +34,9 @@ struct AnnotationSidebar: View {
                                 onSaveEdit: { saveEdit(annotation.id) },
                                 onCancelEdit: { cancelEdit() },
                                 onChangeColor: { color in changeColor(annotation, to: color) },
+                                onTogglePin: {
+                                    Task { await annotationStore.togglePin(id: annotation.id) }
+                                },
                                 onDelete: {
                                     Task { await annotationStore.deleteAnnotation(id: annotation.id) }
                                 }
@@ -151,6 +154,7 @@ struct AnnotationSidebar: View {
     }
 
     private var filteredAnnotations: [Annotation] {
+        // Store already keeps pin/page/created order; filter only by type.
         guard let filter else { return annotationStore.annotations }
         return annotationStore.annotations.filter { $0.type == filter }
     }
@@ -260,6 +264,7 @@ private struct AnnotationRow: View {
     let onSaveEdit: () -> Void
     let onCancelEdit: () -> Void
     let onChangeColor: (String) -> Void
+    let onTogglePin: () -> Void
     let onDelete: () -> Void
 
     @Environment(\.palette) private var palette
@@ -280,6 +285,12 @@ private struct AnnotationRow: View {
                         .tracking(0.5)
                     Text("·")
                     Text("p.\(annotation.pageNumber)")
+                    if annotation.pinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: metaSize - 1))
+                            .foregroundStyle(palette.primary)
+                            .accessibilityLabel("Pinned")
+                    }
                 }
                 .font(.system(size: metaSize, weight: .medium))
                 .foregroundStyle(palette.mutedForeground)
@@ -324,6 +335,21 @@ private struct AnnotationRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
+            // Pin is a sibling control (not nested under the row tap) so it
+            // never also navigates — same pattern as ModelSelector stars.
+            Button(action: onTogglePin) {
+                Image(systemName: annotation.pinned ? "pin.fill" : "pin")
+                    .font(.system(size: 13))
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(annotation.pinned ? palette.primary : palette.mutedForeground)
+            .opacity(hovering || selected || annotation.pinned ? 1 : 0)
+            .help(annotation.pinned ? "Unpin annotation" : "Pin annotation to top")
+            .accessibilityLabel(annotation.pinned ? "Unpin annotation" : "Pin annotation")
+            .accessibilityIdentifier("annotationRow.pin")
+
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .font(.system(size: 14))
@@ -347,6 +373,10 @@ private struct AnnotationRow: View {
         .contentShape(RoundedRectangle(cornerRadius: Radius.lg))
         .onTapGesture(perform: onSelect)
         .onHover { hovering = $0 }
+        .contextMenu {
+            Button(annotation.pinned ? "Unpin" : "Pin to Top", action: onTogglePin)
+            Button("Delete", role: .destructive, action: onDelete)
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

- Annotations (highlights, notes, bookmarks) can now be pinned to the top of the sidebar list via a hover pin button or row context menu ("Pin to Top" / "Unpin")
- Pinned state persists across reopen: PDF annotations use a `/VellumPinned` custom key written via incremental update; web annotations use `is_pinned` in the JSON sidecar
- Outline bookmarks use a dedicated incremental byte-rewrite path since PDFKit cannot write custom keys on outline items directly
- Sort order is: pinned first, then page number ascending, then `created_at`; applied consistently in `Annotation.sortedForDisplay` (shared by both backends and the store's optimistic update)
- `UpdateAnnotationInput` gains an `isPinned: Bool?` field; `AnnotationStore` gains `togglePin(id:)`
- Removes `.github/workflows/claude.yml` (the Claude Code bot workflow)
- Adds unit tests for pin persistence and sort order for both PDF and web backends

## Testing

- Pin a highlight, note, and bookmark in the sidebar — each should immediately float to the top of the list
- Reopen the document and confirm pinned items are still at the top
- Unpin an item and confirm it returns to its natural page/created order
- Verify the pin button is hidden when not hovering, visible on hover, and always visible when pinned
- Confirm the context menu shows "Pin to Top" / "Unpin" correctly
- `PdfPersistenceTests.testPinHighlightPersistsAndSortsFirst` — pin, persist, reopen, sort, unpin
- `PdfPersistenceTests.testPinBookmarkPersistsAndSortsFirst` — bookmark-specific incremental write path
- `WebLibraryStorageTests.testPinAnnotationPersistsAndSortsFirst` — JSON sidecar `is_pinned` round-trip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to pin and unpin annotations and bookmarks.
  * Pinned items appear at the top of annotation lists.
  * Pin status persists when documents and web pages are reopened.
  * Added pin indicators, dedicated pin controls, and Pin/Unpin context menu actions.
* **Bug Fixes**
  * Preserved stable ordering for pinned and unpinned items based on page and creation order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->