### PR TITLE
Keep document commands routed to the active window

### DIFF
--- a/Vellum/App/ContentView.swift
+++ b/Vellum/App/ContentView.swift
@@ -31,7 +31,11 @@ struct ContentView: View {
             .sheet(isPresented: $addWebpagePresented) {
                 AddWebpageSheet()
             }
-            .focusedValue(\.vellumFocus, VellumFocus(workspace: workspace))
+            // Commands belong to the main window, not whichever nested
+            // PDFKit/WebKit/AppKit responder happens to own keyboard focus.
+            // A scene-focused value remains available throughout this window
+            // and automatically disappears when Settings becomes key.
+            .focusedSceneValue(\.vellumFocus, VellumFocus(workspace: workspace))
             .background(WindowAccessor { hostWindow = $0 })
             .onAppear(perform: installKeyMonitor)
             .onDisappear(perform: removeKeyMonitor)

--- a/Vellum/App/VellumCommands.swift
+++ b/Vellum/App/VellumCommands.swift
@@ -2,10 +2,11 @@ import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// Bundle of the stores the menu commands act on, published as a focused value
-/// by the main window's `ContentView`. Routing through `@FocusedValue` gives us
-/// free menu validation: when the Settings window (or any scene that does not
-/// publish this value) is key, the value is nil and every command disables.
+/// Bundle of the stores the menu commands act on, published as a scene-focused
+/// value by the main window's `ContentView`. `@FocusedValue` reads the value
+/// from the key scene, so nested PDFKit/WebKit responders cannot make the menu
+/// lose its target. When Settings (which does not publish the value) is key,
+/// the value is nil and document commands disable.
 struct VellumFocus: Equatable {
     var workspace: WorkspaceStore
 


### PR DESCRIPTION
## Summary
- publish command routing with scene-focused state instead of responder-focused state
- keep document commands active while PDFKit or WebKit owns keyboard focus
- preserve disabled document commands in Settings windows

## Verification
- all 265 macOS tests passed
- macOS app build succeeded
- live computer-use verified File, View, Navigate, and Annotations menus
- live verification confirmed Cmd-T / Cmd-W and Settings command isolation

## Audit
Fixes the release-blocking native menu and shortcut routing defect from the 2026-07-27 application audit.