### PR TITLE
Move global settings to Home

### DIFF
--- a/Tests/SettingsNavigationTests.swift
+++ b/Tests/SettingsNavigationTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Vellum
+
+@MainActor
+final class SettingsNavigationTests: XCTestCase {
+    func testWorkspaceDefaultsToGeneralSettingsAndCanRouteToAi() {
+        let workspace = WorkspaceStore(sessions: DocumentSessionManager())
+
+        XCTAssertEqual(workspace.settingsSection, .general)
+
+        workspace.settingsSection = .ai
+        XCTAssertEqual(workspace.settingsSection, .ai)
+    }
+
+    func testApiKeyProvidersRequireNonWhitespaceCredentials() {
+        let providers: [(AiProvider, WritableKeyPath<AiSettings, String>)] = [
+            (.gemini, \.apiKey),
+            (.openai, \.openaiApiKey),
+            (.openrouter, \.openrouterApiKey),
+            (.opencode, \.opencodeApiKey),
+            (.opencodeGo, \.opencodeGoApiKey),
+        ]
+
+        for (provider, keyPath) in providers {
+            var settings = AiSettings()
+            settings.provider = provider
+            settings[keyPath: keyPath] = " \n "
+            XCTAssertFalse(
+                settings.isConfigured(chatGPTSignedIn: true),
+                "\(provider) should reject whitespace-only credentials")
+
+            settings[keyPath: keyPath] = "credential"
+            XCTAssertTrue(
+                settings.isConfigured(chatGPTSignedIn: false),
+                "\(provider) should accept a non-empty credential")
+        }
+    }
+
+    func testChatGPTConfigurationUsesSignInState() {
+        var settings = AiSettings()
+        settings.provider = .chatgpt
+
+        XCTAssertFalse(settings.isConfigured(chatGPTSignedIn: false))
+        XCTAssertTrue(settings.isConfigured(chatGPTSignedIn: true))
+    }
+}

--- a/Tests/SettingsNavigationTests.swift
+++ b/Tests/SettingsNavigationTests.swift
@@ -10,20 +10,39 @@ final class SettingsNavigationTests: XCTestCase {
 
         workspace.settingsSection = .ai
         XCTAssertEqual(workspace.settingsSection, .ai)
+
+        workspace.settingsSection = .storage
+        XCTAssertEqual(workspace.settingsSection, .storage)
     }
 
-    func testApiKeyProvidersRequireNonWhitespaceCredentials() {
-        let providers: [(AiProvider, WritableKeyPath<AiSettings, String>)] = [
-            (.gemini, \.apiKey),
-            (.openai, \.openaiApiKey),
-            (.openrouter, \.openrouterApiKey),
-            (.opencode, \.opencodeApiKey),
-            (.opencodeGo, \.opencodeGoApiKey),
+    func testUpdateCheckerIsWorkspaceOwnedAndAutomaticCheckIsClaimedOnce() {
+        let workspace = WorkspaceStore(sessions: DocumentSessionManager())
+        let sameChecker = workspace.updateChecker
+
+        XCTAssertTrue(workspace.updateChecker === sameChecker)
+        XCTAssertFalse(workspace.didStartAutomaticUpdateCheck)
+        XCTAssertTrue(workspace.claimAutomaticUpdateCheck())
+        XCTAssertTrue(workspace.didStartAutomaticUpdateCheck)
+        XCTAssertFalse(workspace.claimAutomaticUpdateCheck())
+    }
+
+    func testApiKeyProvidersRequireCredentialsAndModels() {
+        let providers: [(
+            AiProvider,
+            WritableKeyPath<AiSettings, String>,
+            WritableKeyPath<AiSettings, String>
+        )] = [
+            (.gemini, \.apiKey, \.model),
+            (.openai, \.openaiApiKey, \.openaiModel),
+            (.openrouter, \.openrouterApiKey, \.openrouterModel),
+            (.opencode, \.opencodeApiKey, \.opencodeModel),
+            (.opencodeGo, \.opencodeGoApiKey, \.opencodeGoModel),
         ]
 
-        for (provider, keyPath) in providers {
+        for (provider, keyPath, modelPath) in providers {
             var settings = AiSettings()
             settings.provider = provider
+            settings[keyPath: modelPath] = "model"
             settings[keyPath: keyPath] = " \n "
             XCTAssertFalse(
                 settings.isConfigured(chatGPTSignedIn: true),
@@ -32,15 +51,32 @@ final class SettingsNavigationTests: XCTestCase {
             settings[keyPath: keyPath] = "credential"
             XCTAssertTrue(
                 settings.isConfigured(chatGPTSignedIn: false),
-                "\(provider) should accept a non-empty credential")
+                "\(provider) should accept a credential with a selected model")
+
+            settings[keyPath: modelPath] = " \n "
+            XCTAssertFalse(
+                settings.isConfigured(chatGPTSignedIn: true),
+                "\(provider) should reject a missing model")
         }
     }
 
-    func testChatGPTConfigurationUsesSignInState() {
+    func testOpenRouterKeyWithoutModelIsNotConfigured() {
+        var settings = AiSettings()
+        settings.provider = .openrouter
+        settings.openrouterApiKey = "sk-or-test"
+        settings.openrouterModel = ""
+
+        XCTAssertFalse(settings.isConfigured(chatGPTSignedIn: false))
+    }
+
+    func testChatGPTConfigurationUsesSignInStateAndModel() {
         var settings = AiSettings()
         settings.provider = .chatgpt
 
         XCTAssertFalse(settings.isConfigured(chatGPTSignedIn: false))
         XCTAssertTrue(settings.isConfigured(chatGPTSignedIn: true))
+
+        settings.chatgptModel = " "
+        XCTAssertFalse(settings.isConfigured(chatGPTSignedIn: true))
     }
 }

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		6AF2B59C76A57D0A112B2015 /* KaTeX_Caligraphic-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = A7508380103E3495A82E0771 /* KaTeX_Caligraphic-Regular.woff2 */; };
 		6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30CD609AEA2C0A662890153 /* TabBarView.swift */; };
 		6D737237057DD944A4616889 /* ModelSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B43A2E8F7A54C9B8E4E160D /* ModelSelector.swift */; };
+		6FF504D4444288CAFA641BF6 /* SettingsNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583E0A6988C207365E311AC2 /* SettingsNavigationTests.swift */; };
 		73A1100267EF4F5415AC7147 /* KaTeX_Caligraphic-Bold.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 9F7F3D4199D08A3DEE3D8641 /* KaTeX_Caligraphic-Bold.woff2 */; };
 		742579EA974AAA82CA7C2098 /* VellumBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C50948404B30999979C84A /* VellumBundleTests.swift */; };
 		74F87D19B20B4A7A23919B5F /* PaneTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD01D08235008A4E602D0373 /* PaneTreeView.swift */; };
@@ -201,6 +202,7 @@
 		529B3D1901669D3F00BBCF74 /* KaTeX_Script-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Script-Regular.woff2"; sourceTree = "<group>"; };
 		54417DBF142FD33E6B2F6672 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		5513F929B10D107AED515D1E /* PageTextCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextCache.swift; sourceTree = "<group>"; };
+		583E0A6988C207365E311AC2 /* SettingsNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigationTests.swift; sourceTree = "<group>"; };
 		5B4C5B671FAF08B65F04B96F /* DocumentsRelocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentsRelocationTests.swift; sourceTree = "<group>"; };
 		5DFD2EC2ED5A947809EA139F /* AttachmentDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentDrop.swift; sourceTree = "<group>"; };
 		5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightLayer.swift; sourceTree = "<group>"; };
@@ -394,6 +396,7 @@
 				B1F8F1A0CB094398C5390128 /* ScratchpadDropRegistrationTests.swift */,
 				2E0D324F9CE4133DCC02BBD4 /* ScratchpadImportTests.swift */,
 				709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */,
+				583E0A6988C207365E311AC2 /* SettingsNavigationTests.swift */,
 				BF3E4F80AF4A2707D432AF73 /* SidebarDropRoutingTests.swift */,
 				3B76DBD84FB379B34AC58BCE /* StorageManagementTests.swift */,
 				90C50948404B30999979C84A /* VellumBundleTests.swift */,
@@ -898,6 +901,7 @@
 				C6A3A0FCEB6C19A3CA8DEE10 /* ScratchpadDropRegistrationTests.swift in Sources */,
 				36CA355A9BBDE3BB111BC559 /* ScratchpadImportTests.swift in Sources */,
 				FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */,
+				6FF504D4444288CAFA641BF6 /* SettingsNavigationTests.swift in Sources */,
 				5236947317CC86594F165BD2 /* SidebarDropRoutingTests.swift in Sources */,
 				ACD85838F860C270E27BE7FC /* StorageManagementTests.swift in Sources */,
 				742579EA974AAA82CA7C2098 /* VellumBundleTests.swift in Sources */,

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -128,6 +128,9 @@ struct VellumApp: App {
                     }
                     showStorageChoice = WebStorageSettings.needsFirstLaunchChoice
                 }
+                .task {
+                    await workspace.checkForUpdatesAutomatically()
+                }
                 .sheet(isPresented: $showStorageChoice) {
                     StorageLocationChoiceSheet()
                         .environment(\.palette, themeStore.palette)

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -141,18 +141,22 @@ struct AiSettings: Codable, Equatable, Sendable {
     func isConfigured(chatGPTSignedIn: Bool) -> Bool {
         switch provider {
         case .gemini:
-            !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            hasValue(apiKey) && hasValue(model)
         case .openai:
-            !openaiApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            hasValue(openaiApiKey) && hasValue(openaiModel)
         case .openrouter:
-            !openrouterApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            hasValue(openrouterApiKey) && hasValue(openrouterModel)
         case .chatgpt:
-            chatGPTSignedIn
+            chatGPTSignedIn && hasValue(chatgptModel)
         case .opencode:
-            !opencodeApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            hasValue(opencodeApiKey) && hasValue(opencodeModel)
         case .opencodeGo:
-            !opencodeGoApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            hasValue(opencodeGoApiKey) && hasValue(opencodeGoModel)
         }
+    }
+
+    private func hasValue(_ value: String) -> Bool {
+        !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 }
 

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -137,6 +137,23 @@ struct AiSettings: Codable, Equatable, Sendable {
     /// Model ids the user has pinned to the top of the model selector.
     var pinnedModels: [String] = []
     var reasoningEffort: AiThinkingMode = .auto
+
+    func isConfigured(chatGPTSignedIn: Bool) -> Bool {
+        switch provider {
+        case .gemini:
+            !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .openai:
+            !openaiApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .openrouter:
+            !openrouterApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .chatgpt:
+            chatGPTSignedIn
+        case .opencode:
+            !opencodeApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .opencodeGo:
+            !opencodeGoApiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
 }
 
 struct AiPageImageSnapshot: Sendable {

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -41,6 +41,11 @@ final class WorkspaceStore {
     /// document; only its `settings` are used. Changes broadcast to every pane.
     let settingsAi: AiStore
 
+    /// App-wide updater state. Home observes this durable instance instead of
+    /// creating a checker every time a start tab or split pane is mounted.
+    let updateChecker = UpdateChecker()
+    private(set) var didStartAutomaticUpdateCheck = false
+
     /// App-wide AI services, owned here because this store creates every pane's
     /// AiStore (which holds them weakly) and both scenes inject them into the
     /// environment for the AI settings UI.
@@ -68,6 +73,21 @@ final class WorkspaceStore {
 
     func decreaseSidebarFont() {
         sidebarFontSize = max(Self.minSidebarFontSize, sidebarFontSize - 1)
+    }
+
+    /// Runs the launch-time update check at most once per app workspace.
+    /// Claim the check before awaiting the network so actor reentrancy cannot
+    /// start duplicate requests from multiple root-view task invocations.
+    func checkForUpdatesAutomatically() async {
+        guard claimAutomaticUpdateCheck() else { return }
+        await updateChecker.check(silent: true)
+    }
+
+    @discardableResult
+    func claimAutomaticUpdateCheck() -> Bool {
+        guard !didStartAutomaticUpdateCheck else { return false }
+        didStartAutomaticUpdateCheck = true
+        return true
     }
 
     // MARK: Default highlight color — Settings ▸ Annotations. Window-global.

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -11,6 +11,14 @@ import Observation
 @MainActor
 @Observable
 final class WorkspaceStore {
+    enum SettingsSection: Hashable, Sendable {
+        case general
+        case reading
+        case annotations
+        case ai
+        case storage
+    }
+
     let sessions: SessionService
 
     /// The layout tree. Reassigned wholesale on every structural change.
@@ -23,6 +31,11 @@ final class WorkspaceStore {
     var sidebarOpen = true
     var sidebarTab: SidebarTab = .annotations
     enum SidebarTab: Sendable { case annotations, ai, scratchpad }
+
+    /// The destination selected when an in-app action opens the global Settings
+    /// scene. Keeping this at workspace scope lets Home and document panels route
+    /// to the same native window without embedding duplicate settings controls.
+    var settingsSection: SettingsSection = .general
 
     /// A dedicated AiStore backing the Settings window's AI tab. Not tied to a
     /// document; only its `settings` are used. Changes broadcast to every pane.

--- a/Vellum/Views/AI/AiPanel.swift
+++ b/Vellum/Views/AI/AiPanel.swift
@@ -7,6 +7,7 @@ struct AiPanel: View {
     @Environment(AnnotationStore.self) private var annotationStore
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.palette) private var palette
+    @Environment(\.openSettings) private var openSettings
 
     /// The sidebar keeps every panel mounted (ContentView's ZStack), so this
     /// one exists — with live AppKit text views (the composer + transcript
@@ -25,7 +26,6 @@ struct AiPanel: View {
     private var isVisibleTab: Bool { workspace.sidebarTab == .ai }
 
     @State private var input = ""
-    @State private var settingsOpen = false
     /// True while an attachable drag hovers the panel (drives the dashed outline).
     @State private var dropTargeted = false
     @State private var imagePickerOpen = false
@@ -33,8 +33,8 @@ struct AiPanel: View {
     var body: some View {
         VStack(spacing: 0) {
             header
-            if settingsOpen {
-                AiSettingsPanel()
+            if !aiStore.settings.isConfigured(chatGPTSignedIn: workspace.chatgptAuth.isSignedIn) {
+                configureAiBanner
             }
             messages
                 // Floating toast for declined attachment drops — overlaid on the
@@ -88,15 +88,6 @@ struct AiPanel: View {
             }
             Spacer(minLength: 8)
             HStack(spacing: 2) {
-                IconButton(
-                    variant: settingsOpen ? .active : .ghost,
-                    help: "AI settings",
-                    action: { settingsOpen.toggle() }
-                ) {
-                    Image(systemName: "gearshape").font(.system(size: 15))
-                }
-                .accessibilityIdentifier("aiPanel.settings")
-                .accessibilityAddTraits(settingsOpen ? .isSelected : [])
                 IconButton(help: "Clear conversation", action: aiStore.clearConversation) {
                     Image(systemName: "trash").font(.system(size: 15))
                 }
@@ -107,6 +98,29 @@ struct AiPanel: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
         .overlay(alignment: .bottom) { Divider() }
+    }
+
+    private var configureAiBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "key")
+                .foregroundStyle(palette.mutedForeground)
+            Text("Configure AI to start chatting.")
+                .font(.system(size: 12))
+                .foregroundStyle(palette.mutedForeground)
+            Spacer(minLength: 4)
+            Button("Configure AI in Settings", action: showAiSettings)
+                .buttonStyle(.borderless)
+                .accessibilityIdentifier("aiPanel.configureAi")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(palette.surfaceMuted)
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    private func showAiSettings() {
+        workspace.settingsSection = .ai
+        openSettings()
     }
 
     private var messages: some View {

--- a/Vellum/Views/AI/AiSettingsPanel.swift
+++ b/Vellum/Views/AI/AiSettingsPanel.swift
@@ -121,84 +121,7 @@ enum AiModelCatalog {
     }
 }
 
-struct AiSettingsPanel: View {
-    @Environment(AiStore.self) private var aiStore
-    @Environment(OpenRouterCatalog.self) private var openRouterCatalog
-    @Environment(\.palette) private var palette
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            field("Provider") {
-                Picker("", selection: aiStore.providerBinding) {
-                    ForEach(AiProviderOption.all) { option in
-                        Text(option.label).tag(option.provider)
-                    }
-                }
-                .labelsHidden()
-            }
-
-            if aiStore.settings.provider == .chatgpt {
-                field("Account") { ChatGPTSignInControl() }
-            } else {
-                field(aiStore.keyFieldLabel) {
-                    RevealableSecureField(placeholder: aiStore.keyFieldPlaceholder, text: aiStore.apiKeyBinding)
-                        .id(aiStore.settings.provider)
-                }
-            }
-
-            field("Model") {
-                AiModelSelectorField()
-                capabilityWarnings
-            }
-
-            field("Thinking") {
-                Picker("", selection: aiStore.reasoningBinding) {
-                    ForEach(AiThinkingMode.allCases, id: \.self) { mode in
-                        Text(mode.label).tag(mode)
-                    }
-                }
-                .labelsHidden()
-            }
-        }
-        .font(.system(size: 12))
-        .padding(12)
-        .background(palette.surfaceMuted)
-        .overlay(alignment: .bottom) { Rectangle().fill(palette.border).frame(height: 1) }
-    }
-
-    private func field<Content: View>(_ label: String, @ViewBuilder content: () -> Content) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label).foregroundStyle(palette.mutedForeground)
-            content().frame(maxWidth: .infinity)
-        }
-    }
-
-    @ViewBuilder
-    private var capabilityWarnings: some View {
-        if let option = aiStore.selectedOption(catalog: openRouterCatalog) {
-            if !option.supportsVision {
-                warning(AiCapabilityWarning.noVision)
-            }
-            if !option.supportsTools {
-                warning(AiCapabilityWarning.noTools)
-            }
-        }
-    }
-
-    private func warning(_ text: String) -> some View {
-        HStack(alignment: .top, spacing: 4) {
-            Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 9))
-            Text(text)
-        }
-        .font(.system(size: 10))
-        .foregroundStyle(palette.gold)
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-/// Shared model-row content embedded by both AI settings hosts (the in-panel
-/// `AiSettingsPanel` and the Settings window's `AiSettingsTab`). Each host wraps
-/// it in its own label container so the surrounding layout stays distinct.
+/// Model-row content used by the global Settings window's AI tab.
 struct AiModelSelectorField: View {
     @Environment(AiStore.self) private var aiStore
     @Environment(OpenRouterCatalog.self) private var openRouterCatalog
@@ -214,15 +137,13 @@ struct AiModelSelectorField: View {
     }
 }
 
-/// Capability-warning strings shared by both hosts so the copy never drifts.
-/// Each host renders them with its own styling (custom HStack vs `Label`).
+/// Capability-warning strings used by the global AI settings tab.
 enum AiCapabilityWarning {
     static let noVision = "This model can't see the page image — answers about page contents may be less accurate."
     static let noTools = "This model can't run navigation, highlight, or note actions."
 }
 
-/// The provider list shared by both AI settings hosts so the picker never
-/// drifts between the in-panel view and the Settings window.
+/// Provider options used by the global AI settings tab.
 struct AiProviderOption: Identifiable {
     let provider: AiProvider
     let label: String
@@ -239,8 +160,7 @@ struct AiProviderOption: Identifiable {
 }
 
 /// Sign-in / signed-in / sign-out control for the ChatGPT-subscription OAuth
-/// provider, shared by both AI settings hosts. Replaces the API-key field, since
-/// this provider authenticates via the browser rather than a pasted key.
+/// provider in global Settings.
 struct ChatGPTSignInControl: View {
     @Environment(ChatGPTAuth.self) private var auth
     @Environment(\.palette) private var palette

--- a/Vellum/Views/PDF/ToolbarView.swift
+++ b/Vellum/Views/PDF/ToolbarView.swift
@@ -329,15 +329,12 @@ private struct NoteToolToggle: View {
 
 // MARK: - Overflow menu
 
-/// One trailing Menu that collects the low-frequency actions that used to each
-/// claim their own toolbar circle: Open, Save, web library + Export, and the
-/// updater. Keeping them here is what removes the "pill soup" while leaving the
-/// reading controls (nav, zoom, bookmark, note, inspector) permanently visible.
+/// One trailing Menu that collects low-frequency document actions. Global app
+/// actions such as Settings and update checking live on Home instead.
 private struct OverflowMenu: View {
     @Environment(AppStore.self) private var appStore
     @Environment(AiStore.self) private var aiStore
 
-    @State private var updateChecker = UpdateChecker()
     @State private var pageSaved = false
     @State private var exporting = false
     /// Separate guard for the "Export with Notes…" flow so it can't double-fire
@@ -399,20 +396,6 @@ private struct OverflowMenu: View {
                 }
             }
 
-            Section {
-                if updateChecker.state == .available,
-                   let version = updateChecker.availableVersion {
-                    Button(action: updateChecker.install) {
-                        Label("Install Update \(version)", systemImage: "arrow.down.circle")
-                    }
-                }
-                Button {
-                    Task { await updateChecker.check() }
-                } label: {
-                    Label("Check for Updates…", systemImage: "arrow.clockwise")
-                }
-                .disabled(updateChecker.state == .checking)
-            }
         } label: {
             Label("More", systemImage: "ellipsis")
                 // Icon-only keeps the pod the same circle as the neighboring
@@ -421,12 +404,9 @@ private struct OverflowMenu: View {
                 .labelStyle(.iconOnly)
         }
         .menuIndicator(.hidden)
-        .help("More — open, save, export, and updates")
+        .help("More — open, save, and export")
         .accessibilityLabel("More actions")
         .accessibilityIdentifier("toolbar.overflowMenu")
-        .task {
-            await updateChecker.check(silent: true)
-        }
         .task(id: DocumentKey(appStore)) {
             await loadSavedState(for: DocumentKey(appStore))
         }

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -7,22 +7,30 @@ import SwiftUI
 /// highlight color), and AI (provider / key / model). New settings slot
 /// into the matching tab instead of accreting in ad-hoc popovers.
 struct SettingsView: View {
+    @Environment(WorkspaceStore.self) private var workspace
+
     var body: some View {
-        TabView {
+        @Bindable var workspace = workspace
+        TabView(selection: $workspace.settingsSection) {
             GeneralSettingsTab()
                 .tabItem { Label("General", systemImage: "gearshape") }
+                .tag(WorkspaceStore.SettingsSection.general)
 
             ReadingSettingsTab()
                 .tabItem { Label("Reading", systemImage: "text.book.closed") }
+                .tag(WorkspaceStore.SettingsSection.reading)
 
             AnnotationsSettingsTab()
                 .tabItem { Label("Annotations", systemImage: "highlighter") }
+                .tag(WorkspaceStore.SettingsSection.annotations)
 
             AiSettingsTab()
                 .tabItem { Label("AI", systemImage: "sparkles") }
+                .tag(WorkspaceStore.SettingsSection.ai)
 
             StorageSettingsTab()
                 .tabItem { Label("Storage", systemImage: "internaldrive") }
+                .tag(WorkspaceStore.SettingsSection.storage)
         }
         .frame(width: 480)
     }

--- a/Vellum/Views/Welcome/WelcomeScreen.swift
+++ b/Vellum/Views/Welcome/WelcomeScreen.swift
@@ -4,24 +4,31 @@ import UniformTypeIdentifiers
 
 struct WelcomeScreen: View {
     @Environment(AppStore.self) private var appStore
+    @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.palette) private var palette
+    @Environment(\.openSettings) private var openSettings
 
     @State private var recentDocuments = RecentFilesService.getRecent()
     @State private var savedPages: [WebLibraryEntry] = []
     @State private var urlInput = ""
     @State private var selection: LibraryItem.ID?
     @State private var sort: LibrarySort = .recent
+    @State private var updateChecker = UpdateChecker()
 
     private var hasLibrary: Bool {
         !recentDocuments.isEmpty || !savedPages.isEmpty
     }
 
     var body: some View {
-        Group {
-            if hasLibrary {
-                libraryLayout
-            } else {
-                emptyLayout
+        VStack(spacing: 0) {
+            homeHeader
+            Divider()
+            Group {
+                if hasLibrary {
+                    libraryLayout
+                } else {
+                    emptyLayout
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -32,6 +39,55 @@ struct WelcomeScreen: View {
                 savedPages = pages
             }
         }
+    }
+
+    private var homeHeader: some View {
+        HStack(spacing: 8) {
+            Text("Home")
+                .font(.headline)
+                .foregroundStyle(palette.foreground)
+            Spacer()
+            if updateChecker.state == .available,
+               let version = updateChecker.availableVersion {
+                Button {
+                    updateChecker.install()
+                } label: {
+                    Label("Install Update \(version)", systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.borderless)
+                .help(updateChecker.tooltip)
+                .accessibilityIdentifier("welcome.installUpdate")
+            }
+            Button {
+                Task { await updateChecker.check() }
+            } label: {
+                Label("Check for Updates", systemImage: "arrow.clockwise")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .disabled(updateChecker.state == .checking)
+            .help(updateChecker.tooltip)
+            .accessibilityIdentifier("welcome.checkForUpdates")
+
+            Button(action: showSettings) {
+                Label("Settings", systemImage: "gearshape")
+                    .labelStyle(.iconOnly)
+            }
+            .buttonStyle(.borderless)
+            .help("Settings… (⌘,)")
+            .accessibilityIdentifier("welcome.settings")
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 44)
+        .background(palette.background)
+        .task {
+            await updateChecker.check(silent: true)
+        }
+    }
+
+    private func showSettings() {
+        workspace.settingsSection = .general
+        openSettings()
     }
 
     // MARK: - Empty / first-run layout (the calm hero)

--- a/Vellum/Views/Welcome/WelcomeScreen.swift
+++ b/Vellum/Views/Welcome/WelcomeScreen.swift
@@ -13,7 +13,8 @@ struct WelcomeScreen: View {
     @State private var urlInput = ""
     @State private var selection: LibraryItem.ID?
     @State private var sort: LibrarySort = .recent
-    @State private var updateChecker = UpdateChecker()
+
+    private var updateChecker: UpdateChecker { workspace.updateChecker }
 
     private var hasLibrary: Bool {
         !recentDocuments.isEmpty || !savedPages.isEmpty
@@ -80,9 +81,6 @@ struct WelcomeScreen: View {
         .padding(.horizontal, 16)
         .frame(height: 44)
         .background(palette.background)
-        .task {
-            await updateChecker.check(silent: true)
-        }
     }
 
     private func showSettings() {


### PR DESCRIPTION
## Summary
- add visible Settings and Check for Updates actions to Home / New Tab
- remove global AI provider settings and update checking from document chrome
- route unconfigured AI directly to the AI Settings pane

## Verification
- SettingsNavigationTests: 3 passed
- macOS app build succeeded
- live computer-use verified Home actions, native Settings opening, and document overflow cleanup

## Audit
Implements the Home/global settings information-architecture fix from the 2026-07-27 application audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Home header with controls to check for and install available updates.
  * Added direct navigation to specific Settings sections, including General and AI.
  * Added clear guidance in the AI panel when provider credentials are not configured.

* **Bug Fixes**
  * Improved AI configuration validation by rejecting blank credentials and requiring ChatGPT sign-in.
  * Moved update actions from the PDF overflow menu to Home for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->