### PR TITLE
Keep open tabs resident so switching and split-screen are instant

### DIFF
--- a/Tests/TabResidencyTests.swift
+++ b/Tests/TabResidencyTests.swift
@@ -1,0 +1,362 @@
+import Testing
+@testable import Vellum
+
+// The open-tab retention policy (issue #52): a tab's expensive resources stay
+// resident for as long as the tab is open, and are only reclaimed after two
+// hours of inactivity, when a ceiling is exceeded, or when the system reports
+// memory pressure.
+//
+// Every test drives a `ManualResidencyClock`, so "two hours later" costs
+// nothing, and builds the manager with `automaticMaintenance: false` so no
+// background sweeper or memory-pressure source can race the assertions —
+// `sweep()` and `handleMemoryPressure(_:)` are called explicitly instead.
+
+/// Test clock: time only moves when the test moves it.
+@MainActor
+private final class ManualResidencyClock: ResidencyClock {
+    private(set) var now: Duration = .zero
+
+    func advance(by amount: Duration) { now += amount }
+}
+
+/// Stand-in for a parsed PDF / live web view. Records its own release so a test
+/// can prove eviction actually reached the resource rather than just dropping
+/// the dictionary entry.
+@MainActor
+private final class FakeResident: TabResidentResource {
+    let residencyCostBytes: Int
+    private(set) var releaseCount = 0
+
+    init(costBytes: Int = 1) { residencyCostBytes = costBytes }
+
+    func releaseResidency() { releaseCount += 1 }
+}
+
+@MainActor
+private func makeManager(
+    clock: ManualResidencyClock,
+    tabLimit: Int = 8,
+    byteBudget: Int = Int.max
+) -> TabResidencyManager {
+    TabResidencyManager(
+        clock: clock,
+        retention: TabResidencyManager.retentionWindow,
+        tabLimit: tabLimit,
+        byteBudget: byteBudget,
+        automaticMaintenance: false)
+}
+
+private let pane = ObjectIdentifier(TabResidencyTests.self)
+private let otherPane = ObjectIdentifier(FakeResident.self)
+
+@MainActor
+struct TabResidencyTests {
+
+    // MARK: - Basic residency
+
+    @Test func storedResourceIsRetrievable() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let resource = FakeResident()
+
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+
+        #expect(manager.resource(tabId: "a", slot: .preparedPdf) === resource)
+        #expect(manager.residentTabIds == ["a"])
+    }
+
+    @Test func slotsAreIndependent() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let pdf = FakeResident()
+        let web = FakeResident()
+
+        manager.store(pdf, tabId: "a", slot: .preparedPdf)
+        manager.store(web, tabId: "a", slot: .webView)
+
+        #expect(manager.resource(tabId: "a", slot: .preparedPdf) === pdf)
+        #expect(manager.resource(tabId: "a", slot: .webView) === web)
+        // Two slots, but still one resident *tab* as far as the ceiling cares.
+        #expect(manager.residentTabCount == 1)
+    }
+
+    @Test func replacingASlotReleasesTheDisplacedResource() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let first = FakeResident()
+        let second = FakeResident()
+
+        manager.store(first, tabId: "a", slot: .webView)
+        manager.store(second, tabId: "a", slot: .webView)
+
+        #expect(first.releaseCount == 1)
+        #expect(manager.resource(tabId: "a", slot: .webView) === second)
+    }
+
+    // MARK: - The retention window
+
+    @Test func inactiveTabSurvivesUpToTheRetentionWindow() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let resource = FakeResident()
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+        // "a" was never the active tab of any pane, so nothing pins it.
+
+        clock.advance(by: .seconds(2 * 60 * 60 - 1))
+        #expect(manager.sweep().isEmpty)
+        #expect(manager.resource(tabId: "a", slot: .preparedPdf) === resource)
+        #expect(resource.releaseCount == 0)
+    }
+
+    @Test func inactiveTabIsEvictedPastTheRetentionWindow() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let resource = FakeResident()
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+
+        clock.advance(by: .seconds(2 * 60 * 60))
+
+        #expect(manager.sweep() == ["a"])
+        #expect(manager.resource(tabId: "a", slot: .preparedPdf) == nil)
+        #expect(resource.releaseCount == 1)
+    }
+
+    @Test func evictionReleasesEverySlotTheTabOwns() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let pdf = FakeResident()
+        let web = FakeResident()
+        manager.store(pdf, tabId: "a", slot: .preparedPdf)
+        manager.store(web, tabId: "a", slot: .webView)
+
+        clock.advance(by: .seconds(3 * 60 * 60))
+        manager.sweep()
+
+        #expect(pdf.releaseCount == 1)
+        #expect(web.releaseCount == 1)
+        #expect(manager.residentTabCount == 0)
+    }
+
+    // MARK: - Pinning (the tab on screen)
+
+    @Test func activeTabIsNeverEvictedHoweverLongItIsRead() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let resource = FakeResident()
+        manager.markActive(tabId: "a", owner: pane)
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+
+        // Someone reading one long paper all day must not have it evicted out
+        // from under them just because they never switched tabs.
+        clock.advance(by: .seconds(10 * 60 * 60))
+
+        #expect(manager.sweep().isEmpty)
+        #expect(resource.releaseCount == 0)
+    }
+
+    @Test func idleClockStartsWhenTheTabIsSwitchedAwayFrom() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let a = FakeResident()
+        let b = FakeResident()
+        manager.markActive(tabId: "a", owner: pane)
+        manager.store(a, tabId: "a", slot: .preparedPdf)
+
+        // Three hours of reading tab "a", then switch to "b".
+        clock.advance(by: .seconds(3 * 60 * 60))
+        manager.markActive(tabId: "b", owner: pane)
+        manager.store(b, tabId: "b", slot: .preparedPdf)
+
+        // "a" is not immediately stale despite the clock reading 3h — its two
+        // hours start at the switch, not at the activation.
+        #expect(manager.sweep().isEmpty)
+        clock.advance(by: .seconds(2 * 60 * 60))
+        #expect(manager.sweep() == ["a"])
+        #expect(b.releaseCount == 0)
+    }
+
+    @Test func eachPanePinsItsOwnTabInASplitWindow() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let left = FakeResident()
+        let right = FakeResident()
+        manager.markActive(tabId: "left", owner: pane)
+        manager.markActive(tabId: "right", owner: otherPane)
+        manager.store(left, tabId: "left", slot: .preparedPdf)
+        manager.store(right, tabId: "right", slot: .webView)
+
+        clock.advance(by: .seconds(24 * 60 * 60))
+
+        #expect(manager.sweep().isEmpty)
+        #expect(manager.residentTabCount == 2)
+    }
+
+    @Test func forgettingADiscardedPaneUnpinsItsTab() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let resource = FakeResident()
+        manager.markActive(tabId: "a", owner: pane)
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+        clock.advance(by: .seconds(5 * 60 * 60))
+
+        manager.forgetOwner(pane)
+        // Unpinning re-stamps the tab as of now, so it gets a fresh window
+        // rather than being evicted the instant its pane collapses.
+        #expect(manager.sweep().isEmpty)
+
+        clock.advance(by: .seconds(2 * 60 * 60))
+        #expect(manager.sweep() == ["a"])
+    }
+
+    // MARK: - Closing a tab
+
+    @Test func closingATabReleasesImmediately() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let resource = FakeResident()
+        manager.markActive(tabId: "a", owner: pane)
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+
+        manager.release(tabId: "a")
+
+        #expect(resource.releaseCount == 1)
+        #expect(manager.resource(tabId: "a", slot: .preparedPdf) == nil)
+    }
+
+    @Test func releaseAllDropsEverythingIncludingPinnedTabs() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let a = FakeResident()
+        let b = FakeResident()
+        manager.markActive(tabId: "a", owner: pane)
+        manager.store(a, tabId: "a", slot: .preparedPdf)
+        manager.store(b, tabId: "b", slot: .webView)
+
+        manager.releaseAll()
+
+        #expect(a.releaseCount == 1)
+        #expect(b.releaseCount == 1)
+        #expect(manager.residentTabCount == 0)
+    }
+
+    // MARK: - Ceilings
+
+    @Test func tabCeilingEvictsLeastRecentlyActiveFirst() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock, tabLimit: 2)
+        var resources: [String: FakeResident] = [:]
+        // Visit three tabs a minute apart, ending on "c".
+        for tabId in ["a", "b", "c"] {
+            let resource = FakeResident()
+            resources[tabId] = resource
+            manager.markActive(tabId: tabId, owner: pane)
+            manager.store(resource, tabId: tabId, slot: .preparedPdf)
+            clock.advance(by: .seconds(60))
+        }
+
+        #expect(manager.sweep() == ["a"])
+        #expect(resources["a"]?.releaseCount == 1)
+        #expect(manager.residentTabIds == ["b", "c"])
+    }
+
+    @Test func tabCeilingNeverEvictsThePinnedTab() {
+        let clock = ManualResidencyClock()
+        // A limit of zero: only the pin may save a tab.
+        let manager = makeManager(clock: clock, tabLimit: 0)
+        let a = FakeResident()
+        let b = FakeResident()
+        manager.store(a, tabId: "a", slot: .preparedPdf)
+        clock.advance(by: .seconds(60))
+        manager.markActive(tabId: "b", owner: pane)
+        manager.store(b, tabId: "b", slot: .preparedPdf)
+
+        manager.sweep()
+
+        #expect(a.releaseCount == 1)
+        #expect(b.releaseCount == 0)
+        #expect(manager.residentTabIds == ["b"])
+    }
+
+    @Test func byteBudgetEvictsUntilItFits() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock, byteBudget: 250)
+        let a = FakeResident(costBytes: 100)
+        let b = FakeResident(costBytes: 100)
+        let c = FakeResident(costBytes: 100)
+        manager.store(a, tabId: "a", slot: .preparedPdf)
+        clock.advance(by: .seconds(60))
+        manager.store(b, tabId: "b", slot: .preparedPdf)
+        clock.advance(by: .seconds(60))
+        manager.store(c, tabId: "c", slot: .preparedPdf)
+
+        #expect(manager.residentBytes == 300)
+        #expect(manager.sweep() == ["a"])
+        #expect(manager.residentBytes == 200)
+    }
+
+    // MARK: - Memory pressure
+
+    @Test func memoryPressureWarningShrinksToTheTightCeiling() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        var resources: [FakeResident] = []
+        for index in 0..<6 {
+            let resource = FakeResident()
+            resources.append(resource)
+            manager.store(resource, tabId: "tab-\(index)", slot: .preparedPdf)
+            clock.advance(by: .seconds(60))
+        }
+        manager.markActive(tabId: "tab-5", owner: pane)
+
+        manager.handleMemoryPressure(.warning)
+
+        // The pinned tab plus `pressureTabLimit` warm ones survive; the rest go.
+        #expect(manager.residentTabCount <= TabResidencyManager.pressureTabLimit + 1)
+        #expect(manager.residentTabIds.contains("tab-5"))
+        #expect(resources[0].releaseCount == 1)
+    }
+
+    @Test func criticalMemoryPressureEvictsEverythingButTheTabOnScreen() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        let visible = FakeResident()
+        let background = FakeResident()
+        manager.markActive(tabId: "visible", owner: pane)
+        manager.store(visible, tabId: "visible", slot: .preparedPdf)
+        manager.store(background, tabId: "background", slot: .webView)
+
+        manager.handleMemoryPressure(.critical)
+
+        #expect(manager.residentTabIds == ["visible"])
+        #expect(visible.releaseCount == 0)
+        #expect(background.releaseCount == 1)
+    }
+
+    // MARK: - The shared sweeper
+
+    @Test func sweeperRunsOnlyWhileSomethingIsResident() {
+        let clock = ManualResidencyClock()
+        // The one test that wants the real background machinery — an idle
+        // manager must not schedule a timer at all.
+        let manager = TabResidencyManager(
+            clock: clock,
+            retention: TabResidencyManager.retentionWindow,
+            tabLimit: 8,
+            byteBudget: Int.max,
+            automaticMaintenance: true)
+        #expect(!manager.isSweeping)
+
+        manager.store(FakeResident(), tabId: "a", slot: .preparedPdf)
+        #expect(manager.isSweeping)
+
+        manager.release(tabId: "a")
+        #expect(!manager.isSweeping)
+    }
+
+    @Test func noSweeperWhenAutomaticMaintenanceIsOff() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        manager.store(FakeResident(), tabId: "a", slot: .preparedPdf)
+        #expect(!manager.isSweeping)
+    }
+}

--- a/Tests/TabResidencyTests.swift
+++ b/Tests/TabResidencyTests.swift
@@ -46,8 +46,14 @@ private func makeManager(
         automaticMaintenance: false)
 }
 
-private let pane = ObjectIdentifier(TabResidencyTests.self)
-private let otherPane = ObjectIdentifier(FakeResident.self)
+// Stand-ins for the two panes of a split window. The manager keys its
+// "which tab is on screen" table by the pane's `AppStore` identity, so a test
+// only needs two distinct object identities.
+private final class PaneIdentity: Sendable {}
+private let paneA = PaneIdentity()
+private let paneB = PaneIdentity()
+private let pane = ObjectIdentifier(paneA)
+private let otherPane = ObjectIdentifier(paneB)
 
 @MainActor
 struct TabResidencyTests {

--- a/Tests/TabResidencyTests.swift
+++ b/Tests/TabResidencyTests.swift
@@ -300,6 +300,82 @@ struct TabResidencyTests {
         #expect(manager.residentBytes == 200)
     }
 
+    @Test func evictionReportsEachTabOnceEvenWhenItHeldTwoSlots() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock)
+        manager.store(FakeResident(), tabId: "a", slot: .preparedPdf)
+        manager.store(FakeResident(), tabId: "a", slot: .webView)
+
+        clock.advance(by: .seconds(3 * 60 * 60))
+
+        // The window pass walks slots, but the contract is "the tabs that lost
+        // a resource" — one entry per tab, matching the ceiling pass.
+        #expect(manager.sweep() == ["a"])
+    }
+
+    // MARK: - Ceilings applied at store time
+
+    @Test func enforcingCeilingsTrimsWithoutWaitingForASweep() {
+        let clock = ManualResidencyClock()
+        let manager = makeManager(clock: clock, tabLimit: 1)
+        let a = FakeResident()
+        let b = FakeResident()
+        manager.store(a, tabId: "a", slot: .preparedPdf)
+        clock.advance(by: .seconds(60))
+        manager.store(b, tabId: "b", slot: .preparedPdf)
+
+        #expect(manager.enforceCeilings() == ["a"])
+        #expect(a.releaseCount == 1)
+        #expect(manager.residentTabIds == ["b"])
+    }
+
+    @Test func enforcingCeilingsDoesNotApplyTheRetentionWindow() {
+        let clock = ManualResidencyClock()
+        // Room to spare, so only the two-hour window could evict anything —
+        // and the ceiling pass must not be the thing that applies it.
+        let manager = makeManager(clock: clock, tabLimit: 8)
+        let resource = FakeResident()
+        manager.store(resource, tabId: "a", slot: .preparedPdf)
+
+        clock.advance(by: .seconds(5 * 60 * 60))
+
+        #expect(manager.enforceCeilings().isEmpty)
+        #expect(resource.releaseCount == 0)
+        // The sweeper still owns the window.
+        #expect(manager.sweep() == ["a"])
+    }
+
+    @Test func storingOverTheCeilingTrimsOnTheNextTurnNotTheNextSweep() async {
+        let clock = ManualResidencyClock()
+        // Real machinery: the point of this test is that a burst of opens is
+        // bounded long before the sweeper's first 60-second tick.
+        let manager = TabResidencyManager(
+            clock: clock,
+            retention: TabResidencyManager.retentionWindow,
+            tabLimit: 1,
+            byteBudget: Int.max,
+            automaticMaintenance: true)
+        let a = FakeResident()
+        let b = FakeResident()
+        manager.store(a, tabId: "a", slot: .preparedPdf)
+        clock.advance(by: .seconds(60))
+        manager.store(b, tabId: "b", slot: .preparedPdf)
+        // Deliberately deferred, not inline: `store` is reachable from a SwiftUI
+        // body, where releasing an `@Observable` resource would be a
+        // modify-during-update hazard.
+        #expect(manager.residentTabCount == 2)
+
+        var spins = 0
+        while manager.residentTabCount > 1, spins < 100 {
+            await Task.yield()
+            spins += 1
+        }
+
+        #expect(manager.residentTabIds == ["b"])
+        #expect(a.releaseCount == 1)
+        manager.releaseAll()
+    }
+
     // MARK: - Memory pressure
 
     @Test func memoryPressureWarningShrinksToTheTightCeiling() {

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		53B7BE4E93C5CF617CF049D6 /* DocumentIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCBBA9A1DAB0373185D8F5EA /* DocumentIdentityTests.swift */; };
 		546B20185CE6B8EEA5C08069 /* DocumentDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9D539B1461FC063BC82C78 /* DocumentDataStore.swift */; };
 		56FC925BB362E1EA594F963B /* StorageHousekeeping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA50A523F4D87396EC11A8B /* StorageHousekeeping.swift */; };
+		5716E0D875F1A5AD2EC02604 /* TabResidencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */; };
 		5AA233123955997046F4F9EB /* WebNotePopovers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACABB2AAB4911563C0148AD6 /* WebNotePopovers.swift */; };
 		5FF82C62FE4C7CC82FD160FD /* AiConversationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327F0E350D7D13A26878EB77 /* AiConversationStoreTests.swift */; };
 		65858805EE10C9DAA53531F5 /* KaTeX_Script-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 529B3D1901669D3F00BBCF74 /* KaTeX_Script-Regular.woff2 */; };
@@ -125,6 +126,7 @@
 		D5F586434585D55B08108B40 /* StorageSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB83E31DAAFDC48C15F2F130 /* StorageSettingsTab.swift */; };
 		D657C92463B102EF093DC4CB /* KaTeX_Main-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 90AB7C8FB37749DA52B6CF96 /* KaTeX_Main-Regular.woff2 */; };
 		D77E5170582527BDF9282B70 /* tool-descriptions.md in Resources */ = {isa = PBXBuildFile; fileRef = 3E954582457ABFF5574EC93C /* tool-descriptions.md */; };
+		D8FB17ACCD415EFD9623E48B /* TabResidency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E69330A4F460353FBCB25AB /* TabResidency.swift */; };
 		DC190B489E12CE0D1218C949 /* SwiftMath in Frameworks */ = {isa = PBXBuildFile; productRef = 0F9E9D97558DCF004997C26D /* SwiftMath */; };
 		E0C67279AC30EA86F477747B /* KaTeX_AMS-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 920042E47739D0327A193A1C /* KaTeX_AMS-Regular.woff2 */; };
 		E4EC8CEAAD8788E622D56A58 /* AiFileAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D76BD9134C505A0D1E0DFEE /* AiFileAttachment.swift */; };
@@ -171,6 +173,7 @@
 		195A20D8270BAD8604C2E641 /* PdfAnnotationCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfAnnotationCodec.swift; sourceTree = "<group>"; };
 		1DE37DD793875C0DBF92E050 /* KaTeX_Main-BoldItalic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-BoldItalic.woff2"; sourceTree = "<group>"; };
 		20B2D17372EC7164FEB6B7AF /* KaTeX_Math-Italic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Math-Italic.woff2"; sourceTree = "<group>"; };
+		22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabResidencyTests.swift; sourceTree = "<group>"; };
 		2423823E0BE86C417B6ABBC6 /* AiPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiPanel.swift; sourceTree = "<group>"; };
 		287B357B7A7C9503C3C1199C /* ScratchpadPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadPersistence.swift; sourceTree = "<group>"; };
 		28BDBF0FA0F7F13C32A07F05 /* DocumentIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIdentity.swift; sourceTree = "<group>"; };
@@ -193,6 +196,7 @@
 		4B707464546ECFFA1A49EBDE /* purify.min.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = purify.min.js; sourceTree = "<group>"; };
 		4D76BD9134C505A0D1E0DFEE /* AiFileAttachment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiFileAttachment.swift; sourceTree = "<group>"; };
 		4E282C555B1B420914134C74 /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
+		4E69330A4F460353FBCB25AB /* TabResidency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabResidency.swift; sourceTree = "<group>"; };
 		4FA50A523F4D87396EC11A8B /* StorageHousekeeping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageHousekeeping.swift; sourceTree = "<group>"; };
 		4FAA454DB63CD5DAEB44B17B /* WebViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewerView.swift; sourceTree = "<group>"; };
 		504DC8725E6198531EC21429 /* PageTextPersister.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextPersister.swift; sourceTree = "<group>"; };
@@ -396,6 +400,7 @@
 				709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */,
 				BF3E4F80AF4A2707D432AF73 /* SidebarDropRoutingTests.swift */,
 				3B76DBD84FB379B34AC58BCE /* StorageManagementTests.swift */,
+				22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */,
 				90C50948404B30999979C84A /* VellumBundleTests.swift */,
 				DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */,
 				9BAF3F69842AC6333D1D9C38 /* WebProxyUrlTests.swift */,
@@ -444,6 +449,7 @@
 				7E4C07C56943274B9E062A70 /* RecentFilesService.swift */,
 				7280818785023514C87C04C9 /* SessionService.swift */,
 				4FA50A523F4D87396EC11A8B /* StorageHousekeeping.swift */,
+				4E69330A4F460353FBCB25AB /* TabResidency.swift */,
 				95809D33AB6DF0D9BCF1BE88 /* VellumBundle.swift */,
 				7E530DFE8240A79EA6D77961 /* WorkspaceService.swift */,
 				1B073A6D74EA890EC3F5822C /* Ai */,
@@ -860,6 +866,7 @@
 				D5F586434585D55B08108B40 /* StorageSettingsTab.swift in Sources */,
 				6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */,
 				07AE67F8DC12B0AAD737C3FD /* TabDrag.swift in Sources */,
+				D8FB17ACCD415EFD9623E48B /* TabResidency.swift in Sources */,
 				1F177B6D7BEF6B4E7C7620CE /* Theme.swift in Sources */,
 				9E139713CC03274E03B94E92 /* ToolbarView.swift in Sources */,
 				A5E5A42BE09B4A7911646AFF /* UpdateChecker.swift in Sources */,
@@ -900,6 +907,7 @@
 				FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */,
 				5236947317CC86594F165BD2 /* SidebarDropRoutingTests.swift in Sources */,
 				ACD85838F860C270E27BE7FC /* StorageManagementTests.swift in Sources */,
+				5716E0D875F1A5AD2EC02604 /* TabResidencyTests.swift in Sources */,
 				742579EA974AAA82CA7C2098 /* VellumBundleTests.swift in Sources */,
 				4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */,
 				51EFE28F82BCABBB7BDCB589 /* WebProxyUrlTests.swift in Sources */,

--- a/Vellum/Services/Ai/PageTextPersister.swift
+++ b/Vellum/Services/Ai/PageTextPersister.swift
@@ -47,6 +47,12 @@ final class PageTextPersister {
         self.cache = cache
     }
 
+    /// Everything this persister knows about the document: the cache seed plus
+    /// every page the extraction walk has produced so far. The viewer hands this
+    /// to the tab-residency entry on teardown so a warm re-open resumes with the
+    /// full page set instead of re-walking (issue #52).
+    var extractedPages: [Int: String] { pages }
+
     /// Record a newly extracted page (text already whitespace-normalized by
     /// AiStore.setPageText). No-op when unchanged; fires a debounced flush every
     /// `flushThreshold` new pages.

--- a/Vellum/Services/TabResidency.swift
+++ b/Vellum/Services/TabResidency.swift
@@ -214,16 +214,25 @@ final class TabResidencyManager {
         if let existing = entries[key], existing.resource !== resource {
             existing.resource.releaseResidency()
         }
-        let stamp = lastActiveByTab[tabId] ?? clock.now
-        lastActiveByTab[tabId] = stamp
-        entries[key] = Entry(resource: resource, lastActive: stamp)
+        // Storing is itself evidence of use — a resource is only ever built for
+        // the tab the user just opened or switched to — so it stamps the idle
+        // clock. In practice `markActive` has already stamped it a moment
+        // earlier from `applyActiveState`; doing it here too means a caller that
+        // forgets to can never hand us something that is stale on arrival.
+        let now = clock.now
+        lastActiveByTab[tabId] = now
+        entries[key] = Entry(resource: resource, lastActive: now)
+        // Keep a tab's two slots agreeing about how idle the tab is.
+        for other in Array(entries.keys) where other.tabId == tabId && other != key {
+            entries[other]?.lastActive = now
+        }
         startSweeperIfNeeded()
     }
 
     /// The resident resource for a tab, if we still have it. Reading does *not*
-    /// count as use — only `markActive` moves a tab's idle clock, because that
-    /// is the signal the issue is actually about ("inactive tab"), and a
-    /// background probe must not be able to keep a tab alive forever.
+    /// count as use — only `markActive` (and `store`) move a tab's idle clock,
+    /// because that is the signal the issue is actually about ("inactive tab"),
+    /// and a background probe must not be able to keep a tab alive forever.
     func resource(tabId: String, slot: Slot) -> (any TabResidentResource)? {
         entries[Key(tabId: tabId, slot: slot)]?.resource
     }

--- a/Vellum/Services/TabResidency.swift
+++ b/Vellum/Services/TabResidency.swift
@@ -177,6 +177,10 @@ final class TabResidencyManager {
 
     private var sweepTask: Task<Void, Never>?
     private var pressureSource: (any DispatchSourceMemoryPressure)?
+    /// Coalesces the deferred ceiling check `store` schedules — see
+    /// `scheduleCeilingEnforcement`. One hop per runloop turn, however many
+    /// resources are stored in it.
+    private var ceilingCheckScheduled = false
 
     init(
         clock: ResidencyClock = ContinuousResidencyClock(),
@@ -197,9 +201,13 @@ final class TabResidencyManager {
         // `deinit` is nonisolated, so only the two handles that are safe to
         // touch from anywhere get cleaned up here. Cancelling the Task stops the
         // sweep loop; cancelling the DispatchSource stops its handler firing.
-        // The residents themselves are released by ARC as `entries` tears down —
-        // by then the process is going away anyway, and `Vellum App`'s quit path
-        // has already called `releaseAll()`.
+        // The residents themselves are released by ARC as `entries` tears down.
+        // That is enough: `releaseResidency()` has nothing to flush that is not
+        // already persisted (annotations round-trip on every edit, page text is
+        // flushed by `PageTextPersister`, `last_page` is written on tab switch
+        // and again by the quit path), so there is no unsaved work riding on
+        // this teardown. The shared manager never deinits anyway — in practice
+        // this only runs for the per-test managers.
         sweepTask?.cancel()
         pressureSource?.cancel()
     }
@@ -227,6 +235,7 @@ final class TabResidencyManager {
             entries[other]?.lastActive = now
         }
         startSweeperIfNeeded()
+        scheduleCeilingEnforcement()
     }
 
     /// The resident resource for a tab, if we still have it. Reading does *not*
@@ -304,6 +313,37 @@ final class TabResidencyManager {
         evict(tabLimit: tabLimit, byteBudget: byteBudget, expireIdle: true)
     }
 
+    /// Apply only the ceilings — the count limit and the byte budget — without
+    /// the retention window. This is what `store` triggers, because the sweeper
+    /// is the *wrong* place to bound a burst: it first ticks a full
+    /// `sweepInterval` (60s) after the first resource is stored, so until this
+    /// existed, everything a user could open in a minute stayed resident no
+    /// matter how far past the ceilings it went. The window itself is left to
+    /// the sweeper — nothing can newly cross a two-hour threshold as a result of
+    /// a store.
+    @discardableResult
+    func enforceCeilings() -> [String] {
+        evict(tabLimit: tabLimit, byteBudget: byteBudget, expireIdle: false)
+    }
+
+    /// Run `enforceCeilings` on the next main-actor turn rather than inline.
+    ///
+    /// `store` is reachable from a SwiftUI `body` — `PaneView` resolves a tab's
+    /// web controller there — and eviction mutates `@Observable` state on the
+    /// resources it releases (`WebViewerController.initCount`), which is exactly
+    /// the "modifying state during view update" hazard. A hop sidesteps that and
+    /// is still three orders of magnitude sooner than the next sweep, which is
+    /// the whole point.
+    private func scheduleCeilingEnforcement() {
+        guard automaticMaintenance, !ceilingCheckScheduled else { return }
+        ceilingCheckScheduled = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.ceilingCheckScheduled = false
+            self.enforceCeilings()
+        }
+    }
+
     /// Respond to the system running short on memory. This is the escape hatch
     /// that makes "keep every open tab resident" survivable: the 2-hour window
     /// is a *ceiling* on how long we hold things, never a promise to hold them
@@ -338,7 +378,11 @@ final class TabResidencyManager {
             for (key, entry) in entries.map({ ($0.key, $0.value) })
             where !pinned.contains(key.tabId) && now - entry.lastActive >= retention {
                 entries.removeValue(forKey: key)?.resource.releaseResidency()
-                evicted.append(key.tabId)
+                // Per *tab*, not per slot: this loop walks slots, so a tab
+                // holding both a PDF and a web view would otherwise be reported
+                // twice by a routine whose contract is "the tabs that lost a
+                // resource" (pass 2 below already appends once per tab).
+                if !evicted.contains(key.tabId) { evicted.append(key.tabId) }
             }
         }
 

--- a/Vellum/Services/TabResidency.swift
+++ b/Vellum/Services/TabResidency.swift
@@ -1,0 +1,426 @@
+import Dispatch
+import Foundation
+
+// Open-tab residency policy (issue #52).
+//
+// Before this, an inactive tab dropped everything expensive it owned the moment
+// the user switched away. `PaneView` keys its viewer on `activeTabId`, so the
+// whole SwiftUI subtree — and with it the parsed `PDFDocument` and the live
+// `WKWebView` — was torn down and rebuilt on the way back. For a large PDF that
+// meant re-reading the bytes, re-parsing them, re-stripping the embedded
+// annotations and re-consulting the page-text cache; for a webpage it meant a
+// full network re-fetch through the proxy scheme handler. (An LRU of three
+// prepared PDFs used to blunt the worst of the PDF case; this file generalises
+// and replaces it.)
+//
+// The fix is to make "the tab is open" the primary retention signal, and only
+// reclaim after a long idle period. The policy has three layers, in priority
+// order:
+//
+//   1. A tab that is *active* in some pane is never evicted, however long the
+//      user has been sitting on it.
+//   2. A tab idle for longer than `retentionWindow` (2 hours) is evicted.
+//   3. Ceilings — a resident-tab count limit and an approximate byte budget —
+//      evict the least-recently-active *inactive* tabs early, and the system
+//      memory-pressure source tightens both sharply when the OS says it is
+//      short on RAM. Without this layer, "hold every open tab forever" is a
+//      straight path to being jetsammed by a user with forty tabs of scanned
+//      PDFs.
+//
+// Everything here is main-actor: the stores it serves are `@Observable` and
+// main-actor, and eviction reaches into PDFKit/WebKit objects that are only
+// safe to touch there.
+
+// MARK: - Clock
+
+/// Monotonic time source for the retention policy.
+///
+/// Deliberately *not* `Date`: the window is a duration-since-last-use, and
+/// wall-clock arithmetic breaks in two ways here. An NTP correction or a manual
+/// clock change can move `Date()` backwards, which makes an old tab look
+/// arbitrarily fresh (never evicted) or instantly stale (evicted mid-session).
+///
+/// `ContinuousResidencyClock` wraps `ContinuousClock`, which on Darwin is
+/// `mach_continuous_time` and therefore **keeps counting while the Mac is
+/// asleep**. That is a deliberate choice, not an accident: the issue asks for
+/// "inactive for more than 2 hours" as the user experiences it, and a laptop
+/// shut for the night has genuinely left those tabs untouched all night, so
+/// reclaiming them on wake is right — and it is what stops a machine that
+/// sleeps constantly from accumulating unbounded resident documents.
+/// `SuspendingClock` would pause across sleep and hold everything resident
+/// indefinitely, which is the surprising behaviour we do not want.
+///
+/// Tests inject a hand-advanced clock so the 2-hour window can be exercised
+/// without waiting 2 hours.
+@MainActor
+protocol ResidencyClock: AnyObject {
+    /// Monotonic elapsed time since an arbitrary, fixed origin. Never decreases.
+    var now: Duration { get }
+}
+
+@MainActor
+final class ContinuousResidencyClock: ResidencyClock {
+    private let origin = ContinuousClock.now
+    var now: Duration { ContinuousClock.now - origin }
+}
+
+// MARK: - Resident resources
+
+/// An expensive per-tab resource the residency policy can hold and reclaim: a
+/// parsed display `PDFDocument`, a live `WKWebView` host, and so on.
+///
+/// Conformers are responsible for being safe to drop at *any* moment an
+/// eviction can fire. In practice that means: nothing user-visible may live
+/// only inside the resource. Annotations already round-trip through the session
+/// backend on every edit, extracted page text is owned by `PageTextPersister`
+/// (which flushes itself), and reading position is mirrored into `PdfTab` /
+/// `last_page` metadata — so the concrete conformers here have nothing of their
+/// own to save. If that ever stops being true, the flush belongs in
+/// `releaseResidency()`, which is the single funnel every eviction path
+/// (timeout, ceiling, memory pressure, tab close, app teardown) goes through.
+@MainActor
+protocol TabResidentResource: AnyObject {
+    /// Rough resident footprint in bytes. Only used to rank eviction candidates
+    /// and to enforce the byte budget, so an order-of-magnitude estimate is
+    /// fine — do not go measuring anything expensive to produce this.
+    var residencyCostBytes: Int { get }
+
+    /// Flush anything unsaved and release OS resources. Called on the main
+    /// actor, exactly once per stored resource, and must be idempotent.
+    func releaseResidency()
+}
+
+// MARK: - Manager
+
+@MainActor
+final class TabResidencyManager {
+    /// **The retention window.** An open tab keeps everything expensive it owns
+    /// for this long after it was last the active tab; past it, the resources
+    /// are reclaimed and the next visit reloads from scratch. Two hours per
+    /// issue #52 — long enough that a normal day of hopping between references
+    /// never pays a reload, short enough that yesterday's reading does not
+    /// still own a gigabyte this morning.
+    static let retentionWindow: Duration = .seconds(2 * 60 * 60)
+
+    /// Ceiling on how many tabs stay resident at once, regardless of how recently
+    /// they were used. Eight covers "a paper plus its references" comfortably
+    /// while bounding the worst case for someone who leaves forty tabs open.
+    static let residentTabLimit = 8
+
+    /// Approximate ceiling on total resident bytes. A single 400 MB scanned PDF
+    /// plus a couple of heavy web tabs should still fit; a shelf of them should
+    /// not. Deliberately generous — the memory-pressure hook below is the real
+    /// safety net, this is just a guardrail against obvious runaway.
+    static let residentByteBudget = 768 * 1024 * 1024
+
+    /// Tightened ceilings applied while the system reports memory pressure. At
+    /// `.warning` we shrink hard but keep a little warmth; at `.critical` every
+    /// inactive tab goes immediately (see `handleMemoryPressure`).
+    static let pressureTabLimit = 2
+    static let pressureByteBudget = 128 * 1024 * 1024
+
+    /// How often the shared sweeper wakes. One tick per minute is ample
+    /// resolution for a two-hour window, and the generous tolerance lets the
+    /// kernel coalesce it with other timers so an idle Vellum is not the reason
+    /// a Mac stays awake. The sweeper only runs while something is resident.
+    static let sweepInterval: Duration = .seconds(60)
+    static let sweepTolerance: Duration = .seconds(30)
+
+    /// Which expensive resource a resident entry holds. A tab has at most one
+    /// of each; in practice a tab is either a PDF or a webpage, never both, but
+    /// keying by slot keeps the two call sites from stepping on each other (and
+    /// leaves room for a third kind without reworking the store).
+    enum Slot: Hashable, Sendable {
+        case preparedPdf
+        case webView
+    }
+
+    /// Severity reported by the system memory-pressure source, normalised so the
+    /// policy does not have to import Dispatch's option set at every call site.
+    enum PressureLevel: Sendable {
+        case warning
+        case critical
+    }
+
+    /// Shared instance. One policy per process: the ceilings and the memory
+    /// pressure response are only meaningful app-wide, and a per-pane manager
+    /// would mean one sweeper per pane. Tests build their own.
+    static let shared = TabResidencyManager()
+
+    private struct Key: Hashable {
+        let tabId: String
+        let slot: Slot
+    }
+
+    private struct Entry {
+        let resource: any TabResidentResource
+        /// Clock reading when this tab was last the active tab (or first stored).
+        var lastActive: Duration
+    }
+
+    private let clock: ResidencyClock
+    private let retention: Duration
+    private let tabLimit: Int
+    private let byteBudget: Int
+    /// False in tests: no background sweeper task, no memory-pressure source, so
+    /// a test drives `sweep()` and `handleMemoryPressure(_:)` deterministically.
+    private let automaticMaintenance: Bool
+
+    private var entries: [Key: Entry] = [:]
+    /// Last-active reading per tab, kept separately from `entries` so a tab's
+    /// two slots can never disagree about how idle the tab is.
+    private var lastActiveByTab: [String: Duration] = [:]
+    /// Active tab of each pane, keyed by that pane's `AppStore` identity. A tab
+    /// listed here is pinned: the user is looking at it right now, so no amount
+    /// of idle time or memory pressure may pull it out from under them.
+    private var activeTabByOwner: [ObjectIdentifier: String] = [:]
+
+    private var sweepTask: Task<Void, Never>?
+    private var pressureSource: (any DispatchSourceMemoryPressure)?
+
+    init(
+        clock: ResidencyClock = ContinuousResidencyClock(),
+        retention: Duration = TabResidencyManager.retentionWindow,
+        tabLimit: Int = TabResidencyManager.residentTabLimit,
+        byteBudget: Int = TabResidencyManager.residentByteBudget,
+        automaticMaintenance: Bool = true
+    ) {
+        self.clock = clock
+        self.retention = retention
+        self.tabLimit = tabLimit
+        self.byteBudget = byteBudget
+        self.automaticMaintenance = automaticMaintenance
+        if automaticMaintenance { installMemoryPressureSource() }
+    }
+
+    deinit {
+        // `deinit` is nonisolated, so only the two handles that are safe to
+        // touch from anywhere get cleaned up here. Cancelling the Task stops the
+        // sweep loop; cancelling the DispatchSource stops its handler firing.
+        // The residents themselves are released by ARC as `entries` tears down —
+        // by then the process is going away anyway, and `Vellum App`'s quit path
+        // has already called `releaseAll()`.
+        sweepTask?.cancel()
+        pressureSource?.cancel()
+    }
+
+    // MARK: - Store / fetch
+
+    /// Make `resource` resident for `tabId`. Replacing an existing resource in
+    /// the same slot releases the old one — there is never a moment where two
+    /// live `WKWebView`s claim the same tab.
+    func store(_ resource: any TabResidentResource, tabId: String, slot: Slot) {
+        let key = Key(tabId: tabId, slot: slot)
+        if let existing = entries[key], existing.resource !== resource {
+            existing.resource.releaseResidency()
+        }
+        let stamp = lastActiveByTab[tabId] ?? clock.now
+        lastActiveByTab[tabId] = stamp
+        entries[key] = Entry(resource: resource, lastActive: stamp)
+        startSweeperIfNeeded()
+    }
+
+    /// The resident resource for a tab, if we still have it. Reading does *not*
+    /// count as use — only `markActive` moves a tab's idle clock, because that
+    /// is the signal the issue is actually about ("inactive tab"), and a
+    /// background probe must not be able to keep a tab alive forever.
+    func resource(tabId: String, slot: Slot) -> (any TabResidentResource)? {
+        entries[Key(tabId: tabId, slot: slot)]?.resource
+    }
+
+    // MARK: - Activity tracking
+
+    /// Report which tab a pane is currently showing. Pass `nil` when the pane
+    /// goes empty. Pinning is per-pane (`owner`) so a split window keeps *both*
+    /// visible documents resident.
+    func markActive(tabId: String?, owner: ObjectIdentifier) {
+        // The outgoing tab starts its idle countdown from now, not from whenever
+        // it was activated — it was in use right up to this moment.
+        if let outgoing = activeTabByOwner[owner], outgoing != tabId {
+            stamp(outgoing)
+        }
+        if let tabId {
+            activeTabByOwner[owner] = tabId
+            stamp(tabId)
+        } else {
+            activeTabByOwner[owner] = nil
+        }
+    }
+
+    /// Drop a pane's pin when the pane itself goes away (collapsed by a split
+    /// close, or absorbed by View ▸ Merge Panes). Without this, a discarded
+    /// pane's last active tab would stay pinned forever.
+    func forgetOwner(_ owner: ObjectIdentifier) {
+        guard let tabId = activeTabByOwner.removeValue(forKey: owner) else { return }
+        stamp(tabId)
+    }
+
+    private func stamp(_ tabId: String) {
+        let now = clock.now
+        lastActiveByTab[tabId] = now
+        // `Array(...)`: `entries.keys` is a live view, so it must be materialised
+        // before the dictionary is written through. Same everywhere below.
+        for key in Array(entries.keys) where key.tabId == tabId {
+            entries[key]?.lastActive = now
+        }
+    }
+
+    // MARK: - Release
+
+    /// Immediate, unconditional release of everything a tab owns. This is the
+    /// close-tab path: retention is about tabs that are still *open*, so closing
+    /// one gives its memory back straight away rather than two hours later.
+    func release(tabId: String) {
+        for key in Array(entries.keys) where key.tabId == tabId {
+            entries.removeValue(forKey: key)?.resource.releaseResidency()
+        }
+        lastActiveByTab[tabId] = nil
+        stopSweeperIfIdle()
+    }
+
+    /// Release everything (app teardown / tests).
+    func releaseAll() {
+        for entry in entries.values { entry.resource.releaseResidency() }
+        entries.removeAll()
+        lastActiveByTab.removeAll()
+        stopSweeperIfIdle()
+    }
+
+    // MARK: - Sweeping
+
+    /// Apply the whole policy once. Returns the tab ids that lost a resource,
+    /// which is what the tests assert on.
+    @discardableResult
+    func sweep() -> [String] {
+        evict(tabLimit: tabLimit, byteBudget: byteBudget, expireIdle: true)
+    }
+
+    /// Respond to the system running short on memory. This is the escape hatch
+    /// that makes "keep every open tab resident" survivable: the 2-hour window
+    /// is a *ceiling* on how long we hold things, never a promise to hold them
+    /// that long when the OS is asking for the memory back.
+    @discardableResult
+    func handleMemoryPressure(_ level: PressureLevel) -> [String] {
+        switch level {
+        case .warning:
+            // Keep the pinned tabs plus a small warm set — switching between the
+            // two documents you are comparing should still be instant even on a
+            // machine that is swapping.
+            return evict(
+                tabLimit: Self.pressureTabLimit,
+                byteBudget: Self.pressureByteBudget,
+                expireIdle: true)
+        case .critical:
+            // Everything that is not on screen goes, now.
+            return evict(tabLimit: 0, byteBudget: 0, expireIdle: true)
+        }
+    }
+
+    /// The one eviction routine. Pinned tabs are exempt from every rule;
+    /// everything else is ordered least-recently-active first and dropped until
+    /// both ceilings are satisfied.
+    private func evict(tabLimit: Int, byteBudget: Int, expireIdle: Bool) -> [String] {
+        let pinned = Set(activeTabByOwner.values)
+        let now = clock.now
+        var evicted: [String] = []
+
+        // Pass 1 — the retention window.
+        if expireIdle {
+            for (key, entry) in entries.map({ ($0.key, $0.value) })
+            where !pinned.contains(key.tabId) && now - entry.lastActive >= retention {
+                entries.removeValue(forKey: key)?.resource.releaseResidency()
+                evicted.append(key.tabId)
+            }
+        }
+
+        // Pass 2 — the ceilings. Rank surviving *tabs* (not slots) by idle time
+        // so a web tab's view and its future siblings leave together.
+        var candidates = residentTabsByIdleDescending(excluding: pinned)
+        while !candidates.isEmpty,
+              residentTabCount > max(0, tabLimit) || residentBytes > max(0, byteBudget) {
+            let victim = candidates.removeFirst()
+            for key in Array(entries.keys) where key.tabId == victim {
+                entries.removeValue(forKey: key)?.resource.releaseResidency()
+            }
+            evicted.append(victim)
+        }
+
+        // Forget idle stamps for tabs we no longer hold anything for, so the
+        // dictionary cannot grow without bound over a long session. A tab that
+        // is still open just re-stamps on its next activation.
+        let live = Set(entries.keys.map(\.tabId)).union(pinned)
+        lastActiveByTab = lastActiveByTab.filter { live.contains($0.key) }
+
+        stopSweeperIfIdle()
+        return evicted
+    }
+
+    private func residentTabsByIdleDescending(excluding pinned: Set<String>) -> [String] {
+        var idleByTab: [String: Duration] = [:]
+        for (key, entry) in entries where !pinned.contains(key.tabId) {
+            // If a tab somehow holds two slots with different stamps, the older
+            // one wins — evict on the most pessimistic reading.
+            idleByTab[key.tabId] = min(idleByTab[key.tabId] ?? entry.lastActive, entry.lastActive)
+        }
+        return idleByTab.sorted { $0.value < $1.value }.map(\.key)
+    }
+
+    // MARK: - Introspection (diagnostics + tests)
+
+    var residentTabIds: Set<String> { Set(entries.keys.map(\.tabId)) }
+    var residentTabCount: Int { residentTabIds.count }
+    var residentBytes: Int { entries.values.reduce(0) { $0 + $1.resource.residencyCostBytes } }
+    var isSweeping: Bool { sweepTask != nil }
+
+    // MARK: - Background machinery
+
+    /// One shared sweeper for the whole app, started lazily on the first
+    /// resident resource and stopped as soon as nothing is resident — an idle
+    /// Vellum schedules no timer at all.
+    private func startSweeperIfNeeded() {
+        guard automaticMaintenance, sweepTask == nil, !entries.isEmpty else { return }
+        sweepTask = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: Self.sweepInterval, tolerance: Self.sweepTolerance)
+                } catch {
+                    return  // cancelled
+                }
+                guard let self, !Task.isCancelled else { return }
+                self.sweep()
+            }
+        }
+    }
+
+    /// `sweep()` calls this, so the loop cancels *itself* once the last resource
+    /// is gone; the `Task.isCancelled` check at the top of the loop then exits.
+    private func stopSweeperIfIdle() {
+        guard entries.isEmpty, let task = sweepTask else { return }
+        sweepTask = nil
+        task.cancel()
+    }
+
+    /// Subscribe to the kernel's memory-pressure notifications. `DispatchSource`
+    /// (rather than `NSApplication`, which has no equivalent signal on macOS) is
+    /// the supported way to hear about this; the handler is delivered on the main
+    /// queue so it can go straight into the main-actor eviction path.
+    private func installMemoryPressureSource() {
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical], queue: .main)
+        source.setEventHandler { [weak self] in
+            let data = source.data
+            // The handler runs on DispatchQueue.main, which *is* the main actor's
+            // executor, but Dispatch cannot express that in the type system.
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                if data.contains(.critical) {
+                    self.handleMemoryPressure(.critical)
+                } else if data.contains(.warning) {
+                    self.handleMemoryPressure(.warning)
+                }
+            }
+        }
+        source.resume()
+        pressureSource = source
+    }
+}

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -16,35 +16,84 @@ final class AppStore {
 
     let sessions: SessionService
 
-    // MARK: - Prepared-PDF cache
+    /// The app-wide open-tab retention policy (issue #52). Everything expensive a
+    /// tab owns — its prepared `PDFDocument`, its live `WKWebView` — is parked
+    /// here instead of being dropped on the way out of the tab, and is only
+    /// reclaimed after `TabResidencyManager.retentionWindow` of inactivity, when
+    /// a ceiling is hit, or when the system reports memory pressure. See
+    /// Services/TabResidency.swift for the policy itself.
+    @ObservationIgnored let residency: TabResidencyManager
+
+    /// This pane's identity in the residency manager's per-pane "active tab"
+    /// table. One `AppStore` backs exactly one pane, so its object identity is
+    /// the natural key.
+    @ObservationIgnored private lazy var residencyOwner = ObjectIdentifier(self)
+
+    // MARK: - Prepared-PDF residency
     //
     // Switching tabs tears down and rebuilds the viewer (`.id(activeTabId)`), so
     // without a cache every switch re-reads + re-parses + re-strips the whole PDF
-    // (now off-main, but still a visible delay for large docs). Cache the display-
-    // ready PDFDocument per tab so switching back is instant. A stripped display
-    // doc stays valid across annotation edits (annotations render from overlays,
-    // page content is unchanged), so no invalidation is needed beyond close/LRU.
-    private static let maxPreparedCache = 3
-    @ObservationIgnored private var preparedPdfCache: [(tabId: String, doc: PDFDocument)] = []
+    // (off-main, but still a visible delay for large docs) and re-hashes the bytes
+    // to consult the page-text cache. Keeping the display-ready PDFDocument (and
+    // the page text that came with it) resident makes switching back instant. A
+    // stripped display doc stays valid across annotation edits — annotations
+    // render from store overlays and the page content is unchanged — so nothing
+    // invalidates it except closing the tab or the residency policy reclaiming it.
 
-    func cachedPreparedPdf(tabId: String) -> PDFDocument? {
-        guard let index = preparedPdfCache.firstIndex(where: { $0.tabId == tabId }) else { return nil }
-        // Touch: move to most-recently-used.
-        let entry = preparedPdfCache.remove(at: index)
-        preparedPdfCache.append(entry)
-        return entry.doc
+    func cachedPreparedPdf(tabId: String) -> PreparedPdfResidency? {
+        residency.resource(tabId: tabId, slot: .preparedPdf) as? PreparedPdfResidency
     }
 
-    func storePreparedPdf(_ doc: PDFDocument, tabId: String) {
-        preparedPdfCache.removeAll { $0.tabId == tabId }
-        preparedPdfCache.append((tabId, doc))
-        if preparedPdfCache.count > Self.maxPreparedCache {
-            preparedPdfCache.removeFirst()
+    func storePreparedPdf(
+        _ doc: PDFDocument, pageTexts: [Int: String], byteCount: Int, tabId: String
+    ) {
+        residency.store(
+            PreparedPdfResidency(document: doc, pageTexts: pageTexts, byteCount: byteCount),
+            tabId: tabId, slot: .preparedPdf)
+    }
+
+    /// Fold newly extracted page text back into the resident entry so the next
+    /// visit to this tab skips the extraction walk as well as the parse. Called
+    /// from the viewer's teardown with the *persister's* authoritative dict —
+    /// never with `AiStore.pageTexts`, which by then may already belong to the
+    /// incoming tab.
+    func updatePreparedPdfPageTexts(_ pageTexts: [Int: String], tabId: String) {
+        guard !pageTexts.isEmpty, let entry = cachedPreparedPdf(tabId: tabId) else { return }
+        entry.pageTexts.merge(pageTexts) { _, new in new }
+    }
+
+    // MARK: - Web-view residency
+    //
+    // The web path was the worse of the two: a fresh `WKWebView` per mount meant
+    // every switch back re-navigated through the vellum-web:// proxy, which
+    // re-FETCHES the page over the network unless the tab is a snapshot-only
+    // archive. Keeping the controller (and therefore the web view, its process,
+    // its scroll offset, and its running page) resident turns that into a
+    // re-parent of an already-loaded view.
+
+    /// The web viewer for `tabId`, created on first use. Handing the *same*
+    /// controller back on a later mount is what makes the tab resume rather than
+    /// reload; `WebViewerController.attach` detects the warm case and skips the
+    /// navigation.
+    func residentWebController(tabId: String) -> WebViewerController {
+        if let existing = residency.resource(tabId: tabId, slot: .webView) as? WebViewerController {
+            return existing
         }
+        let controller = WebViewerController()
+        residency.store(controller, tabId: tabId, slot: .webView)
+        return controller
     }
 
-    func evictPreparedPdf(tabId: String) {
-        preparedPdfCache.removeAll { $0.tabId == tabId }
+    /// The tab is gone for good — hand its memory back now rather than letting
+    /// the retention window run.
+    func evictResidentResources(tabId: String) {
+        residency.release(tabId: tabId)
+    }
+
+    /// This pane is being discarded (split collapsed / panes merged). Drop its
+    /// pin so the tab it last showed is no longer exempt from eviction.
+    func releaseResidencyOwnership() {
+        residency.forgetOwner(residencyOwner)
     }
 
     // Tab state
@@ -115,8 +164,9 @@ final class AppStore {
     /// has (issue #37 PR B).
     var flushPageTextCacheHandler: (() async -> Void)?
 
-    init(sessions: SessionService) {
+    init(sessions: SessionService, residency: TabResidencyManager = .shared) {
         self.sessions = sessions
+        self.residency = residency
     }
 
     // MARK: - Opening documents
@@ -242,7 +292,9 @@ final class AppStore {
     func closeTab(_ tabId: String) async {
         guard let closingIndex = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let closingTab = tabs[closingIndex]
-        evictPreparedPdf(tabId: tabId)
+        // Closing is not "inactive" — the tab is gone, so its resident PDF /
+        // web view is released immediately instead of waiting out the window.
+        evictResidentResources(tabId: tabId)
         // Start tabs carry no backend session — skip the metadata/close round
         // trips that would otherwise fire against a nonexistent session id.
         if closingTab.document != nil {
@@ -758,6 +810,10 @@ final class AppStore {
         // registers its own handlers on mount.
         resetFindState()
         pendingNoteContent = nil
+        // Pin the incoming tab (never evictable while on screen) and restart the
+        // outgoing tab's idle countdown from now — it was in use until this
+        // instant, so its two hours start here.
+        residency.markActive(tabId: tab.id, owner: residencyOwner)
         activeTabId = tab.id
         document = tab.document
         currentPage = tab.currentPage
@@ -772,6 +828,8 @@ final class AppStore {
     private func applyEmptyActiveState() {
         resetFindState()
         pendingNoteContent = nil
+        // No tab on screen here, so this pane pins nothing.
+        residency.markActive(tabId: nil, owner: residencyOwner)
         activeTabId = nil
         document = nil
         currentPage = 1
@@ -793,5 +851,36 @@ final class AppStore {
         var tab = tabs[index]
         mutate(&tab)
         tabs[index] = tab
+    }
+}
+
+/// A PDF tab's resident state: the parsed, annotation-stripped display document
+/// plus whatever page text has been resolved for it (seeded from the on-disk
+/// `PageTextCache`, topped up by the extraction walk). Held as a class so the
+/// viewer can top up `pageTexts` in place without disturbing the residency
+/// entry's idle stamp.
+@MainActor
+final class PreparedPdfResidency: TabResidentResource {
+    let document: PDFDocument
+    var pageTexts: [Int: String]
+    /// Size of the PDF bytes this document was parsed from. PDFKit's own
+    /// footprint is larger (and unknowable), but the file size tracks it closely
+    /// enough to rank eviction candidates and enforce the byte budget.
+    private let byteCount: Int
+
+    init(document: PDFDocument, pageTexts: [Int: String], byteCount: Int) {
+        self.document = document
+        self.pageTexts = pageTexts
+        self.byteCount = byteCount
+    }
+
+    var residencyCostBytes: Int { byteCount }
+
+    func releaseResidency() {
+        // Nothing to flush. The display document is a throwaway copy — every
+        // annotation edit is written through the session backend to the file on
+        // disk, and the page text mirrored here has already been persisted by
+        // `PageTextPersister` (the viewer's teardown flushes it before handing
+        // the dict over). Dropping the last reference is the whole eviction.
     }
 }

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -226,7 +226,11 @@ final class WorkspaceStore {
     /// Collapse a pane; its sibling reclaims the space. Closing the last pane
     /// resets the window to a single empty pane.
     func closePane(_ paneId: String) {
-        guard root.leaf(id: paneId) != nil else { return }
+        guard let closing = root.leaf(id: paneId) else { return }
+        // The pane is going away, so its "this tab is on screen" pin in the
+        // residency policy must go with it — otherwise whatever it last showed
+        // stays exempt from eviction for the life of the process.
+        closing.app.releaseResidencyOwnership()
         if root.isLeaf {
             let pane = makePane(startTab: false)
             root = .leaf(pane)
@@ -265,6 +269,9 @@ final class WorkspaceStore {
             for tab in leaf.app.tabs {
                 keep.app.attachTab(tab)
             }
+            // Same reasoning as closePane: the absorbed pane is discarded, so
+            // drop its residency pin (its tabs are now pinned, or not, by `keep`).
+            leaf.app.releaseResidencyOwnership()
         }
         if let keepActiveTabId {
             keep.app.activateTab(keepActiveTabId)

--- a/Vellum/Views/PDF/PdfSelectionBridge.swift
+++ b/Vellum/Views/PDF/PdfSelectionBridge.swift
@@ -730,6 +730,11 @@ final class PdfViewerController {
         self.persister = persister
     }
 
+    /// Page text the current document has resolved so far (cache seed + walk),
+    /// or nil when no persister is installed. Read by the viewer's teardown to
+    /// top up the tab's residency entry (issue #52).
+    var persistedPageTexts: [Int: String]? { persister?.extractedPages }
+
     /// Flush any pending page text to disk (outgoing doc on tab switch, quit).
     func flushPersister() async {
         await persister?.flush()

--- a/Vellum/Views/PDF/PdfViewerView.swift
+++ b/Vellum/Views/PDF/PdfViewerView.swift
@@ -94,16 +94,29 @@ struct PdfViewerView: View {
         // clears it alongside the local state reset).
         aiStore.clearDocumentContext()
         do {
-            // The persistent text cache is keyed by the current PDF bytes, so
-            // read them even when this tab can reuse an already prepared PDF.
-            let data = try await app.sessions.readPdfBytes(sessionId: tabId)
-            guard !Task.isCancelled, app.activeTabId == tabId else { return }
+            // Storage key resolved from the just-opened DocumentInfo: its docId
+            // when the file carries one, else the path hash. The IO actor keyed
+            // itself the same way at open, so lookup, persister, and every
+            // in-app refreshHash agree for the whole session.
+            let storageKey = app.document.map { DocumentIdentity.storageKey(for: $0) }
+            let path = app.document?.pdfPath
             let document: PDFDocument
-            if let cached = app.cachedPreparedPdf(tabId: tabId) {
-                // Fast path: this tab was opened recently — reuse the prepared
-                // document, skipping the disk read, parse, and strip entirely.
-                document = cached
+            let pageTexts: [Int: String]
+
+            if let resident = app.cachedPreparedPdf(tabId: tabId) {
+                // Warm path (issue #52): the tab never left residency, so skip
+                // the disk read, the parse, the annotation strip AND the
+                // page-text cache lookup — the latter hashes the entire file,
+                // which is the other half of the cost on a large PDF. The
+                // resident page text is at least as good as a fresh lookup: it
+                // was seeded from the on-disk cache and topped up by this tab's
+                // own extraction walk (see teardown), and page text does not
+                // change when an annotation is added.
+                document = resident.document
+                pageTexts = resident.pageTexts
             } else {
+                let data = try await app.sessions.readPdfBytes(sessionId: tabId)
+                guard !Task.isCancelled, app.activeTabId == tabId else { return }
                 // Parse the PDF and strip its embedded annotations OFF the main
                 // thread — both are heavy CGPDF work that would otherwise freeze
                 // the UI (beachball) on every tab switch for a large document.
@@ -123,29 +136,26 @@ struct PdfViewerView: View {
                     loadState = .parseFailed
                     return
                 }
-                app.storePreparedPdf(parsed, tabId: tabId)
+                // Restore persisted page text before adopting (PDF only; this
+                // view is guarded to document.kind == .pdf). Hashing + JSON
+                // decode run off the main actor inside the cache actor.
+                let cached: [Int: String]?
+                if let path, let storageKey {
+                    cached = await PageTextCache.shared.lookup(
+                        key: storageKey, path: path, data: data, title: app.document?.title)
+                } else {
+                    cached = nil
+                }
+                guard !Task.isCancelled, app.activeTabId == tabId else { return }
                 document = parsed
+                pageTexts = cached ?? [:]
+                app.storePreparedPdf(
+                    parsed, pageTexts: pageTexts, byteCount: data.count, tabId: tabId)
             }
-            // Restore persisted page text before adopting (PDF only; this view
-            // is guarded to document.kind == .pdf). Hashing + JSON decode run
-            // off the main actor inside the cache actor.
-            // Storage key resolved from the just-opened DocumentInfo: its docId
-            // when the file carries one, else the path hash. The IO actor keyed
-            // itself the same way at open, so lookup, persister, and every
-            // in-app refreshHash agree for the whole session.
-            let storageKey = app.document.map { DocumentIdentity.storageKey(for: $0) }
-            let cached: [Int: String]?
-            if let path = app.document?.pdfPath, let storageKey {
-                cached = await PageTextCache.shared.lookup(
-                    key: storageKey, path: path, data: data, title: app.document?.title)
-            } else {
-                cached = nil
-            }
-            guard !Task.isCancelled, app.activeTabId == tabId else { return }
             // Unconditional replace (empty on a miss): anything an outgoing
             // tab's extraction wrote into pageTexts during the awaits above
             // belongs to the OLD document and must not survive into this one.
-            aiStore.restorePageTexts(cached ?? [:])
+            aiStore.restorePageTexts(pageTexts)
             controller.adopt(
                 document: document,
                 app: app,
@@ -154,13 +164,13 @@ struct PdfViewerView: View {
                 initialPage: app.currentPage
             )
             app.setNumPages(document.pageCount)
-            if document.pageCount >= 1, let path = app.document?.pdfPath, let storageKey {
+            if document.pageCount >= 1, let path, let storageKey {
                 controller.installPersister(PageTextPersister(
                     key: storageKey,
                     path: path,
                     title: app.document?.title,
                     pageCount: document.pageCount,
-                    seeded: cached ?? [:]))
+                    seeded: pageTexts))
             }
             registerHandlers()
             handlersTabId = tabId
@@ -232,6 +242,16 @@ struct PdfViewerView: View {
         // handlers never leak.
         if app.activeTabId == handlersTabId || app.document == nil {
             unregisterHandlers()
+            // Fold what this tab's extraction walk produced back into its
+            // resident entry BEFORE the persister is dropped, so the next visit
+            // resumes with a full page-text set instead of re-walking the
+            // document. Taken from the persister (which owns the authoritative
+            // dict) and never from AiStore.pageTexts, which by now may already
+            // belong to the incoming tab. This is a warm-cache top-up, not a
+            // substitute for persistence — flushAndDropPersister still writes.
+            if let tabId = handlersTabId, let extracted = controller.persistedPageTexts {
+                app.updatePreparedPdfPageTexts(extracted, tabId: tabId)
+            }
             controller.flushAndDropPersister()
             aiStore.clearDocumentContext()
         }

--- a/Vellum/Views/Panes/PaneView.swift
+++ b/Vellum/Views/Panes/PaneView.swift
@@ -112,9 +112,15 @@ struct PaneView: View {
     private var content: some View {
         if app.document == nil {
             WelcomeScreen()
-        } else if app.document?.kind == .web {
-            WebViewerView()
-                .id(app.activeTabId)
+        } else if app.document?.kind == .web, let tabId = app.activeTabId {
+            // The web controller (and its WKWebView) is owned by the tab
+            // residency policy, not by the view — looking it up by tab id here
+            // is what lets a return visit re-parent the already-loaded page
+            // instead of building a new web view and re-fetching (issue #52).
+            // The lookup is idempotent: the same tab id always yields the same
+            // controller until the tab closes or residency reclaims it.
+            WebViewerView(controller: app.residentWebController(tabId: tabId))
+                .id(tabId)
         } else {
             PdfViewerView()
                 .id(app.activeTabId)

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -58,13 +58,22 @@ struct WebHighlightEditorState {
 // MARK: - View
 
 struct WebViewerView: View {
+    /// The tab's controller, owned by `TabResidencyManager` rather than by this
+    /// view (issue #52). `PaneView` looks it up per tab id, so switching away and
+    /// back hands the SAME controller — and therefore the same already-loaded
+    /// `WKWebView` — to the new mount instead of building one from scratch and
+    /// re-fetching the page. It is only really destroyed when the tab closes or
+    /// the residency policy reclaims it.
+    let controller: WebViewerController
+
     @Environment(AppStore.self) private var appStore
     @Environment(AnnotationStore.self) private var annotationStore
     @Environment(AiStore.self) private var aiStore
     @Environment(ScratchpadStore.self) private var scratchpadStore
     @Environment(\.palette) private var palette
 
-    @State private var controller = WebViewerController()
+    /// This mount's attach token — see `WebViewerController.mountGeneration`.
+    @State private var mountToken = 0
 
     var body: some View {
         GeometryReader { proxy in
@@ -182,10 +191,14 @@ struct WebViewerView: View {
         .background(palette.well)
         .clipped()
         .onAppear {
-            controller.attach(app: appStore, annotationStore: annotationStore, aiStore: aiStore)
+            mountToken = controller.attach(
+                app: appStore, annotationStore: annotationStore, aiStore: aiStore)
         }
         .onDisappear {
-            controller.detach()
+            // Hand the token back: the controller outlives this view, so it has
+            // to be able to tell this teardown from a stale one belonging to a
+            // mount it has already replaced.
+            controller.detach(token: mountToken)
         }
         .onChange(of: controller.initCount) {
             controller.pushAnnotations(annotationStore.annotations)
@@ -265,7 +278,14 @@ private struct WebViewRepresentable: NSViewRepresentable {
     let controller: WebViewerController
 
     func makeNSView(context: Context) -> WKWebView {
-        controller.webView
+        // The web view outlives this representable (see WebViewerView.controller),
+        // so it may still be sitting in the previous mount's host hierarchy when
+        // SwiftUI builds the replacement — SwiftUI mounts the incoming view
+        // before unmounting the outgoing one. Detach it first so the new host
+        // adopts a parentless view, exactly as it would a freshly created one.
+        let webView = controller.webView
+        webView.removeFromSuperview()
+        return webView
     }
 
     func updateNSView(_ nsView: WKWebView, context: Context) {}
@@ -275,7 +295,14 @@ private struct WebViewRepresentable: NSViewRepresentable {
 
 @MainActor
 @Observable
-final class WebViewerController: NSObject {
+final class WebViewerController: NSObject, TabResidentResource {
+    /// Rough resident footprint, used only to rank eviction candidates and
+    /// enforce the residency byte budget. A loaded `WKWebView` carries its own
+    /// web content process, so it is never cheap; there is no way to ask WebKit
+    /// what a given page actually costs, so this is a flat, deliberately
+    /// pessimistic estimate for "a real webpage with its process attached".
+    var residencyCostBytes: Int { 96 * 1024 * 1024 }
+
     // Counts inits from the document currently bound to this tab; 0 = nothing
     // loaded yet. A counter (not a boolean) so highlight application re-fires
     // after in-tab navigation replaces the document.
@@ -311,6 +338,12 @@ final class WebViewerController: NSObject {
     @ObservationIgnored private weak var aiStore: AiStore?
     @ObservationIgnored private var mountTabId: String?
     @ObservationIgnored private var attached = false
+    /// Bumped on every `attach`. Because the controller now outlives its view
+    /// (issue #52), the same object can be attached by a new mount before the
+    /// previous mount's `onDisappear` runs — and that late `detach()` would rip
+    /// the handler slots out from under the live mount. The view hands its token
+    /// back on the way out so a stale teardown is recognised and ignored.
+    @ObservationIgnored private var mountGeneration = 0
     // Whether the injected content script supports point anchors (declared in
     // its init handshake).
     @ObservationIgnored private var supportsPositions = false
@@ -334,6 +367,16 @@ final class WebViewerController: NSObject {
     @ObservationIgnored private var pendingLocates: [String: (LocatedText?) -> Void] = [:]
     @ObservationIgnored private var pendingCaptures: [String: (CapturedWebPosition?) -> Void] = [:]
     @ObservationIgnored private var eventMonitor: Any?
+    /// The document the web view is *confirmed* to be showing, as reported by
+    /// the content script's init handshake — not merely what we last asked it to
+    /// load. `attach` uses it to tell a warm resume (page already there, just
+    /// re-parent) from a cold mount (navigate). Derived from the page itself so
+    /// redirects, soft navigations, and snapshot fallbacks can't desync it; nil
+    /// whenever a load is in flight.
+    @ObservationIgnored private var loadedUrl: String?
+    /// See `pushAnnotations`: swallows the single empty annotation push that a
+    /// warm resume's store reload produces.
+    @ObservationIgnored private var skipEmptyAnnotationPush = false
 
     @ObservationIgnored private lazy var _webView: WKWebView = makeWebView()
     var webView: WKWebView { _webView }
@@ -375,9 +418,22 @@ final class WebViewerController: NSObject {
 
     // MARK: Lifecycle
 
-    func attach(app: AppStore, annotationStore: AnnotationStore, aiStore: AiStore) {
-        guard !attached else { return }
+    /// Bind the controller to a mount. Returns the mount token to hand back to
+    /// `detach(token:)`.
+    @discardableResult
+    func attach(app: AppStore, annotationStore: AnnotationStore, aiStore: AiStore) -> Int {
+        mountGeneration += 1
+        let token = mountGeneration
+        // Already live (a re-mount raced the previous mount's teardown): the
+        // registrations below are idempotent for the same tab, so just hand out
+        // the new token — its predecessor's detach will now be ignored.
+        guard !attached else { return token }
         attached = true
+        bind(app: app, annotationStore: annotationStore, aiStore: aiStore)
+        return token
+    }
+
+    private func bind(app: AppStore, annotationStore: AnnotationStore, aiStore: AiStore) {
         self.app = app
         self.annotationStore = annotationStore
         self.aiStore = aiStore
@@ -420,15 +476,53 @@ final class WebViewerController: NSObject {
             self?.printPage()
         }
 
-        if let doc = app.document, doc.kind == .web {
-            webView.load(URLRequest(url: VellumWebSchemeHandler.proxyUrl(for: doc.pdfPath)))
+        guard let doc = app.document, doc.kind == .web else { return }
+
+        if loadedUrl == doc.pdfPath {
+            // Warm resume (issue #52). This controller kept its WKWebView across
+            // the tab switch — the rendered DOM, the scroll offset, the running
+            // web content process and the injected content script are all still
+            // there — so re-parenting the view is the entire job. Reloading here
+            // would throw away precisely what we were holding it for, and for a
+            // live page it would re-fetch over the network.
+            //
+            // No new init handshake fires, so the view's
+            // `onChange(of: controller.initCount)` push never runs; replay the
+            // parts of it that are cheap and non-destructive. Annotations are
+            // deliberately NOT pushed here — they are already rendered in the
+            // page, and `PaneView` is concurrently reloading the store (clear →
+            // fetch), so its `onChange(of:annotations)` will push the real set.
+            pushMode(app.mode)
+            pushSelectedHighlight()
+            skipEmptyAnnotationPush = true
+            return
         }
+
+        loadedUrl = nil
+        webView.load(URLRequest(url: VellumWebSchemeHandler.proxyUrl(for: doc.pdfPath)))
     }
 
-    func detach() {
+    /// Leave the tab: the view is unmounting, but the page stays loaded and the
+    /// web view stays alive under the residency policy. Only things bound to
+    /// *being on screen* are undone here — the shared handler slots, the
+    /// click-outside monitor, and any async request whose caller has gone away.
+    ///
+    /// Note what is deliberately NOT undone any more: the script message handler
+    /// stays registered and `stopLoading()` is not called, because tearing those
+    /// down is exactly what made a return visit expensive. A pending auto-archive
+    /// is also left to complete rather than cancelled — it is a real write, it is
+    /// already scoped to its own session id and URL, and dropping it silently
+    /// lost the archive whenever the user switched tabs within 1.5s of a page
+    /// finishing. Hard teardown lives in `releaseResidency()`.
+    func detach(token: Int) {
+        // Stale teardown from a mount this controller has already replaced.
+        guard token == mountGeneration else { return }
+        detach()
+    }
+
+    private func detach() {
         guard attached else { return }
         attached = false
-        cancelPendingArchive()
         for resolve in pendingLocates.values { resolve(nil) }
         pendingLocates.removeAll()
         for resolve in pendingCaptures.values { resolve(nil) }
@@ -447,9 +541,41 @@ final class WebViewerController: NSObject {
             app.findClearHandler = nil
             app.printHandler = nil
         }
+        // Popovers are anchored to a view that is going away; a resident
+        // controller would otherwise re-show them floating over the next mount.
+        clearSelection()
+        closeNotePopovers()
+        hideContextMenu()
+    }
+
+    /// Hard teardown, driven by `TabResidencyManager`: the tab was closed, sat
+    /// idle past the retention window, or the system asked for memory back. This
+    /// is the point at which the page really is thrown away.
+    func releaseResidency() {
+        // Defensive: eviction only ever targets tabs that are not on screen, so
+        // `detach()` has normally already run. Belt and braces if it hasn't.
+        detach()
+        // A debounced auto-archive is a real write to the user's library. Never
+        // drop one — keep this controller (and the session it archives through)
+        // alive until the task lands. The debounce is 1.5s, so by the time the
+        // two-hour timeout fires there is nothing pending; this only matters for
+        // an eviction triggered by memory pressure moments after a page loaded.
+        if let archiveTask {
+            self.archiveTask = nil
+            Task { await archiveTask.value; withExtendedLifetime(self) {} }
+        }
+        loadedUrl = nil
+        initCount = 0
+        restoredUrl = nil
+        archivedUrl = nil
         webView.configuration.userContentController
             .removeScriptMessageHandler(forName: "vellum", contentWorld: Self.bridgeWorld)
         webView.stopLoading()
+        // Navigate to a blank page so WebKit can retire the web content process
+        // and its memory now, rather than whenever this object happens to be
+        // deallocated (the caller drops its reference immediately after, but the
+        // web view can be briefly retained by an in-flight AppKit teardown).
+        webView.loadHTMLString("", baseURL: nil)
     }
 
     // MARK: Outbound commands
@@ -603,6 +729,17 @@ final class WebViewerController: NSObject {
 
     func pushAnnotations(_ annotations: [Annotation]) {
         guard initCount > 0 else { return }
+        if skipEmptyAnnotationPush {
+            // Warm resume: the page already carries the right highlights, but
+            // `PaneView.loadDocumentState` reloads the store by clearing it and
+            // re-fetching, so the first push we see is a transient empty array.
+            // Applying it would visibly strip every highlight off the page and
+            // re-add it a beat later. Swallow exactly that one push — the
+            // reload's real result arrives on the next change, and a document
+            // that genuinely has no annotations has none in the page either.
+            skipEmptyAnnotationPush = false
+            if annotations.isEmpty { return }
+        }
 
         func anchor(_ annotation: Annotation) -> [String: Any] {
             [
@@ -1110,8 +1247,23 @@ final class WebViewerController: NSObject {
     /// Rebind the tab to a new page and reload the reader — used by the
     /// content script's link interception, the navigation delegate's escape
     /// hatch for router-driven top-level loads, and window.open routing.
+    /// The document THIS controller is bound to.
+    ///
+    /// Since the controller now outlives its mount (issue #52), a background
+    /// tab's web view is still live and its WebKit delegates still fire — so
+    /// anything acting on "the document" must resolve the controller's OWN tab
+    /// rather than `AppStore.document`, which is whatever is on screen right
+    /// now. Reading the wrong one would let a background page hijack the
+    /// foreground tab: a meta-refresh rebinding someone else's session, or a
+    /// crashed background web process reloading the visible tab's URL.
+    private var mountedDocument: DocumentInfo? {
+        guard let app, let mountTabId else { return nil }
+        return app.tabs.first { $0.id == mountTabId }?.document
+    }
+
     func navigateTo(_ url: String) {
-        guard let app, let tabId = app.activeTabId else { return }
+        // `mountTabId`, not `app.activeTabId` — see `mountedDocument`.
+        guard let app, let tabId = mountTabId else { return }
         // A pending auto-archive for the outgoing page must not fire
         // against the rebound session.
         cancelPendingArchive()
@@ -1124,13 +1276,14 @@ final class WebViewerController: NSObject {
         processReloadedUrl = nil
         clearSelection()
         closeNotePopovers()
-        let outgoing = app.document?.pdfPath
+        let outgoing = mountedDocument?.pdfPath
         Task { [weak self] in
             guard let rebound = await app.webNavigated(tabId: tabId, url: url),
                   let self else { return }
             self.pendingNavUrl = rebound.pdfPath
             self.outgoingNavUrl = outgoing
             self.initCount = 0
+            self.loadedUrl = nil
             self.webView.load(
                 URLRequest(url: VellumWebSchemeHandler.proxyUrl(for: rebound.pdfPath)))
         }
@@ -1187,6 +1340,7 @@ final class WebViewerController: NSObject {
                     self.pendingNavUrl = rebound.pdfPath
                     self.outgoingNavUrl = nil
                     self.initCount = 0
+                    self.loadedUrl = nil
                     self.webView.load(
                         URLRequest(url: VellumWebSchemeHandler.proxyUrl(for: rebound.pdfPath)))
                 } else {
@@ -1197,6 +1351,11 @@ final class WebViewerController: NSObject {
         }
 
         initCount += 1
+        // The page itself has now confirmed which document it is showing, which
+        // is what `attach` checks to decide "warm resume" vs "navigate". Taking
+        // it from the handshake rather than from the last `load()` call keeps it
+        // truthful through redirects, soft navigations and snapshot fallbacks.
+        loadedUrl = currentDoc.pdfPath
 
         if let pageCount = intValue(data["pageCount"]), pageCount > 0 {
             app.setNumPages(pageCount)
@@ -1414,12 +1573,15 @@ extension WebViewerController: WKNavigationDelegate, WKUIDelegate {
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        guard let doc = app?.document, doc.kind == .web else { return }
+        // Resolve this controller's own tab, never the one on screen — a
+        // resident background web view can lose its content process too.
+        guard let doc = mountedDocument, doc.kind == .web else { return }
         if processReloadedUrl == doc.pdfPath {
             loadSnapshotFallback()
         } else {
             processReloadedUrl = doc.pdfPath
             initCount = 0
+            loadedUrl = nil
             webView.load(URLRequest(url: VellumWebSchemeHandler.proxyUrl(for: doc.pdfPath)))
         }
     }
@@ -1437,10 +1599,11 @@ extension WebViewerController: WKNavigationDelegate, WKUIDelegate {
     /// Serve the offline snapshot (or Vellum's own error page) instead of
     /// ever leaving the user on WebKit's native error screen.
     private func loadSnapshotFallback() {
-        guard let app, let doc = app.document, doc.kind == .web else { return }
+        guard let doc = mountedDocument, doc.kind == .web else { return }
         // The fallback itself failing must not loop.
         guard webView.url?.host != VellumWebSchemeHandler.snapshotHost else { return }
         initCount = 0
+        loadedUrl = nil
         webView.load(URLRequest(
             url: VellumWebSchemeHandler.snapshotUrl(forKey: WebLibrary.pageKey(doc.pdfPath))))
     }

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -424,16 +424,37 @@ final class WebViewerController: NSObject, TabResidentResource {
     func attach(app: AppStore, annotationStore: AnnotationStore, aiStore: AiStore) -> Int {
         mountGeneration += 1
         let token = mountGeneration
-        // Already live (a re-mount raced the previous mount's teardown): the
-        // registrations below are idempotent for the same tab, so just hand out
-        // the new token — its predecessor's detach will now be ignored.
-        guard !attached else { return token }
+        // A re-mount can race the outgoing mount's teardown, because SwiftUI
+        // mounts the incoming view before unmounting the outgoing one. It is
+        // tempting to treat that as "already live, nothing to do" — but the
+        // incoming mount can belong to a DIFFERENT pane. A tab keeps its id (and
+        // therefore its resident controller) when it is dragged between panes
+        // (`WorkspaceStore.moveTab` / `splitWithTab`) or absorbed by View ▸ Merge
+        // Panes, and each pane has its own `AppStore`, `AnnotationStore` and
+        // `AiStore`. Skipping the rebind left the controller wired to the pane
+        // the tab had just left — for the rest of the process, since the stale
+        // mount's `detach` is then ignored by the token check below. The tab
+        // still rendered, but find/print/scroll-to-page and the AI locate and
+        // capture hooks were registered on the wrong store, `mountedDocument`
+        // resolved against a store whose `tabs` no longer contained the tab
+        // (killing web-process crash recovery), and `handleMessage`'s
+        // `activeTabId == mountTabId` guard compared against the wrong pane, so
+        // every inbound script message — scroll position, selection, context
+        // menu, note placement — was silently dropped.
+        //
+        // Rebinding is idempotent (all the slots below are plain assignments),
+        // so doing it unconditionally is both the simple and the correct answer.
+        let isRemount = attached
         attached = true
-        bind(app: app, annotationStore: annotationStore, aiStore: aiStore)
+        bind(
+            app: app, annotationStore: annotationStore, aiStore: aiStore,
+            isRemount: isRemount)
         return token
     }
 
-    private func bind(app: AppStore, annotationStore: AnnotationStore, aiStore: AiStore) {
+    private func bind(
+        app: AppStore, annotationStore: AnnotationStore, aiStore: AiStore, isRemount: Bool
+    ) {
         self.app = app
         self.annotationStore = annotationStore
         self.aiStore = aiStore
@@ -498,6 +519,12 @@ final class WebViewerController: NSObject, TabResidentResource {
             return
         }
 
+        // Cold: nothing confirmed in the view, so navigate. Except on a remount,
+        // where `loadedUrl` is nil only because this tab's own load is still in
+        // flight (it is set by the page's init handshake) — the previous mount
+        // already started it, and kicking off a second one would re-fetch
+        // exactly what we are waiting for and reset the page's progress.
+        guard !isRemount else { return }
         loadedUrl = nil
         webView.load(URLRequest(url: VellumWebSchemeHandler.proxyUrl(for: doc.pdfPath)))
     }
@@ -568,6 +595,24 @@ final class WebViewerController: NSObject, TabResidentResource {
         initCount = 0
         restoredUrl = nil
         archivedUrl = nil
+        // Unhook the WebKit delegates BEFORE the teardown navigation below, for
+        // two independent reasons.
+        //
+        // 1. `decidePolicyFor` cancels every non-http(s) main-frame navigation
+        //    that is not one of our own proxy schemes — which includes the
+        //    about:blank the blank-out produces. With the delegate still
+        //    installed the blank load is simply refused and the page (and its
+        //    web content process) stays put, so the eviction frees nothing.
+        //
+        // 2. The delegates are a resurrection path. A timed or pressure eviction
+        //    targets a tab that is still OPEN, so `mountedDocument` still
+        //    resolves — and a late `webViewWebContentProcessDidTerminate` would
+        //    re-load the tab's real URL over the network into a view nobody can
+        //    see. That callback is not hypothetical here: jetsamming background
+        //    web content processes is precisely what the system does under the
+        //    memory pressure that triggered the eviction in the first place.
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
         webView.configuration.userContentController
             .removeScriptMessageHandler(forName: "vellum", contentWorld: Self.bridgeWorld)
         webView.stopLoading()
@@ -1047,7 +1092,24 @@ final class WebViewerController: NSObject, TabResidentResource {
               let app else { return }
         // Drop messages queued from before a tab switch: this viewer belongs
         // to one tab, and acting on another tab's state would corrupt it.
-        guard app.activeTabId == mountTabId else { return }
+        guard app.activeTabId == mountTabId else {
+            // …but a resident background tab is a live page that can navigate
+            // itself while we are not looking (a meta refresh, an SPA timer, a
+            // redirect that lands after the user switched away). We still must
+            // not act on the message — that would write the FOREGROUND tab's
+            // state — yet an `init` reporting a different URL tells us the view
+            // no longer shows what `loadedUrl` claims. Left standing, `attach`
+            // would take the warm-resume shortcut on the way back and adopt the
+            // new page under the old document's session, title, address pill and
+            // annotations. Invalidating instead costs one reload in a rare case
+            // and keeps the tab truthful. Normalized to match `handleInit`, so a
+            // plain re-extraction init for the same page keeps its warmth.
+            if type == "init", let reported = data["url"] as? String,
+               ((try? WebUrl.normalize(reported)) ?? reported) != loadedUrl {
+                loadedUrl = nil
+            }
+            return
+        }
 
         switch type {
         case "init":


### PR DESCRIPTION
Closes #52

## The problem

Switching tabs threw away everything expensive the outgoing tab owned. `PaneView` keys its viewer on `activeTabId`, so the whole SwiftUI subtree — and with it the parsed `PDFDocument` and the live `WKWebView` — was torn down and rebuilt on the way back.

I traced both paths before touching anything:

| | cost on switching back (before) |
|---|---|
| **PDF** | `readPdfBytes` (full file read) → `PDFDocument(data:)` parse → embedded-annotation strip → SHA hash of the bytes to consult `PageTextCache` → page-text extraction walk restarts. An LRU of **three** prepared `PDFDocument`s blunted the parse for the last 3 tabs only; the read + hash happened *unconditionally*, even on a cache hit. |
| **Web** | Nothing was cached at all. A fresh `WKWebView` per mount, and `attach` re-navigated through `vellum-web://`, whose scheme handler does a **live network re-fetch** of the page unless the tab is a snapshot-only archive. |

So the answer to "is it the parse, the view teardown, the `WKWebView`, or the page text?" was: all four, with the web re-fetch by far the worst.

## The retention policy

New `TabResidencyManager` (`Vellum/Services/TabResidency.swift`) — a main-actor policy engine that makes *"the tab is open"* the primary retention signal. Three layers, in priority order:

1. **Pinned tabs are never evicted.** A tab that is active in some pane stays resident however long the user sits on it. Pinning is per-pane (keyed on the `AppStore`'s object identity), so a split window keeps **both** visible documents resident — that is the split-screen half of the issue.
2. **The retention window.** A tab idle past `TabResidencyManager.retentionWindow` — one named constant, 2 hours, with a comment — is evicted on the next sweep. The idle clock starts when you switch *away* from a tab, not when you activated it.
3. **Ceilings.** `residentTabLimit` (8) and `residentByteBudget` (768 MB) evict the least-recently-active *inactive* tabs early.

**Closing a tab still releases immediately** — retention is about tabs that are still open.

## Memory-pressure escape hatch

Holding every open tab's `PDFDocument` and `WKWebView` forever is how an app gets jetsammed, so the 2-hour window is a *ceiling* on how long we hold things, never a promise to hold them that long.

`DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)` (macOS has no `NSApplication` equivalent) feeds straight into the same eviction routine:

- `.warning` → tighten to `pressureTabLimit` (2) / `pressureByteBudget` (128 MB). You keep the pinned tabs plus a small warm set, so comparing two documents is still instant on a machine that is swapping.
- `.critical` → every off-screen tab goes, now.

Pinned tabs survive both — we never yank a document out from under the user.

## The timer and the clock

**One shared sweeper**, not one timer per tab: a single `Task` ticking every 60s with a 30s `tolerance` so the kernel can coalesce the wakeup. It **starts lazily** on the first resident resource and **cancels itself** when the last one goes, so an idle Vellum schedules no timer at all. Cancelled in `deinit` alongside the pressure source.

**Deliberately not `Date`.** Wall-clock arithmetic breaks twice over here: an NTP correction or a manual clock change can move `Date()` backwards, making a tab look either permanently fresh (never evicted) or instantly stale (evicted mid-session). The policy runs on a monotonic `ContinuousClock` behind a `ResidencyClock` protocol.

`ContinuousClock` (not `SuspendingClock`) is a deliberate, commented choice: on Darwin it is `mach_continuous_time` and **keeps counting while the Mac is asleep**. The issue asks for "inactive for more than 2 hours" as the user experiences it, and a laptop shut for the night genuinely has left those tabs untouched all night — so reclaiming on wake is right, and it is also what stops a machine that sleeps constantly from accumulating unbounded resident documents. `SuspendingClock` would pause across sleep and hold everything indefinitely, which is the surprising behaviour we do not want.

## Wiring

**PDF** — the residency entry (`PreparedPdfResidency`) holds the display document *and* its page text, so a warm switch now also skips `readPdfBytes` and the `PageTextCache` lookup entirely. The viewer's teardown folds the extraction walk's output back into the entry, taken from `PageTextPersister`'s authoritative dict and never from `AiStore.pageTexts`, which by then can already belong to the incoming tab.

**Web** — `WebViewerController` is owned by the policy rather than by the view, so a return visit re-parents an already-loaded `WKWebView`:

- `attach` distinguishes warm from cold via `loadedUrl`, derived from the content script's own init handshake rather than the last `load()` call, so redirects, soft navigations and snapshot fallbacks can't desync it. Warm → skip the navigation entirely.
- `detach` became a **suspend**: it no longer removes the script message handler or calls `stopLoading()`. It also no longer cancels a pending auto-archive — that silently lost the archive whenever you switched tabs within 1.5s of a page loading. Hard teardown moved to `releaseResidency()`, which keeps the controller alive until any pending archive lands.

Two hazards come with a controller outliving its view, both fixed:

- **Mount token.** SwiftUI mounts the incoming view before unmounting the outgoing one, so the same controller can be re-attached before the old mount's `onDisappear` runs — and that late `detach()` would rip the handler slots out from under the live mount. The view hands its token back so a stale teardown is ignored.
- **`mountedDocument`.** A resident *background* web view is still live and its WebKit delegates still fire. Anything acting on "the document" now resolves the controller's own tab instead of `AppStore.document` — otherwise a background meta-refresh could rebind the foreground tab's session, or a crashed background web process could reload the visible tab's URL.

## Unsaved state

Eviction cannot lose anything: annotations round-trip through the session backend on every edit, page text is flushed by `PageTextPersister` before the dict is handed over, and reading position is mirrored into `PdfTab` / `last_page` metadata. `releaseResidency()` is the single funnel every eviction path (timeout, ceiling, memory pressure, tab close, `releaseAll`) goes through, so any future flush has exactly one home.

`WorkspaceStore.closePane` / `mergeAll` drop a discarded pane's pin, so a collapsed split can't leave a tab pinned for the life of the process.

## Testing

**Unit** — 19 Swift Testing cases in `Tests/TabResidencyTests.swift`, all driven through an injectable `ResidencyClock` so the 2-hour window is exercised without waiting 2 hours, and with `automaticMaintenance: false` so no background sweeper can race the assertions. Covers: survival right up to the window and eviction at it; the pinned tab never expiring however long it is read; the idle clock starting at the switch-away, not the activation; both panes pinning in a split; LRU order under the tab ceiling and the byte budget; immediate release on close; `.warning` / `.critical` pressure; and the sweeper only existing while something is resident.

```
xcodebuild build -project Vellum.xcodeproj -scheme Vellum -destination 'platform=macOS' -derivedDataPath .dd/build   # BUILD SUCCEEDED, no new warnings
xcodebuild test  -project Vellum.xcodeproj -scheme Vellum -destination 'platform=macOS' -derivedDataPath .dd/build   # 265 XCTest + 19 Swift Testing, 0 failures
```

**Live app** — drove the real build with 5 restored tabs (2 PDFs incl. a 904-page book, 3 webpages):

- Switched to a web tab (cold load), away to another web tab, then back — the screenshot taken with **zero delay** after the switch shows the page fully rendered. Before, that was a network re-fetch.
- Same for the 904-page PDF: the immediate post-switch screenshot already shows `1 / 904` and the page painting, with no "Loading PDF…" placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)