### PR TITLE
Add unified library search and filters

### DIFF
--- a/Tests/LibraryCatalogTests.swift
+++ b/Tests/LibraryCatalogTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+@testable import Vellum
+
+struct LibraryCatalogTests {
+    private let recent = [
+        RecentDocument(
+            pdfPath: "/Users/reader/Papers/Attention Is All You Need.pdf",
+            kind: .pdf,
+            title: "Transformers",
+            pageCount: 15,
+            openedAt: "2026-07-27T10:00:00.000Z"
+        ),
+        RecentDocument(
+            pdfPath: "https://example.com/research/reading-list",
+            kind: .web,
+            title: "A Useful Reading List",
+            pageCount: nil,
+            openedAt: "2026-07-26T10:00:00.000Z"
+        )
+    ]
+
+    private let saved = [
+        WebLibraryEntry(
+            url: "https://example.com/research/reading-list",
+            title: "Saved Reading List",
+            pageCount: nil,
+            savedAt: "2026-07-25T10:00:00.000Z",
+            hasSnapshot: true
+        ),
+        WebLibraryEntry(
+            url: "https://swift.org/blog/swift-6/",
+            title: "Swift 6",
+            pageCount: nil,
+            savedAt: "2026-07-24T10:00:00.000Z",
+            hasSnapshot: false
+        )
+    ]
+
+    @Test("Recent and saved copies of a webpage become one library row", .bug(id: 62))
+    func deduplicatesRecentAndSavedWebpages() throws {
+        let items = LibraryCatalog.items(
+            recent: recent,
+            saved: saved,
+            query: "",
+            filter: .all,
+            sort: .recent
+        )
+
+        #expect(items.count == 3)
+        let readingList = try #require(items.first { $0.key.contains("reading-list") })
+        #expect(readingList.isSaved)
+        #expect(readingList.isOffline)
+        #expect(readingList.recordedRecentKey != nil)
+        #expect(readingList.savedKey != nil)
+    }
+
+    @Test(
+        "Search checks titles, filenames, domains, and URLs",
+        arguments: ["transformers", "attention", "example.com", "research/reading-list"]
+    )
+    func searchesAllVisibleMetadata(query: String) {
+        let items = LibraryCatalog.items(
+            recent: recent,
+            saved: saved,
+            query: query,
+            filter: .all,
+            sort: .recent
+        )
+
+        #expect(items.count == 1)
+    }
+
+    @Test("Search is case and diacritic insensitive")
+    func normalizedSearch() {
+        let accented = [
+            RecentDocument(
+                pdfPath: "/tmp/cafe.pdf",
+                kind: .pdf,
+                title: "Café Notes",
+                pageCount: nil,
+                openedAt: "2026-07-27T10:00:00.000Z"
+            )
+        ]
+
+        let items = LibraryCatalog.items(
+            recent: accented,
+            saved: [],
+            query: "CAFE",
+            filter: .all,
+            sort: .recent
+        )
+
+        #expect(items.map(\.title) == ["Café Notes"])
+    }
+
+    @Test(
+        "Type and saved filters use the unified rows",
+        arguments: [
+            (LibraryFilter.pdf, 1),
+            (LibraryFilter.web, 2),
+            (LibraryFilter.saved, 2)
+        ]
+    )
+    func filtersLibrary(filter: LibraryFilter, expectedCount: Int) {
+        let items = LibraryCatalog.items(
+            recent: recent,
+            saved: saved,
+            query: "",
+            filter: filter,
+            sort: .recent
+        )
+
+        #expect(items.count == expectedCount)
+    }
+
+    @Test("A query with no matches returns a clear empty result")
+    func noResults() {
+        let items = LibraryCatalog.items(
+            recent: recent,
+            saved: saved,
+            query: "nothing in this library",
+            filter: .all,
+            sort: .recent
+        )
+
+        #expect(items.isEmpty)
+    }
+
+    @Test("Name sort is independent of recency")
+    func sortsByName() {
+        let items = LibraryCatalog.items(
+            recent: recent,
+            saved: saved,
+            query: "",
+            filter: .all,
+            sort: .name
+        )
+
+        #expect(items.map(\.title) == [
+            "A Useful Reading List",
+            "Swift 6",
+            "Transformers"
+        ])
+    }
+
+    @Test("Rows for two paths of the same stamped PDF retain unique identities")
+    func movedPdfRowsHaveUniqueIDs() {
+        let moved = [
+            RecentDocument(
+                pdfPath: "/old/paper.pdf",
+                kind: .pdf,
+                title: "Paper",
+                pageCount: 1,
+                openedAt: "2026-07-26T10:00:00.000Z",
+                docId: "stable-document-id"
+            ),
+            RecentDocument(
+                pdfPath: "/new/paper.pdf",
+                kind: .pdf,
+                title: "Paper",
+                pageCount: 1,
+                openedAt: "2026-07-27T10:00:00.000Z",
+                docId: "stable-document-id"
+            )
+        ]
+
+        let items = LibraryCatalog.items(
+            recent: moved,
+            saved: [],
+            query: "",
+            filter: .all,
+            sort: .recent
+        )
+
+        #expect(items.count == 2)
+        #expect(Set(items.map(\.id)).count == 2)
+    }
+
+    @Test("Delete respects the facet the user is filtering")
+    func removalTargetMatchesFilter() throws {
+        let merged = try #require(LibraryCatalog.items(
+            recent: recent,
+            saved: saved,
+            query: "",
+            filter: .all,
+            sort: .recent
+        ).first { $0.savedKey != nil && $0.recordedRecentKey != nil })
+
+        #expect(LibraryCatalog.removalTarget(for: merged, activeFilter: .all) == .recent)
+        #expect(LibraryCatalog.removalTarget(for: merged, activeFilter: .saved) == .saved)
+    }
+}

--- a/Tests/LibraryCatalogTests.swift
+++ b/Tests/LibraryCatalogTests.swift
@@ -55,6 +55,59 @@ struct LibraryCatalogTests {
         #expect(readingList.savedKey != nil)
     }
 
+    @Test("Canonical URL identity preserves meaningful trailing slashes")
+    func keepsDistinctWebPathsSeparate() throws {
+        let recentPage = RecentDocument(
+            pdfPath: "https://example.com/article",
+            kind: .web,
+            title: "Recent article",
+            pageCount: nil,
+            openedAt: "2026-07-27T10:00:00.000Z"
+        )
+        let savedPage = WebLibraryEntry(
+            url: "https://example.com/article/",
+            title: "Saved article",
+            pageCount: nil,
+            savedAt: "2026-07-26T10:00:00.000Z",
+            hasSnapshot: true
+        )
+
+        let items = LibraryCatalog.makeItems(recent: [recentPage], saved: [savedPage])
+
+        #expect(items.count == 2)
+        #expect(Set(items.map(\.id)).count == 2)
+        let recentItem = try #require(items.first { $0.recordedRecentKey != nil })
+        let savedItem = try #require(items.first { $0.savedKey != nil })
+        let canonicalRecentURL = try WebUrl.normalize(recentPage.pdfPath)
+        let canonicalSavedURL = try WebUrl.normalize(savedPage.url)
+        #expect(recentItem.savedKey == nil)
+        #expect(savedItem.recordedRecentKey == nil)
+        #expect(LibraryCatalog.canonicalWebIdentity(recentPage.pdfPath) == canonicalRecentURL)
+        #expect(LibraryCatalog.canonicalWebIdentity(savedPage.url) == canonicalSavedURL)
+    }
+
+    @Test("Search reuses precomputed catalog metadata")
+    func filtersPrecomputedCatalog() {
+        let catalog = LibraryCatalog.makeItems(recent: recent, saved: saved)
+
+        let titleMatches = LibraryCatalog.filteredItems(
+            catalog,
+            query: "transformers",
+            filter: .all,
+            sort: .recent
+        )
+        let domainMatches = LibraryCatalog.filteredItems(
+            catalog,
+            query: "swift.org",
+            filter: .web,
+            sort: .name
+        )
+
+        #expect(catalog.count == 3)
+        #expect(titleMatches.map(\.title) == ["Transformers"])
+        #expect(domainMatches.map(\.title) == ["Swift 6"])
+    }
+
     @Test(
         "Search checks titles, filenames, domains, and URLs",
         arguments: ["transformers", "attention", "example.com", "research/reading-list"]

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		9C7F3F0B4C0CDEE7ED83CBB4 /* AnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18CA5A14795BD97D91F2056 /* AnnotationStore.swift */; };
 		9E139713CC03274E03B94E92 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E2B3DF66E30481C363C740 /* ToolbarView.swift */; };
 		9E702B90F8729B9145F7D31B /* SelectableMessageText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4601C034B834B5E610FD84 /* SelectableMessageText.swift */; };
+		A312A073C601D23C37AD97EA /* LibraryCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C307643429DD5B843ADC2C10 /* LibraryCatalogTests.swift */; };
 		A5E5A42BE09B4A7911646AFF /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723EC058218A6DF8D994CC26 /* UpdateChecker.swift */; };
 		A84C2B18F7A53ECE5F96F618 /* PaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD27558DB4D8DB212826B68 /* PaneView.swift */; };
 		AB9A39277DECF67164B86B08 /* tool-mode-native.md in Resources */ = {isa = PBXBuildFile; fileRef = 88825E2B57F4AFE2A2D1DE36 /* tool-mode-native.md */; };
@@ -114,6 +115,7 @@
 		C4998709FBAE647C23BF3E5A /* KaTeX_Size3-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 511B978E41D84CD3B0C24FCB /* KaTeX_Size3-Regular.woff2 */; };
 		C529F97AB901B963D8DB4726 /* AiPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA459842CA86BEED9D34C1E /* AiPipelineTests.swift */; };
 		C6A3A0FCEB6C19A3CA8DEE10 /* ScratchpadDropRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F8F1A0CB094398C5390128 /* ScratchpadDropRegistrationTests.swift */; };
+		C7013C855B1B3B20CCDECC1A /* LibraryNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88FC76B0CE4906E1523EB539 /* LibraryNoResultsView.swift */; };
 		C7F0A762A988E52CD11D2A5E /* PdfAtomicWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E923D872F0FF00E6DAB9BA8 /* PdfAtomicWriter.swift */; };
 		C82D9FC05EC46B7D699B8B0F /* KaTeX_Size1-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 3180FE94F812DBF0B9C91ED5 /* KaTeX_Size1-Regular.woff2 */; };
 		CA6BCC8D048C1E43CBC52E99 /* KaTeX_SansSerif-Italic.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 81F1F3B1E8E330471651991F /* KaTeX_SansSerif-Italic.woff2 */; };
@@ -140,10 +142,12 @@
 		F14F33AEF8094C593CF6A6DE /* DocumentSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */; };
 		F33467F1BF882C20214E4EB4 /* editor.html in Resources */ = {isa = PBXBuildFile; fileRef = C024B0FD91AE2990C4277000 /* editor.html */; };
 		F375A6682F4CEFF5406ADD9D /* OAuthLoopbackServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5B78507B70CB73698D8DC4 /* OAuthLoopbackServer.swift */; };
+		F3E3199E51D6E4D1F467168D /* LibraryBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9CAA039E3AA4702D7F4EACC /* LibraryBadge.swift */; };
 		F5DFB55D5AEB2B65E76E5613 /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8909CC21C72AF947D20B4B6C /* AppStore.swift */; };
 		F9DA8014506FBB48C440F718 /* AiStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = E201F2530645C6348ECC59AA /* AiStreaming.swift */; };
 		FE3F6412427EE4948EC38358 /* katex.min.css in Resources */ = {isa = PBXBuildFile; fileRef = BA27035FFAE43080C7118AC4 /* katex.min.css */; };
 		FE7D8E1CF0734B927687D5AF /* OpenRouterClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96768879872A93B8FD39C342 /* OpenRouterClient.swift */; };
+		FEA3C5C8BFE548371A791831 /* LibraryCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = E666A0B25070B7D3EDB09D52 /* LibraryCatalog.swift */; };
 		FF8B0D4EDFA98B3310F21727 /* VellumBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95809D33AB6DF0D9BCF1BE88 /* VellumBundle.swift */; };
 		FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */; };
 /* End PBXBuildFile section */
@@ -224,6 +228,7 @@
 		87B22387C1A8E19F0316151E /* PdfViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfViewerView.swift; sourceTree = "<group>"; };
 		88261ED7614D2528C41ED0E5 /* editor.bundle.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = editor.bundle.js; sourceTree = "<group>"; };
 		88825E2B57F4AFE2A2D1DE36 /* tool-mode-native.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "tool-mode-native.md"; sourceTree = "<group>"; };
+		88FC76B0CE4906E1523EB539 /* LibraryNoResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryNoResultsView.swift; sourceTree = "<group>"; };
 		8909CC21C72AF947D20B4B6C /* AppStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStore.swift; sourceTree = "<group>"; };
 		89E21441131E7C57CE324E83 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		8A774391C8C286453B790F75 /* MarkdownMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMessage.swift; sourceTree = "<group>"; };
@@ -267,6 +272,7 @@
 		C1F083E5C02A66A025F06638 /* WebContentScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentScript.swift; sourceTree = "<group>"; };
 		C21D7E5EC3C32E20B0FDC7DB /* PdfMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfMetadata.swift; sourceTree = "<group>"; };
 		C283744BF352A2D7CDB6FB52 /* KaTeX_Main-Italic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-Italic.woff2"; sourceTree = "<group>"; };
+		C307643429DD5B843ADC2C10 /* LibraryCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCatalogTests.swift; sourceTree = "<group>"; };
 		C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiClient.swift; sourceTree = "<group>"; };
 		C4DE459571959DABFA99D4BB /* AiSettingsPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSettingsPanel.swift; sourceTree = "<group>"; };
 		C75C2F535B12256E191B781C /* PdfKitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfKitView.swift; sourceTree = "<group>"; };
@@ -289,6 +295,7 @@
 		E064C75923B5E7D98E256470 /* WebArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebArchive.swift; sourceTree = "<group>"; };
 		E201F2530645C6348ECC59AA /* AiStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiStreaming.swift; sourceTree = "<group>"; };
 		E30CD609AEA2C0A662890153 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		E666A0B25070B7D3EDB09D52 /* LibraryCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCatalog.swift; sourceTree = "<group>"; };
 		E8C9F22335B2DEA99AF5ABF5 /* KaTeX_Typewriter-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Typewriter-Regular.woff2"; sourceTree = "<group>"; };
 		E9A35D0EA31DC7A28CB8FA8A /* ScratchpadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadStore.swift; sourceTree = "<group>"; };
 		E9CE9BA76EA961FB5939EDCE /* DocumentDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentDataStoreTests.swift; sourceTree = "<group>"; };
@@ -298,6 +305,7 @@
 		F2630E8BE36D65B9E485FD6F /* Controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controls.swift; sourceTree = "<group>"; };
 		F39E1889C3B2C6F221C33BC9 /* OpenCodeZenClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeZenClient.swift; sourceTree = "<group>"; };
 		F8BEC014138483BE0B9DC274 /* KaTeX_SansSerif-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_SansSerif-Regular.woff2"; sourceTree = "<group>"; };
+		F9CAA039E3AA4702D7F4EACC /* LibraryBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryBadge.swift; sourceTree = "<group>"; };
 		FD01D08235008A4E602D0373 /* PaneTreeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTreeView.swift; sourceTree = "<group>"; };
 		FF653B1B8741B61DBE9B55EE /* WebStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebStorage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -386,6 +394,7 @@
 				E9CE9BA76EA961FB5939EDCE /* DocumentDataStoreTests.swift */,
 				CCBBA9A1DAB0373185D8F5EA /* DocumentIdentityTests.swift */,
 				5B4C5B671FAF08B65F04B96F /* DocumentsRelocationTests.swift */,
+				C307643429DD5B843ADC2C10 /* LibraryCatalogTests.swift */,
 				6F5F272385E3E99333CFC6C1 /* MarkdownParserTests.swift */,
 				13F6592FEBC0C0187E0C35A3 /* PageTextCacheTests.swift */,
 				524641B76B46DE4D791F4E6A /* PaneTreeTests.swift */,
@@ -592,6 +601,9 @@
 		CF0E2D9A717E39ABDB39C16B /* Welcome */ = {
 			isa = PBXGroup;
 			children = (
+				F9CAA039E3AA4702D7F4EACC /* LibraryBadge.swift */,
+				E666A0B25070B7D3EDB09D52 /* LibraryCatalog.swift */,
+				88FC76B0CE4906E1523EB539 /* LibraryNoResultsView.swift */,
 				4E282C555B1B420914134C74 /* WelcomeScreen.swift */,
 			);
 			path = Welcome;
@@ -817,6 +829,9 @@
 				4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */,
 				4FF972F2B1437D5D46AE6BA4 /* HighlightLayer.swift in Sources */,
 				D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */,
+				F3E3199E51D6E4D1F467168D /* LibraryBadge.swift in Sources */,
+				FEA3C5C8BFE548371A791831 /* LibraryCatalog.swift in Sources */,
+				C7013C855B1B3B20CCDECC1A /* LibraryNoResultsView.swift in Sources */,
 				E5F120A320C5FC13A9026B70 /* MarkdownMessage.swift in Sources */,
 				ED7C505CE3E48CE35C600873 /* MathRenderer.swift in Sources */,
 				6D737237057DD944A4616889 /* ModelSelector.swift in Sources */,
@@ -890,6 +905,7 @@
 				252A859CBF3B6F40740EC8BB /* DocumentDataStoreTests.swift in Sources */,
 				53B7BE4E93C5CF617CF049D6 /* DocumentIdentityTests.swift in Sources */,
 				831CF3958ED8C1AF87C6319A /* DocumentsRelocationTests.swift in Sources */,
+				A312A073C601D23C37AD97EA /* LibraryCatalogTests.swift in Sources */,
 				8E2B30ED60C29E54F33081F7 /* MarkdownParserTests.swift in Sources */,
 				91ACF610BE2A44480DD31843 /* PageTextCacheTests.swift in Sources */,
 				2E35DAA98C4A45A551382874 /* PaneTreeTests.swift in Sources */,

--- a/Vellum/Views/Welcome/LibraryBadge.swift
+++ b/Vellum/Views/Welcome/LibraryBadge.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct LibraryBadge: View {
+    private let title: String
+    private let systemImage: String
+
+    init(_ title: String, systemImage: String) {
+        self.title = title
+        self.systemImage = systemImage
+    }
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(.system(size: 10, weight: .medium))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 4)
+            .background(.quaternary.opacity(0.55), in: Capsule())
+            .accessibilityElement(children: .combine)
+    }
+}

--- a/Vellum/Views/Welcome/LibraryCatalog.swift
+++ b/Vellum/Views/Welcome/LibraryCatalog.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+enum LibraryFilter: String, CaseIterable, Identifiable {
+    case all
+    case pdf
+    case web
+    case saved
+
+    var id: Self { self }
+
+    var label: String {
+        switch self {
+        case .all: "All"
+        case .pdf: "PDFs"
+        case .web: "Web"
+        case .saved: "Saved"
+        }
+    }
+}
+
+enum LibrarySort: String, CaseIterable {
+    case recent
+    case name
+
+    var label: String {
+        switch self {
+        case .recent: "Recently opened"
+        case .name: "Name"
+        }
+    }
+}
+
+enum LibraryRemovalTarget: Equatable {
+    case recent
+    case saved
+}
+
+struct LibraryItem: Identifiable, Hashable {
+    let id: String
+    let kind: DocumentKind
+    let key: String
+    let recordedRecentKey: String?
+    let savedKey: String?
+    let icon: String
+    let title: String
+    let subtitle: String
+    let tooltip: String
+    let canRevealInFinder: Bool
+    let isSaved: Bool
+    let isOffline: Bool
+    fileprivate let recency: Date?
+    fileprivate let sourceOrder: Int
+    fileprivate let searchText: String
+}
+
+enum LibraryCatalog {
+    static func removalTarget(
+        for item: LibraryItem,
+        activeFilter: LibraryFilter
+    ) -> LibraryRemovalTarget? {
+        if activeFilter == .saved, item.savedKey != nil {
+            return .saved
+        }
+        if item.recordedRecentKey != nil {
+            return .recent
+        }
+        if item.savedKey != nil {
+            return .saved
+        }
+        return nil
+    }
+
+    static func items(
+        recent: [RecentDocument],
+        saved: [WebLibraryEntry],
+        query: String,
+        filter: LibraryFilter,
+        sort: LibrarySort
+    ) -> [LibraryItem] {
+        let allItems = mergedItems(recent: recent, saved: saved)
+        let terms = query
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .split(whereSeparator: \.isWhitespace)
+            .map(String.init)
+
+        let filtered = allItems.filter { item in
+            let includedByFilter = switch filter {
+            case .all: true
+            case .pdf: item.kind == .pdf
+            case .web: item.kind == .web
+            case .saved: item.isSaved
+            }
+            guard includedByFilter else { return false }
+            guard terms.isEmpty == false else { return true }
+            let searchable = item.searchText.folding(
+                options: [.caseInsensitive, .diacriticInsensitive],
+                locale: .current
+            )
+            return terms.allSatisfy(searchable.contains)
+        }
+
+        switch sort {
+        case .recent:
+            return filtered.sorted {
+                switch ($0.recency, $1.recency) {
+                case let (left?, right?) where left != right:
+                    return left > right
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                default:
+                    return $0.sourceOrder < $1.sourceOrder
+                }
+            }
+        case .name:
+            return filtered.sorted {
+                $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+            }
+        }
+    }
+
+    private static func mergedItems(
+        recent: [RecentDocument],
+        saved: [WebLibraryEntry]
+    ) -> [LibraryItem] {
+        var savedByURL: [String: WebLibraryEntry] = [:]
+        for page in saved {
+            savedByURL[normalizedURL(page.url)] = page
+        }
+
+        var items: [LibraryItem] = []
+        var representedSavedURLs = Set<String>()
+        var representedRecentURLs = Set<String>()
+
+        for (index, entry) in recent.enumerated() {
+            if entry.kind == .web {
+                let normalized = normalizedURL(entry.pdfPath)
+                guard representedRecentURLs.insert(normalized).inserted else { continue }
+                let savedPage = savedByURL[normalized]
+                if savedPage != nil {
+                    representedSavedURLs.insert(normalized)
+                }
+                items.append(webItem(recent: entry, saved: savedPage, sourceOrder: index))
+            } else {
+                items.append(pdfItem(entry, sourceOrder: index))
+            }
+        }
+
+        for (index, page) in saved.enumerated() {
+            let normalized = normalizedURL(page.url)
+            guard representedSavedURLs.contains(normalized) == false else { continue }
+            items.append(webItem(
+                recent: nil,
+                saved: page,
+                sourceOrder: recent.count + index
+            ))
+        }
+        return items
+    }
+
+    private static func pdfItem(_ entry: RecentDocument, sourceOrder: Int) -> LibraryItem {
+        let fileName = RecentFilesService.fileName(for: entry.pdfPath)
+        let title = displayTitle(entry.title, fallback: fileName)
+        var details: [String] = []
+        if title != fileName {
+            details.append(fileName)
+        }
+        if let count = entry.pageCount, count > 0 {
+            details.append("\(count) \(count == 1 ? "page" : "pages")")
+        }
+        details.append(formatOpenedDate(entry.openedAt))
+
+        let resolvedPath = RecentFilesService.resolvedPath(for: entry)
+        let onDisk = FileManager.default.fileExists(atPath: resolvedPath)
+        let searchText = [title, fileName, entry.pdfPath, resolvedPath, details.joined(separator: " ")]
+            .joined(separator: "\n")
+
+        return LibraryItem(
+            // A moved stamped PDF can temporarily have two recent records with
+            // the same docId. Keep each visible row's identity path-specific.
+            id: "pdf:\(entry.pdfPath)",
+            kind: .pdf,
+            key: resolvedPath,
+            recordedRecentKey: entry.pdfPath,
+            savedKey: nil,
+            icon: "doc.text",
+            title: title,
+            subtitle: details.joined(separator: " · "),
+            tooltip: resolvedPath,
+            canRevealInFinder: onDisk,
+            isSaved: false,
+            isOffline: false,
+            recency: parseDate(entry.openedAt),
+            sourceOrder: sourceOrder,
+            searchText: searchText
+        )
+    }
+
+    private static func webItem(
+        recent: RecentDocument?,
+        saved: WebLibraryEntry?,
+        sourceOrder: Int
+    ) -> LibraryItem {
+        let url = recent?.pdfPath ?? saved?.url ?? ""
+        let displayName = RecentFilesService.webpageDisplayName(for: url)
+        let title = displayTitle(
+            nonemptyTitle(recent?.title) ?? nonemptyTitle(saved?.title),
+            fallback: displayName
+        )
+        let host = URL(string: url)?.host ?? ""
+        var details = [displayName]
+        if let openedAt = recent?.openedAt {
+            details.append(formatOpenedDate(openedAt))
+        }
+        let searchText = [
+            title,
+            recent?.title ?? "",
+            saved?.title ?? "",
+            displayName,
+            host,
+            url,
+            saved?.url ?? "",
+            details.joined(separator: " ")
+        ]
+            .joined(separator: "\n")
+
+        return LibraryItem(
+            id: "web:\(normalizedURL(url))",
+            kind: .web,
+            key: url,
+            recordedRecentKey: recent?.pdfPath,
+            savedKey: saved?.url,
+            icon: "globe",
+            title: title,
+            subtitle: details.joined(separator: " · "),
+            tooltip: url,
+            canRevealInFinder: false,
+            isSaved: saved != nil,
+            isOffline: saved?.hasSnapshot == true,
+            recency: recent.flatMap { parseDate($0.openedAt) }
+                ?? saved.flatMap { page in page.savedAt.flatMap(parseDate) },
+            sourceOrder: sourceOrder,
+            searchText: searchText
+        )
+    }
+
+    private static func displayTitle(_ title: String?, fallback: String) -> String {
+        let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? fallback : trimmed
+    }
+
+    private static func nonemptyTitle(_ title: String?) -> String? {
+        let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalizedURL(_ value: String) -> String {
+        guard var components = URLComponents(string: value) else { return value.lowercased() }
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+        components.fragment = nil
+        if components.path == "/" {
+            components.path = ""
+        } else if components.path.hasSuffix("/") {
+            components.path.removeLast()
+        }
+        return components.string ?? value.lowercased()
+    }
+
+    private static func parseDate(_ value: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+    }
+
+    private static func formatOpenedDate(_ openedAt: String) -> String {
+        guard let date = parseDate(openedAt) else { return "Recently opened" }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter.string(from: date)
+    }
+}

--- a/Vellum/Views/Welcome/LibraryCatalog.swift
+++ b/Vellum/Views/Welcome/LibraryCatalog.swift
@@ -54,6 +54,12 @@ struct LibraryItem: Identifiable, Hashable {
 }
 
 enum LibraryCatalog {
+    private static let fractionalISO8601Format = Date.ISO8601FormatStyle(
+        includingFractionalSeconds: true
+    )
+    private static let ISO8601Format = Date.ISO8601FormatStyle()
+    private static let openedDateFormat = Date.FormatStyle(date: .abbreviated, time: .omitted)
+
     static func removalTarget(
         for item: LibraryItem,
         activeFilter: LibraryFilter
@@ -77,7 +83,29 @@ enum LibraryCatalog {
         filter: LibraryFilter,
         sort: LibrarySort
     ) -> [LibraryItem] {
-        let allItems = mergedItems(recent: recent, saved: saved)
+        filteredItems(
+            makeItems(recent: recent, saved: saved),
+            query: query,
+            filter: filter,
+            sort: sort
+        )
+    }
+
+    /// Builds the stable catalog metadata once when its source collections
+    /// change. Search and sort updates can then reuse these items.
+    static func makeItems(
+        recent: [RecentDocument],
+        saved: [WebLibraryEntry]
+    ) -> [LibraryItem] {
+        mergedItems(recent: recent, saved: saved)
+    }
+
+    static func filteredItems(
+        _ allItems: [LibraryItem],
+        query: String,
+        filter: LibraryFilter,
+        sort: LibrarySort
+    ) -> [LibraryItem] {
         let terms = query
             .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
             .split(whereSeparator: \.isWhitespace)
@@ -92,11 +120,7 @@ enum LibraryCatalog {
             }
             guard includedByFilter else { return false }
             guard terms.isEmpty == false else { return true }
-            let searchable = item.searchText.folding(
-                options: [.caseInsensitive, .diacriticInsensitive],
-                locale: .current
-            )
-            return terms.allSatisfy(searchable.contains)
+            return terms.allSatisfy(item.searchText.contains)
         }
 
         switch sort {
@@ -126,7 +150,7 @@ enum LibraryCatalog {
     ) -> [LibraryItem] {
         var savedByURL: [String: WebLibraryEntry] = [:]
         for page in saved {
-            savedByURL[normalizedURL(page.url)] = page
+            savedByURL[canonicalWebIdentity(page.url)] = page
         }
 
         var items: [LibraryItem] = []
@@ -135,7 +159,7 @@ enum LibraryCatalog {
 
         for (index, entry) in recent.enumerated() {
             if entry.kind == .web {
-                let normalized = normalizedURL(entry.pdfPath)
+                let normalized = canonicalWebIdentity(entry.pdfPath)
                 guard representedRecentURLs.insert(normalized).inserted else { continue }
                 let savedPage = savedByURL[normalized]
                 if savedPage != nil {
@@ -148,7 +172,7 @@ enum LibraryCatalog {
         }
 
         for (index, page) in saved.enumerated() {
-            let normalized = normalizedURL(page.url)
+            let normalized = canonicalWebIdentity(page.url)
             guard representedSavedURLs.contains(normalized) == false else { continue }
             items.append(webItem(
                 recent: nil,
@@ -173,8 +197,13 @@ enum LibraryCatalog {
 
         let resolvedPath = RecentFilesService.resolvedPath(for: entry)
         let onDisk = FileManager.default.fileExists(atPath: resolvedPath)
-        let searchText = [title, fileName, entry.pdfPath, resolvedPath, details.joined(separator: " ")]
-            .joined(separator: "\n")
+        let searchText = normalizedSearchText([
+            title,
+            fileName,
+            entry.pdfPath,
+            resolvedPath,
+            details.joined(separator: " ")
+        ])
 
         return LibraryItem(
             // A moved stamped PDF can temporarily have two recent records with
@@ -213,7 +242,7 @@ enum LibraryCatalog {
         if let openedAt = recent?.openedAt {
             details.append(formatOpenedDate(openedAt))
         }
-        let searchText = [
+        let searchText = normalizedSearchText([
             title,
             recent?.title ?? "",
             saved?.title ?? "",
@@ -222,11 +251,10 @@ enum LibraryCatalog {
             url,
             saved?.url ?? "",
             details.joined(separator: " ")
-        ]
-            .joined(separator: "\n")
+        ])
 
         return LibraryItem(
-            id: "web:\(normalizedURL(url))",
+            id: "web:\(canonicalWebIdentity(url))",
             kind: .web,
             key: url,
             recordedRecentKey: recent?.pdfPath,
@@ -255,30 +283,23 @@ enum LibraryCatalog {
         return trimmed.isEmpty ? nil : trimmed
     }
 
-    private static func normalizedURL(_ value: String) -> String {
-        guard var components = URLComponents(string: value) else { return value.lowercased() }
-        components.scheme = components.scheme?.lowercased()
-        components.host = components.host?.lowercased()
-        components.fragment = nil
-        if components.path == "/" {
-            components.path = ""
-        } else if components.path.hasSuffix("/") {
-            components.path.removeLast()
-        }
-        return components.string ?? value.lowercased()
+    static func canonicalWebIdentity(_ value: String) -> String {
+        (try? WebUrl.normalize(value)) ?? value
+    }
+
+    private static func normalizedSearchText(_ components: [String]) -> String {
+        components
+            .joined(separator: "\n")
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
     }
 
     private static func parseDate(_ value: String) -> Date? {
-        let fractional = ISO8601DateFormatter()
-        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return fractional.date(from: value) ?? ISO8601DateFormatter().date(from: value)
+        (try? fractionalISO8601Format.parse(value))
+            ?? (try? ISO8601Format.parse(value))
     }
 
     private static func formatOpenedDate(_ openedAt: String) -> String {
         guard let date = parseDate(openedAt) else { return "Recently opened" }
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter.string(from: date)
+        return date.formatted(openedDateFormat)
     }
 }

--- a/Vellum/Views/Welcome/LibraryNoResultsView.swift
+++ b/Vellum/Views/Welcome/LibraryNoResultsView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct LibraryNoResultsView: View {
+    let query: String
+    let filter: LibraryFilter
+    let reset: () -> Void
+
+    @Environment(\.palette) private var palette
+
+    private var detail: String {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return "There aren’t any \(filter.label.lowercased()) items in your library yet."
+        }
+        if filter == .all {
+            return "No title, filename, domain, or URL matches “\(trimmed)”."
+        }
+        return "No \(filter.label.lowercased()) item matches “\(trimmed)”."
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "doc.text.magnifyingglass")
+                .font(.system(size: 30, weight: .regular))
+                .foregroundStyle(palette.mutedForeground)
+            Text("No library results")
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(palette.foreground)
+            Text(detail)
+                .font(.system(size: 13))
+                .foregroundStyle(palette.mutedForeground)
+                .multilineTextAlignment(.center)
+            Button("Show all items", action: reset)
+                .buttonStyle(.link)
+                .accessibilityIdentifier("welcome.librarySearch.reset")
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(32)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("welcome.library.noResults")
+    }
+}

--- a/Vellum/Views/Welcome/WelcomeScreen.swift
+++ b/Vellum/Views/Welcome/WelcomeScreen.swift
@@ -6,14 +6,29 @@ struct WelcomeScreen: View {
     @Environment(AppStore.self) private var appStore
     @Environment(\.palette) private var palette
 
-    @State private var recentDocuments = RecentFilesService.getRecent()
+    @State private var recentDocuments: [RecentDocument]
     @State private var savedPages: [WebLibraryEntry] = []
+    @State private var catalogItems: [LibraryItem]
+    @State private var visibleItems: [LibraryItem]
     @State private var urlInput = ""
     @State private var selection: LibraryItem.ID?
     @State private var sort: LibrarySort = .recent
     @State private var searchQuery = ""
     @State private var filter: LibraryFilter = .all
     @FocusState private var searchFocused: Bool
+
+    init() {
+        let recentDocuments = RecentFilesService.getRecent()
+        let catalogItems = LibraryCatalog.makeItems(recent: recentDocuments, saved: [])
+        _recentDocuments = State(initialValue: recentDocuments)
+        _catalogItems = State(initialValue: catalogItems)
+        _visibleItems = State(initialValue: LibraryCatalog.filteredItems(
+            catalogItems,
+            query: "",
+            filter: .all,
+            sort: .recent
+        ))
+    }
 
     private var hasLibrary: Bool {
         !recentDocuments.isEmpty || !savedPages.isEmpty
@@ -22,7 +37,7 @@ struct WelcomeScreen: View {
     var body: some View {
         Group {
             if hasLibrary {
-                libraryLayout
+                libraryLayout(items: visibleItems)
             } else {
                 emptyLayout
             }
@@ -33,7 +48,26 @@ struct WelcomeScreen: View {
             if let pages = try? await appStore.sessions.listSavedWebpages() {
                 guard !Task.isCancelled else { return }
                 savedPages = pages
+                rebuildCatalog()
             }
+        }
+        .onChange(of: visibleItems.map(\.id)) { _, visibleIDs in
+            guard let selection else { return }
+            if visibleIDs.contains(selection) == false {
+                self.selection = nil
+            }
+        }
+        .onChange(of: searchQuery) {
+            refreshVisibleItems()
+        }
+        .onChange(of: filter) {
+            refreshVisibleItems()
+        }
+        .onChange(of: sort) {
+            refreshVisibleItems()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            rebuildCatalog()
         }
     }
 
@@ -56,11 +90,11 @@ struct WelcomeScreen: View {
 
     // MARK: - Library layout (native list, uses the window width)
 
-    private var libraryLayout: some View {
+    private func libraryLayout(items: [LibraryItem]) -> some View {
         VStack(spacing: 0) {
             libraryHeader
             Divider()
-            libraryList
+            libraryList(items: items)
         }
     }
 
@@ -194,9 +228,9 @@ struct WelcomeScreen: View {
         .accessibilityIdentifier("welcome.sort")
     }
 
-    private var libraryList: some View {
+    private func libraryList(items: [LibraryItem]) -> some View {
         Group {
-            if visibleItems.isEmpty {
+            if items.isEmpty {
                 LibraryNoResultsView(
                     query: searchQuery,
                     filter: filter,
@@ -205,7 +239,7 @@ struct WelcomeScreen: View {
             } else {
                 List(selection: $selection) {
                     Section("Library") {
-                        ForEach(visibleItems) { LibraryRow(item: $0) }
+                        ForEach(items) { LibraryRow(item: $0) }
                     }
                 }
                 .listStyle(.inset)
@@ -225,12 +259,6 @@ struct WelcomeScreen: View {
                 }
                 .accessibilityIdentifier("welcome.library")
             }
-        }
-        .onChange(of: searchQuery) {
-            clearInvisibleSelection()
-        }
-        .onChange(of: filter) {
-            clearInvisibleSelection()
         }
     }
 
@@ -355,30 +383,15 @@ struct WelcomeScreen: View {
         }
     }
 
-    // MARK: - Library item model
-
-    private var visibleItems: [LibraryItem] {
-        LibraryCatalog.items(
-            recent: recentDocuments,
-            saved: savedPages,
-            query: searchQuery,
-            filter: filter,
-            sort: sort
-        )
-    }
-
-    private var allItems: [LibraryItem] {
-        LibraryCatalog.items(
-            recent: recentDocuments,
-            saved: savedPages,
-            query: "",
-            filter: .all,
-            sort: sort
-        )
-    }
-
     private func item(for id: LibraryItem.ID) -> LibraryItem? {
-        allItems.first { $0.id == id }
+        catalogItems.first { $0.id == id }
+    }
+
+    private func freshItem(for id: LibraryItem.ID) -> LibraryItem? {
+        LibraryCatalog.makeItems(
+            recent: recentDocuments,
+            saved: savedPages
+        ).first { $0.id == id }
     }
 
     // MARK: - Actions
@@ -395,7 +408,7 @@ struct WelcomeScreen: View {
     }
 
     private func open(_ id: LibraryItem.ID) {
-        guard let item = item(for: id), !appStore.isLoading else { return }
+        guard let item = freshItem(for: id), !appStore.isLoading else { return }
         if item.kind == .web {
             Task { await appStore.openUrl(item.key) }
         } else {
@@ -403,6 +416,7 @@ struct WelcomeScreen: View {
             // the re-record (on successful open) doesn't leave a duplicate.
             if let recordedKey = item.recordedRecentKey, item.key != recordedKey {
                 recentDocuments = RecentFilesService.remove(path: recordedKey)
+                rebuildCatalog()
             }
             Task { await appStore.openFile(path: item.key) }
         }
@@ -411,12 +425,14 @@ struct WelcomeScreen: View {
     private func removeFromRecent(_ item: LibraryItem) {
         guard let recordedKey = item.recordedRecentKey else { return }
         recentDocuments = RecentFilesService.remove(path: recordedKey)
+        rebuildCatalog()
         if selection == item.id { selection = nil }
     }
 
     private func removeFromSaved(_ item: LibraryItem) {
         guard let savedKey = item.savedKey else { return }
         savedPages.removeAll { $0.url == savedKey }
+        rebuildCatalog()
         Task { try? await appStore.sessions.removeSavedWebpage(url: savedKey) }
         if selection == item.id { selection = nil }
     }
@@ -439,15 +455,26 @@ struct WelcomeScreen: View {
         searchFocused = true
     }
 
-    private func clearInvisibleSelection() {
-        guard let selection else { return }
-        if visibleItems.contains(where: { $0.id == selection }) == false {
-            self.selection = nil
-        }
+    private func rebuildCatalog() {
+        let items = LibraryCatalog.makeItems(
+            recent: recentDocuments,
+            saved: savedPages
+        )
+        catalogItems = items
+        refreshVisibleItems(from: items)
+    }
+
+    private func refreshVisibleItems(from items: [LibraryItem]? = nil) {
+        visibleItems = LibraryCatalog.filteredItems(
+            items ?? catalogItems,
+            query: searchQuery,
+            filter: filter,
+            sort: sort
+        )
     }
 
     private func revealInFinder(_ item: LibraryItem) {
-        guard item.canRevealInFinder else { return }
+        guard let item = freshItem(for: item.id), item.canRevealInFinder else { return }
         NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: item.key)])
     }
 

--- a/Vellum/Views/Welcome/WelcomeScreen.swift
+++ b/Vellum/Views/Welcome/WelcomeScreen.swift
@@ -11,6 +11,9 @@ struct WelcomeScreen: View {
     @State private var urlInput = ""
     @State private var selection: LibraryItem.ID?
     @State private var sort: LibrarySort = .recent
+    @State private var searchQuery = ""
+    @State private var filter: LibraryFilter = .all
+    @FocusState private var searchFocused: Bool
 
     private var hasLibrary: Bool {
         !recentDocuments.isEmpty || !savedPages.isEmpty
@@ -117,6 +120,46 @@ struct WelcomeScreen: View {
                 sortMenu
             }
 
+            HStack(spacing: 12) {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(palette.mutedForeground)
+                    TextField("Search title, filename, domain, or URL", text: $searchQuery)
+                        .textFieldStyle(.plain)
+                        .focused($searchFocused)
+                        .accessibilityIdentifier("welcome.librarySearch")
+                    if searchQuery.isEmpty == false {
+                        Button("Clear search", systemImage: "xmark.circle.fill") {
+                            searchQuery = ""
+                            searchFocused = true
+                        }
+                        .buttonStyle(.plain)
+                        .labelStyle(.iconOnly)
+                        .foregroundStyle(palette.mutedForeground)
+                        .accessibilityIdentifier("welcome.librarySearch.clear")
+                    }
+                }
+                .padding(.horizontal, 12)
+                .frame(maxWidth: 420)
+                .frame(height: 34)
+                .background(.quaternary.opacity(0.35), in: RoundedRectangle(cornerRadius: Radius.md))
+                .overlay {
+                    RoundedRectangle(cornerRadius: Radius.md)
+                        .strokeBorder(.separator)
+                }
+
+                Picker("Filter library", selection: $filter) {
+                    ForEach(LibraryFilter.allCases) { option in
+                        Text(option.label).tag(option)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .fixedSize()
+                .accessibilityIdentifier("welcome.libraryFilter")
+
+                Spacer(minLength: 0)
+            }
+
             if appStore.error != nil {
                 errorBanner
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -152,34 +195,43 @@ struct WelcomeScreen: View {
     }
 
     private var libraryList: some View {
-        List(selection: $selection) {
-            if !recentItems.isEmpty {
-                Section("Recent") {
-                    ForEach(recentItems) { LibraryRow(item: $0) }
+        Group {
+            if visibleItems.isEmpty {
+                LibraryNoResultsView(
+                    query: searchQuery,
+                    filter: filter,
+                    reset: resetLibrarySearch
+                )
+            } else {
+                List(selection: $selection) {
+                    Section("Library") {
+                        ForEach(visibleItems) { LibraryRow(item: $0) }
+                    }
                 }
-            }
-            if !savedItems.isEmpty {
-                Section("Saved") {
-                    ForEach(savedItems) { LibraryRow(item: $0) }
+                .listStyle(.inset)
+                .scrollContentBackground(.hidden)
+                .background(palette.well)
+                .environment(\.defaultMinListRowHeight, 52)
+                .contextMenu(forSelectionType: LibraryItem.ID.self) { ids in
+                    contextMenu(for: ids)
+                } primaryAction: { ids in
+                    for id in ids { open(id) }
                 }
+                .onDeleteCommand { removeSelected() }
+                .onKeyPress(.return) {
+                    guard let selection else { return .ignored }
+                    open(selection)
+                    return .handled
+                }
+                .accessibilityIdentifier("welcome.library")
             }
         }
-        .listStyle(.inset)
-        .scrollContentBackground(.hidden)
-        .background(palette.well)
-        .environment(\.defaultMinListRowHeight, 52)
-        .contextMenu(forSelectionType: LibraryItem.ID.self) { ids in
-            contextMenu(for: ids)
-        } primaryAction: { ids in
-            for id in ids { open(id) }
+        .onChange(of: searchQuery) {
+            clearInvisibleSelection()
         }
-        .onDeleteCommand { removeSelected() }
-        .onKeyPress(.return) {
-            guard let selection else { return .ignored }
-            open(selection)
-            return .handled
+        .onChange(of: filter) {
+            clearInvisibleSelection()
         }
-        .accessibilityIdentifier("welcome.library")
     }
 
     @ViewBuilder
@@ -189,9 +241,18 @@ struct WelcomeScreen: View {
             if item.canRevealInFinder {
                 Button("Show in Finder") { revealInFinder(item) }
             }
-            Divider()
-            Button(item.section == .saved ? "Remove from Saved" : "Remove from Recent", role: .destructive) {
-                remove(id)
+            if item.recordedRecentKey != nil || item.savedKey != nil {
+                Divider()
+            }
+            if item.recordedRecentKey != nil {
+                Button("Remove from Recent", role: .destructive) {
+                    removeFromRecent(item)
+                }
+            }
+            if item.savedKey != nil {
+                Button("Remove from Saved", role: .destructive) {
+                    removeFromSaved(item)
+                }
             }
         }
     }
@@ -296,22 +357,28 @@ struct WelcomeScreen: View {
 
     // MARK: - Library item model
 
-    private var recentItems: [LibraryItem] {
-        let items = recentDocuments.map(LibraryItem.init(recent:))
-        return sort == .name
-            ? items.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
-            : items
+    private var visibleItems: [LibraryItem] {
+        LibraryCatalog.items(
+            recent: recentDocuments,
+            saved: savedPages,
+            query: searchQuery,
+            filter: filter,
+            sort: sort
+        )
     }
 
-    private var savedItems: [LibraryItem] {
-        let items = savedPages.map(LibraryItem.init(saved:))
-        return sort == .name
-            ? items.sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
-            : items
+    private var allItems: [LibraryItem] {
+        LibraryCatalog.items(
+            recent: recentDocuments,
+            saved: savedPages,
+            query: "",
+            filter: .all,
+            sort: sort
+        )
     }
 
     private func item(for id: LibraryItem.ID) -> LibraryItem? {
-        recentItems.first { $0.id == id } ?? savedItems.first { $0.id == id }
+        allItems.first { $0.id == id }
     }
 
     // MARK: - Actions
@@ -329,38 +396,54 @@ struct WelcomeScreen: View {
 
     private func open(_ id: LibraryItem.ID) {
         guard let item = item(for: id), !appStore.isLoading else { return }
-        switch item.section {
-        case .recent:
-            if item.kind == .web {
-                Task { await appStore.openUrl(item.key) }
-            } else {
-                // A moved PDF re-resolved to a new path: drop the stale entry so
-                // the re-record (on successful open) doesn't leave a duplicate.
-                if item.key != item.recordedKey {
-                    recentDocuments = RecentFilesService.remove(path: item.recordedKey)
-                }
-                Task { await appStore.openFile(path: item.key) }
-            }
-        case .saved:
+        if item.kind == .web {
             Task { await appStore.openUrl(item.key) }
+        } else {
+            // A moved PDF re-resolved to a new path: drop the stale entry so
+            // the re-record (on successful open) doesn't leave a duplicate.
+            if let recordedKey = item.recordedRecentKey, item.key != recordedKey {
+                recentDocuments = RecentFilesService.remove(path: recordedKey)
+            }
+            Task { await appStore.openFile(path: item.key) }
         }
     }
 
-    private func remove(_ id: LibraryItem.ID) {
-        guard let item = item(for: id) else { return }
-        switch item.section {
-        case .recent:
-            recentDocuments = RecentFilesService.remove(path: item.key)
-        case .saved:
-            savedPages.removeAll { $0.url == item.key }
-            Task { try? await appStore.sessions.removeSavedWebpage(url: item.key) }
-        }
-        if selection == id { selection = nil }
+    private func removeFromRecent(_ item: LibraryItem) {
+        guard let recordedKey = item.recordedRecentKey else { return }
+        recentDocuments = RecentFilesService.remove(path: recordedKey)
+        if selection == item.id { selection = nil }
+    }
+
+    private func removeFromSaved(_ item: LibraryItem) {
+        guard let savedKey = item.savedKey else { return }
+        savedPages.removeAll { $0.url == savedKey }
+        Task { try? await appStore.sessions.removeSavedWebpage(url: savedKey) }
+        if selection == item.id { selection = nil }
     }
 
     private func removeSelected() {
+        guard let selection, let item = item(for: selection) else { return }
+        switch LibraryCatalog.removalTarget(for: item, activeFilter: filter) {
+        case .recent:
+            removeFromRecent(item)
+        case .saved:
+            removeFromSaved(item)
+        case nil:
+            break
+        }
+    }
+
+    private func resetLibrarySearch() {
+        searchQuery = ""
+        filter = .all
+        searchFocused = true
+    }
+
+    private func clearInvisibleSelection() {
         guard let selection else { return }
-        remove(selection)
+        if visibleItems.contains(where: { $0.id == selection }) == false {
+            self.selection = nil
+        }
     }
 
     private func revealInFinder(_ item: LibraryItem) {
@@ -384,102 +467,6 @@ struct WelcomeScreen: View {
         guard panel.runModal() == .OK else { return }
         let paths = panel.urls.map(\.path)
         Task { await appStore.openFiles(paths: paths) }
-    }
-}
-
-// MARK: - Library sort
-
-private enum LibrarySort: String, CaseIterable {
-    case recent
-    case name
-
-    var label: String {
-        switch self {
-        case .recent: "Recently opened"
-        case .name: "Name"
-        }
-    }
-}
-
-// MARK: - Unified library item
-
-private struct LibraryItem: Identifiable, Hashable {
-    enum Section { case recent, saved }
-
-    let id: String
-    let section: Section
-    let kind: DocumentKind
-    /// The path/URL to actually open — the recorded one, or a re-resolved path
-    /// when a moved PDF was found via its docId's meta.json.
-    let key: String
-    /// The path exactly as stored in the recent entry, so `open` can dedupe the
-    /// stale entry when it re-resolved to a new location.
-    let recordedKey: String
-    let icon: String
-    let title: String
-    let subtitle: String
-    let tooltip: String
-    let canRevealInFinder: Bool
-
-    init(recent entry: RecentDocument) {
-        let fileName = entry.kind == .web
-            ? RecentFilesService.webpageDisplayName(for: entry.pdfPath)
-            : RecentFilesService.fileName(for: entry.pdfPath)
-        let trimmedTitle = entry.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let displayTitle = trimmedTitle.isEmpty ? fileName : trimmedTitle
-
-        var pieces: [String] = []
-        if displayTitle != fileName { pieces.append(fileName) }
-        if entry.kind == .pdf, let count = entry.pageCount, count != 0 {
-            pieces.append("\(count) \(count == 1 ? "page" : "pages")")
-        }
-        pieces.append(Self.formatOpenedDate(entry.openedAt))
-
-        // Re-resolve a moved PDF by its stable id (design §7): when the recorded
-        // path is gone but the document carries a /VellumDocId, meta.json's
-        // last_known_path (kept fresh by DocumentDataStore.touch) may point at
-        // where the file moved to.
-        let resolvedPath = RecentFilesService.resolvedPath(for: entry)
-        let onDisk = entry.kind == .pdf && FileManager.default.fileExists(atPath: resolvedPath)
-
-        id = "recent:\(entry.pdfPath)"
-        section = .recent
-        kind = entry.kind
-        key = resolvedPath
-        recordedKey = entry.pdfPath
-        icon = entry.kind == .web ? "globe" : "doc.text"
-        title = displayTitle
-        subtitle = pieces.joined(separator: " · ")
-        tooltip = resolvedPath
-        canRevealInFinder = onDisk
-    }
-
-    init(saved page: WebLibraryEntry) {
-        let displayName = RecentFilesService.webpageDisplayName(for: page.url)
-        let trimmedTitle = page.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let displayTitle = trimmedTitle.isEmpty ? displayName : trimmedTitle
-
-        id = "saved:\(page.url)"
-        section = .saved
-        kind = .web
-        key = page.url
-        recordedKey = page.url
-        icon = "globe"
-        title = displayTitle
-        subtitle = displayName + (page.hasSnapshot ? " · available offline" : "")
-        tooltip = page.url
-        canRevealInFinder = false
-    }
-
-    private static func formatOpenedDate(_ openedAt: String) -> String {
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let date = iso.date(from: openedAt) ?? ISO8601DateFormatter().date(from: openedAt)
-        guard let date else { return "Recently opened" }
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-        return formatter.string(from: date)
     }
 }
 
@@ -513,6 +500,13 @@ private struct LibraryRow: View {
             }
 
             Spacer(minLength: 0)
+
+            if item.isSaved {
+                LibraryBadge("Saved", systemImage: "bookmark.fill")
+            }
+            if item.isOffline {
+                LibraryBadge("Offline", systemImage: "arrow.down.circle.fill")
+            }
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)


### PR DESCRIPTION
## Summary
- replace separate Recent/Saved lists with one deduplicated library catalog
- add live title, filename, domain, and URL search plus All/PDFs/Web/Saved filters
- show Saved and Offline state badges, clear no-results recovery, and accessible keyboard behavior
- preserve correct Delete semantics under filtered results

## Verification
- focused Swift Testing: 8 passed
- targeted macOS build passed
- exact-build computer-use verified live search, every filter, no-results recovery, unified rows, and badges
- Codex review findings around moved-PDF identities and filtered Delete behavior were fixed and retested

## Audit
Implements the independently shippable library findability portion of Issue #62 and the 2026-07-27 audit.