### PR TITLE
Complete AI reference and composer focus flow

### DIFF
--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -407,7 +407,56 @@ final class AiPipelineTests: XCTestCase {
 
         // And messages persisted before telemetry (no usage key) still decode.
         let legacy = Data(#"{"id":"a","role":"assistant","content":"old","createdAt":"2026-01-01T00:00:00.000Z"}"#.utf8)
-        XCTAssertNil(try JSONDecoder().decode(AiMessage.self, from: legacy).usage)
+        let decodedLegacy = try JSONDecoder().decode(AiMessage.self, from: legacy)
+        XCTAssertNil(decodedLegacy.usage)
+        XCTAssertTrue(decodedLegacy.references.isEmpty)
+    }
+
+    /// Sent references survive persistence without retaining image payloads,
+    /// and preserve enough provenance to explain the completed turn.
+    func testSentReferenceProvenanceSurvivesEncodingRoundTrip() throws {
+        let reference = AiReference(kind: .selection(
+            text: "  A selected passage\nwith whitespace.  ",
+            page: 7
+        ))
+        let provenance = AiMessageReference(reference: reference, documentTitle: "Research.pdf")
+        let message = AiPersistence.makeMessage(
+            role: .user,
+            content: "Explain this",
+            references: [provenance]
+        )
+
+        let decoded = try JSONDecoder().decode(
+            AiMessage.self,
+            from: JSONEncoder().encode(message)
+        )
+
+        XCTAssertEqual(decoded.references.count, 1)
+        XCTAssertEqual(decoded.references.first?.kind, .selection)
+        XCTAssertEqual(decoded.references.first?.label, "A selected passage with whitespace.")
+        XCTAssertEqual(decoded.references.first?.page, 7)
+        XCTAssertEqual(decoded.references.first?.documentTitle, "Research.pdf")
+    }
+
+    /// Every attachment action requests focus (including repeated actions) and
+    /// moves the window-global inspector to AI in one state transition.
+    @MainActor
+    func testAddingReferenceOpensAiAndRequestsComposerFocus() {
+        let workspace = WorkspaceStore(sessions: DocumentSessionManager())
+        let store = workspace.focusedPane.ai
+        workspace.sidebarOpen = false
+        workspace.sidebarTab = .annotations
+        let initialRequest = store.composerFocusRequest
+
+        store.addReference(AiReference(kind: .selection(text: "First", page: 1)))
+        XCTAssertTrue(workspace.sidebarOpen)
+        XCTAssertEqual(workspace.sidebarTab, .ai)
+        XCTAssertEqual(store.composerFocusRequest, initialRequest + 1)
+        XCTAssertEqual(store.composerReferences.count, 1)
+
+        store.addReference(AiReference(kind: .selection(text: "Second", page: 2)))
+        XCTAssertEqual(store.composerFocusRequest, initialRequest + 2)
+        XCTAssertEqual(store.composerReferences.count, 2)
     }
 
     // MARK: - Auto page-image gating

--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -436,27 +436,175 @@ final class AiPipelineTests: XCTestCase {
         XCTAssertEqual(decoded.references.first?.label, "A selected passage with whitespace.")
         XCTAssertEqual(decoded.references.first?.page, 7)
         XCTAssertEqual(decoded.references.first?.documentTitle, "Research.pdf")
+        XCTAssertEqual(decoded.references.first?.delivery, .sent)
     }
 
-    /// Every attachment action requests focus (including repeated actions) and
-    /// moves the window-global inspector to AI in one state transition.
+    /// Focus requests are one-shot store-owned tokens, so fulfilling one cannot
+    /// replay when the inspector is closed and rebuilt.
     @MainActor
     func testAddingReferenceOpensAiAndRequestsComposerFocus() {
         let workspace = WorkspaceStore(sessions: DocumentSessionManager())
         let store = workspace.focusedPane.ai
         workspace.sidebarOpen = false
         workspace.sidebarTab = .annotations
-        let initialRequest = store.composerFocusRequest
 
         store.addReference(AiReference(kind: .selection(text: "First", page: 1)))
         XCTAssertTrue(workspace.sidebarOpen)
         XCTAssertEqual(workspace.sidebarTab, .ai)
-        XCTAssertEqual(store.composerFocusRequest, initialRequest + 1)
+        let firstRequest = store.composerFocusRequest
+        XCTAssertNotNil(firstRequest)
         XCTAssertEqual(store.composerReferences.count, 1)
+        store.consumeComposerFocusRequest(try! XCTUnwrap(firstRequest))
+        XCTAssertNil(store.composerFocusRequest)
 
         store.addReference(AiReference(kind: .selection(text: "Second", page: 2)))
-        XCTAssertEqual(store.composerFocusRequest, initialRequest + 2)
+        XCTAssertNotNil(store.composerFocusRequest)
+        XCTAssertNotEqual(store.composerFocusRequest, firstRequest)
         XCTAssertEqual(store.composerReferences.count, 2)
+    }
+
+    /// Split panes own independent one-shot focus namespaces.
+    @MainActor
+    func testComposerFocusRequestsAreScopedToTheirSplitPane() throws {
+        let workspace = WorkspaceStore(sessions: DocumentSessionManager())
+        let original = workspace.focusedPane.ai
+        original.addReference(AiReference(kind: .selection(text: "Left", page: 1)))
+        let originalRequest = try XCTUnwrap(original.composerFocusRequest)
+        original.consumeComposerFocusRequest(originalRequest)
+
+        workspace.splitFocused(.horizontal)
+        let split = workspace.focusedPane.ai
+        split.addReference(AiReference(kind: .selection(text: "Right", page: 1)))
+
+        XCTAssertNil(original.composerFocusRequest)
+        XCTAssertNotNil(split.composerFocusRequest)
+        XCTAssertNotEqual(split.composerFocusRequest, originalRequest)
+    }
+
+    /// A PDF capture that completes after a tab switch must not attach bytes
+    /// from the old PDF to the newly active document.
+    @MainActor
+    func testPdfPageCaptureAfterAwaitIsRejectedAfterTabSwitch() throws {
+        let workspace = WorkspaceStore(sessions: DocumentSessionManager())
+        let store = workspace.focusedPane.ai
+        let app = workspace.focusedPane.app
+        app.attachTab(Self.tab(
+            id: "pdf-a",
+            document: DocumentInfo(
+                kind: .pdf, pdfPath: "/tmp/a.pdf", title: "A",
+                pageCount: 1, lastPage: 1, docId: "doc-a"
+            )
+        ))
+        let target = try XCTUnwrap(store.currentReferenceTarget())
+        app.attachTab(Self.tab(
+            id: "pdf-b",
+            document: DocumentInfo(
+                kind: .pdf, pdfPath: "/tmp/b.pdf", title: "B",
+                pageCount: 1, lastPage: 1, docId: "doc-b"
+            )
+        ))
+
+        let attached = store.addCapturedReference(
+            AiReference(kind: .pageSnapshot(image: Self.snapshot, page: 1)),
+            target: target
+        )
+
+        XCTAssertFalse(attached)
+        XCTAssertTrue(store.composerReferences.isEmpty)
+    }
+
+    /// The same post-await identity check protects web region captures.
+    @MainActor
+    func testWebRegionCaptureAfterAwaitIsRejectedAfterTabSwitch() throws {
+        let workspace = WorkspaceStore(sessions: DocumentSessionManager())
+        let store = workspace.focusedPane.ai
+        let app = workspace.focusedPane.app
+        app.attachTab(Self.tab(
+            id: "web-a",
+            document: DocumentInfo(
+                kind: .web, pdfPath: "https://a.example", title: "A",
+                pageCount: 1, lastPage: 1, docId: "web-doc-a"
+            )
+        ))
+        let target = try XCTUnwrap(store.currentReferenceTarget())
+        app.attachTab(Self.tab(
+            id: "web-b",
+            document: DocumentInfo(
+                kind: .web, pdfPath: "https://b.example", title: "B",
+                pageCount: 1, lastPage: 1, docId: "web-doc-b"
+            )
+        ))
+
+        let attached = store.addCapturedReference(
+            AiReference(kind: .region(image: Self.snapshot, page: 1)),
+            target: target
+        )
+
+        XCTAssertFalse(attached)
+        XCTAssertTrue(store.composerReferences.isEmpty)
+    }
+
+    func testReferencePlanPersistsWholeReferenceBudgetOmissionsAccurately() {
+        let references = (1...5).map {
+            AiReference(kind: .selection(
+                text: String(repeating: Character("\($0)"), count: 8_000),
+                page: $0
+            ))
+        }
+
+        let plan = AiPrompts.planReferences(
+            references,
+            supportsImages: true,
+            documentTitle: "Large.pdf"
+        )
+
+        XCTAssertEqual(plan.provenance.count, 5)
+        XCTAssertEqual(
+            plan.provenance.filter { $0.delivery == .sent }.count,
+            plan.included.count
+        )
+        XCTAssertGreaterThan(plan.included.count, 0)
+        XCTAssertLessThan(plan.included.count, references.count)
+        XCTAssertEqual(
+            plan.provenance.filter { $0.delivery == .omittedBudget }.count,
+            references.count - plan.included.count
+        )
+    }
+
+    func testReferencePlanOmitsImagesForTextOnlyModels() {
+        let image = AiReference(kind: .image(image: Self.snapshot, name: "diagram.png"))
+        let plan = AiPrompts.planReferences(
+            [image],
+            supportsImages: false,
+            documentTitle: "Notes"
+        )
+
+        XCTAssertTrue(plan.included.isEmpty)
+        XCTAssertEqual(plan.provenance.map(\.delivery), [.omittedUnsupportedImage])
+    }
+
+    func testReferenceMetadataIsNormalizedWhenDecoded() throws {
+        let references = (0..<20).map { index in
+            """
+            {"id":"\(String(repeating: "i", count: 200))\(index)","kind":"selection",\
+            "label":"\(String(repeating: "l", count: 220))","page":-2,\
+            "documentTitle":"\(String(repeating: "d", count: 300))","delivery":"sent"}
+            """
+        }.joined(separator: ",")
+        let data = Data("""
+        {"id":"message","role":"user","content":"hello","createdAt":"now",\
+        "references":[\(references)]}
+        """.utf8)
+
+        let message = try JSONDecoder().decode(AiMessage.self, from: data)
+
+        XCTAssertEqual(message.references.count, AiMessageReference.maxPerMessage)
+        XCTAssertTrue(message.references.allSatisfy {
+            $0.id.count <= AiMessageReference.maxIdCharacters
+                && $0.label.count <= AiMessageReference.maxLabelCharacters
+                && ($0.documentTitle?.count ?? 0) <= AiMessageReference.maxDocumentTitleCharacters
+                && $0.page == nil
+        })
     }
 
     // MARK: - Auto page-image gating
@@ -586,6 +734,28 @@ final class AiPipelineTests: XCTestCase {
         XCTAssertTrue(AiModelCatalog.supportsVision(provider: .opencode, model: "claude-sonnet-5", catalog: nil))
         XCTAssertTrue(AiModelCatalog.supportsVision(provider: .gemini, model: "anything", catalog: nil))
         XCTAssertTrue(AiModelCatalog.supportsVision(provider: .openrouter, model: "vendor/unknown", catalog: nil))
+    }
+
+    private static let snapshot = AiPageImageSnapshot(
+        pageNumber: 1,
+        base64Data: "aGVsbG8=",
+        mediaType: "image/png",
+        width: 12,
+        height: 9
+    )
+
+    private static func tab(id: String, document: DocumentInfo) -> PdfTab {
+        PdfTab(
+            id: id,
+            document: document,
+            currentPage: 1,
+            numPages: 1,
+            zoom: 1,
+            visiblePages: [1],
+            webVisibleRange: nil,
+            webVisibleBookmarks: [],
+            mode: .view
+        )
     }
 
     /// Bytes for a blank bitmap in PNG, as a stand-in for a dropped file.

--- a/Tests/SidebarDropRoutingTests.swift
+++ b/Tests/SidebarDropRoutingTests.swift
@@ -118,6 +118,43 @@ final class SidebarDropRoutingTests: XCTestCase {
         XCTAssertTrue(mounted.workspace.sidebarOpen)
         XCTAssertTrue(window?.firstResponder === composer)
         XCTAssertEqual(mounted.pane.ai.composerReferences.count, 1)
+        XCTAssertNil(mounted.pane.ai.composerFocusRequest)
+
+        // Closing and reopening the inspector remounts its AppKit composer.
+        // The consumed token must not replay and steal focus from another
+        // control in the new hierarchy.
+        window?.orderOut(nil)
+        let root = SidebarPanelStack()
+            .environment(mounted.workspace)
+            .environment(mounted.pane.app)
+            .environment(mounted.pane.annotations)
+            .environment(mounted.pane.ai)
+            .environment(mounted.pane.scratchpad)
+        let remountedHost = NSHostingView(rootView: root)
+        remountedHost.frame = NSRect(x: 0, y: 0, width: 340, height: 700)
+        let remountedWindow = NSWindow(
+            contentRect: remountedHost.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let focusSentinel = NSButton(title: "Sentinel", target: nil, action: nil)
+        let container = NSView(frame: remountedHost.frame)
+        container.addSubview(remountedHost)
+        focusSentinel.frame = NSRect(x: 0, y: 0, width: 1, height: 1)
+        container.addSubview(focusSentinel)
+        remountedWindow.contentView = container
+        XCTAssertTrue(remountedWindow.makeFirstResponder(focusSentinel))
+        remountedHost.layoutSubtreeIfNeeded()
+        pump(0.5)
+        let remountedComposer = try XCTUnwrap(
+            firstSubview(of: SubmitTextView.self, in: remountedHost)
+        )
+
+        XCTAssertTrue(remountedWindow.firstResponder === focusSentinel)
+        XCTAssertFalse(remountedWindow.firstResponder === remountedComposer)
+        XCTAssertNil(mounted.pane.ai.composerFocusRequest)
+        window = remountedWindow
     }
 
     private func firstSubview<T: NSView>(of type: T.Type, in root: NSView) -> T? {

--- a/Tests/SidebarDropRoutingTests.swift
+++ b/Tests/SidebarDropRoutingTests.swift
@@ -100,6 +100,34 @@ final class SidebarDropRoutingTests: XCTestCase {
         pump(0.4)
     }
 
+    /// "Add to AI Chat" must not leave keyboard users stranded in the document:
+    /// the same state mutation that reveals AI requests first responder for the
+    /// real AppKit composer, so typing or Return works immediately.
+    func testAddingReferenceFocusesRealComposer() throws {
+        let mounted = hostSidebar(initialTab: .annotations)
+        let composer = try XCTUnwrap(firstSubview(of: SubmitTextView.self, in: mounted.host))
+        XCTAssertFalse(window?.firstResponder === composer)
+
+        mounted.pane.ai.addReference(
+            AiReference(kind: .selection(text: "Focus this passage", page: 3))
+        )
+        mounted.host.layoutSubtreeIfNeeded()
+        pump(0.5)
+
+        XCTAssertEqual(mounted.workspace.sidebarTab, .ai)
+        XCTAssertTrue(mounted.workspace.sidebarOpen)
+        XCTAssertTrue(window?.firstResponder === composer)
+        XCTAssertEqual(mounted.pane.ai.composerReferences.count, 1)
+    }
+
+    private func firstSubview<T: NSView>(of type: T.Type, in root: NSView) -> T? {
+        if let match = root as? T { return match }
+        for child in root.subviews {
+            if let match = firstSubview(of: type, in: child) { return match }
+        }
+        return nil
+    }
+
     /// The registered drag destination AppKit would route a drop at
     /// `windowPoint` to: the deepest registered view along the frontmost sibling
     /// branch containing the point. Front-to-back = `subviews` reversed.

--- a/Tests/VellumBundleTests.swift
+++ b/Tests/VellumBundleTests.swift
@@ -48,7 +48,22 @@ final class VellumBundleTests: XCTestCase {
             message(id: "imp-1", role: .user, content: "imported q", createdAt: "2026-02-01T00:00:00Z"),
             message(id: "imp-2", role: .assistant, content: "imported a", createdAt: "2026-02-01T00:00:01Z"),
         ]
-        let conversationsData = try JSONEncoder().encode(exportedConversation)
+        var encodedConversation = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: JSONEncoder().encode(exportedConversation)
+            ) as? [[String: Any]]
+        )
+        encodedConversation[0]["references"] = (0..<20).map { index in
+            [
+                "id": String(repeating: "i", count: 200) + "\(index)",
+                "kind": "image",
+                "label": String(repeating: "l", count: 220),
+                "page": -1,
+                "documentTitle": String(repeating: "d", count: 300),
+                "delivery": "sent",
+            ] as [String: Any]
+        }
+        let conversationsData = try JSONSerialization.data(withJSONObject: encodedConversation)
         let documentData = Data("%PDF-1.7 fake pdf bytes".utf8)
 
         let content = VellumBundle.Content(
@@ -105,6 +120,17 @@ final class VellumBundleTests: XCTestCase {
         let mergedData = try XCTUnwrap(DocumentDataStore.loadConversationsData(forKey: installKey))
         let merged = try JSONDecoder().decode([AiMessage].self, from: mergedData)
         XCTAssertEqual(merged.map(\.id), ["local-1", "imp-1", "imp-2"])
+        let importedReferences = try XCTUnwrap(
+            merged.first(where: { $0.id == "imp-1" })?.references
+        )
+        XCTAssertEqual(importedReferences.count, AiMessageReference.maxPerMessage)
+        XCTAssertTrue(importedReferences.allSatisfy {
+            $0.id.count <= AiMessageReference.maxIdCharacters
+                && $0.label.count <= AiMessageReference.maxLabelCharacters
+                && ($0.documentTitle?.count ?? 0)
+                    <= AiMessageReference.maxDocumentTitleCharacters
+                && $0.page == nil
+        })
     }
 
     // MARK: - Unstamped-PDF import stamps the manifest id

--- a/Vellum/Services/Ai/AiPersistence.swift
+++ b/Vellum/Services/Ai/AiPersistence.swift
@@ -310,12 +310,18 @@ enum AiPersistence {
         dirtyKeys.remove(key)
     }
 
-    static func makeMessage(role: AiRole, content: String, id: String? = nil) -> AiMessage {
+    static func makeMessage(
+        role: AiRole,
+        content: String,
+        id: String? = nil,
+        references: [AiMessageReference] = []
+    ) -> AiMessage {
         AiMessage(
             id: id ?? UUID().uuidString.lowercased(),
             role: role,
             content: content,
-            createdAt: ISO8601DateFormatter.aiTimestamp.string(from: Date())
+            createdAt: ISO8601DateFormatter.aiTimestamp.string(from: Date()),
+            references: references
         )
     }
 
@@ -426,12 +432,18 @@ enum AiPersistence {
            let usageData = try? JSONSerialization.data(withJSONObject: usageValue) {
             usage = try? JSONDecoder().decode(AiUsage.self, from: usageData)
         }
+        var references: [AiMessageReference] = []
+        if let referencesValue = value["references"] as? [[String: Any]],
+           let referencesData = try? JSONSerialization.data(withJSONObject: referencesValue) {
+            references = (try? JSONDecoder().decode([AiMessageReference].self, from: referencesData)) ?? []
+        }
         return AiMessage(
             id: rawId?.isEmpty == false ? rawId! : UUID().uuidString.lowercased(),
             role: role,
             content: content,
             createdAt: rawDate?.isEmpty == false ? rawDate! : ISO8601DateFormatter.aiTimestamp.string(from: Date()),
-            usage: usage
+            usage: usage,
+            references: references
         )
     }
 

--- a/Vellum/Services/Ai/AiPersistence.swift
+++ b/Vellum/Services/Ai/AiPersistence.swift
@@ -384,7 +384,7 @@ enum AiPersistence {
 
     private static func limit(_ messages: [AiMessage]) -> [AiMessage] {
         messages.suffix(maxMessagesPerDocument).map { message in
-            var message = message
+            var message = message.normalizedReferenceMetadata()
             if message.content.count > maxMessageCharacters {
                 let end = message.content.index(message.content.startIndex, offsetBy: maxMessageCharacters)
                 message.content = String(message.content[..<end]) + "\n[truncated]"

--- a/Vellum/Services/Ai/AiPrompts.swift
+++ b/Vellum/Services/Ai/AiPrompts.swift
@@ -28,12 +28,66 @@ struct AiUserPrompt {
     var joined: String { stable + "\n\n" + volatile }
 }
 
+struct AiReferencePlan: Sendable {
+    var included: [AiReference]
+    var provenance: [AiMessageReference]
+}
+
 enum AiPrompts {
     static let maxContextCharacters = 120_000
     /// Per-reference text cap so a single quoted reply or selection can't bloat
     /// the prompt, plus an overall cap on the joined referenced block.
     static let maxReferenceCharacters = 8_000
     static let maxReferencedBlockCharacters = 32_000
+
+    /// Select whole references for the provider payload. This is deliberately
+    /// done before persistence so provenance can say which references were sent
+    /// and which were omitted, instead of claiming a joined block's truncated
+    /// tail reached the model.
+    static func planReferences(
+        _ references: [AiReference],
+        supportsImages: Bool,
+        documentTitle: String?
+    ) -> AiReferencePlan {
+        var included: [AiReference] = []
+        var provenance: [AiMessageReference] = []
+        var usedCharacters = 0
+
+        for rawReference in references.prefix(AiMessageReference.maxPerMessage) {
+            let reference = rawReference.normalizedMetadata()
+            if reference.image != nil, !supportsImages {
+                provenance.append(AiMessageReference(
+                    reference: reference,
+                    documentTitle: documentTitle,
+                    delivery: .omittedUnsupportedImage
+                ))
+                continue
+            }
+
+            let line = referenceLine(reference)
+            let separatorCharacters = included.isEmpty ? 0 : 1
+            guard usedCharacters + separatorCharacters + line.count
+                    <= maxReferencedBlockCharacters
+            else {
+                provenance.append(AiMessageReference(
+                    reference: reference,
+                    documentTitle: documentTitle,
+                    delivery: .omittedBudget
+                ))
+                continue
+            }
+
+            usedCharacters += separatorCharacters + line.count
+            included.append(reference)
+            provenance.append(AiMessageReference(
+                reference: reference,
+                documentTitle: documentTitle,
+                delivery: .sent
+            ))
+        }
+
+        return AiReferencePlan(included: included, provenance: provenance)
+    }
 
     static func nativeSystemPrompt() throws -> String {
         try loadTemplate(named: "tool-mode-native")
@@ -89,7 +143,7 @@ enum AiPrompts {
             "attached (\($0.width)x\($0.height), \($0.mediaType))"
         } ?? "none"
 
-        let referenced = boundedReferencedBlock(context.references.map(referenceLine).joined(separator: "\n"))
+        let referenced = context.references.map(referenceLine).joined(separator: "\n")
 
         // Ordered most-stable-first so the leading bytes stay identical across a
         // session and stay cacheable (PR A.5). Session-invariant document
@@ -141,14 +195,6 @@ enum AiPrompts {
         guard text.count > maxReferenceCharacters else { return text }
         let end = text.index(text.startIndex, offsetBy: maxReferenceCharacters)
         return String(text[..<end]) + "…[truncated]"
-    }
-
-    /// Cap the whole referenced block after joining, in case many references add
-    /// up past the limit even when each fits under the per-item cap.
-    private static func boundedReferencedBlock(_ block: String) -> String {
-        guard block.count > maxReferencedBlockCharacters else { return block }
-        let end = block.index(block.startIndex, offsetBy: maxReferencedBlockCharacters)
-        return String(block[..<end]) + "\n[referenced context truncated]"
     }
 
     private static func annotationLine(_ annotation: Annotation) -> String {

--- a/Vellum/Services/VellumBundle.swift
+++ b/Vellum/Services/VellumBundle.swift
@@ -451,7 +451,7 @@ enum VellumBundle {
     /// over-long content.
     private static func capConversation(_ messages: [AiMessage]) -> [AiMessage] {
         messages.suffix(AiPersistence.maxMessagesPerDocument).map { message in
-            var message = message
+            var message = message.normalizedReferenceMetadata()
             if message.content.count > AiPersistence.maxMessageCharacters {
                 let end = message.content.index(
                     message.content.startIndex, offsetBy: AiPersistence.maxMessageCharacters)

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -52,6 +52,68 @@ enum AiThinkingMode: String, Codable, Sendable, CaseIterable {
     }
 }
 
+struct AiMessageReference: Codable, Equatable, Identifiable, Sendable {
+    enum Kind: String, Codable, Sendable {
+        case selection
+        case highlight
+        case region
+        case pageSnapshot
+        case quote
+        case image
+    }
+
+    var id: String
+    var kind: Kind
+    /// Compact, immutable description of what was sent. Image bytes are
+    /// deliberately not persisted with the transcript.
+    var label: String
+    var page: Int?
+    /// The document active when the reference was sent. This makes provenance
+    /// unambiguous when a conversation is exported or revisited later.
+    var documentTitle: String?
+
+    init(reference: AiReference, documentTitle: String?) {
+        id = reference.id
+        let trimmedTitle = documentTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.documentTitle = trimmedTitle?.isEmpty == false ? trimmedTitle : nil
+        switch reference.kind {
+        case let .selection(text, page):
+            kind = .selection
+            label = Self.collapsed(text)
+            self.page = page
+        case let .highlight(text, page):
+            kind = .highlight
+            label = Self.collapsed(text)
+            self.page = page
+        case let .region(_, page):
+            kind = .region
+            label = "Region"
+            self.page = page
+        case let .pageSnapshot(_, page):
+            kind = .pageSnapshot
+            label = "Page \(page)"
+            self.page = page
+        case let .quote(text, _):
+            kind = .quote
+            label = Self.collapsed(text)
+            page = nil
+        case let .image(_, name):
+            kind = .image
+            label = name
+            page = nil
+        }
+    }
+
+    private static func collapsed(_ text: String) -> String {
+        let collapsed = text
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard collapsed.count > 80 else { return collapsed }
+        return String(collapsed.prefix(77)) + "…"
+    }
+}
+
 struct AiMessage: Codable, Equatable, Identifiable, Sendable {
     var id: String
     var role: AiRole
@@ -60,6 +122,39 @@ struct AiMessage: Codable, Equatable, Identifiable, Sendable {
     /// Per-response token/cost telemetry; absent on messages persisted
     /// before telemetry existed and on user messages.
     var usage: AiUsage? = nil
+    /// Immutable provenance for references attached to this user turn.
+    /// Empty for assistant messages and conversations written before #58.
+    var references: [AiMessageReference] = []
+
+    private enum CodingKeys: String, CodingKey {
+        case id, role, content, createdAt, usage, references
+    }
+
+    init(
+        id: String,
+        role: AiRole,
+        content: String,
+        createdAt: String,
+        usage: AiUsage? = nil,
+        references: [AiMessageReference] = []
+    ) {
+        self.id = id
+        self.role = role
+        self.content = content
+        self.createdAt = createdAt
+        self.usage = usage
+        self.references = references
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(String.self, forKey: .id)
+        role = try values.decode(AiRole.self, forKey: .role)
+        content = try values.decode(String.self, forKey: .content)
+        createdAt = try values.decode(String.self, forKey: .createdAt)
+        usage = try values.decodeIfPresent(AiUsage.self, forKey: .usage)
+        references = try values.decodeIfPresent([AiMessageReference].self, forKey: .references) ?? []
+    }
 }
 
 /// Coarse phase of an in-flight request, surfaced by the panel's activity
@@ -218,6 +313,9 @@ final class AiStore {
     /// Context the user has attached to the next message (selection, highlight,
     /// snapshot, or an AI-reply quote). Rendered as chips in the composer.
     private(set) var composerReferences: [AiReference] = []
+    /// Monotonic request observed by the AppKit-backed composer. A counter (not
+    /// a Bool) means repeated "Add to AI Chat" actions always refocus it.
+    private(set) var composerFocusRequest = 0
 
     /// Registered by the PDF viewer: locate a verbatim phrase on a page at
     /// zoom 1 in top-left-origin PDF points (lib/highlight-locator.ts).
@@ -343,6 +441,7 @@ final class AiStore {
         composerReferences.append(reference)
         app?.workspace?.sidebarTab = .ai
         app?.workspace?.sidebarOpen = true
+        composerFocusRequest &+= 1
     }
 
     func removeReference(id: String) {
@@ -601,7 +700,14 @@ final class AiStore {
             return
         }
 
-        let userMessage = AiPersistence.makeMessage(role: .user, content: trimmed)
+        let sentReferences = context.references.map {
+            AiMessageReference(reference: $0, documentTitle: documentAtStart.title)
+        }
+        let userMessage = AiPersistence.makeMessage(
+            role: .user,
+            content: trimmed,
+            references: sentReferences
+        )
         messages.append(userMessage)
         // Empty assistant placeholder the stream fills in-place. Kept out of the
         // persisted list until it has content so a mid-stream crash leaves no

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -53,6 +53,11 @@ enum AiThinkingMode: String, Codable, Sendable, CaseIterable {
 }
 
 struct AiMessageReference: Codable, Equatable, Identifiable, Sendable {
+    static let maxPerMessage = 16
+    static let maxIdCharacters = 128
+    static let maxLabelCharacters = 160
+    static let maxDocumentTitleCharacters = 256
+
     enum Kind: String, Codable, Sendable {
         case selection
         case highlight
@@ -60,6 +65,12 @@ struct AiMessageReference: Codable, Equatable, Identifiable, Sendable {
         case pageSnapshot
         case quote
         case image
+    }
+
+    enum Delivery: String, Codable, Sendable {
+        case sent
+        case omittedBudget
+        case omittedUnsupportedImage
     }
 
     var id: String
@@ -71,11 +82,26 @@ struct AiMessageReference: Codable, Equatable, Identifiable, Sendable {
     /// The document active when the reference was sent. This makes provenance
     /// unambiguous when a conversation is exported or revisited later.
     var documentTitle: String?
+    /// Whether the payload reached the provider. Omitted references remain in
+    /// provenance so the transcript never claims that context was sent.
+    var delivery: Delivery
 
-    init(reference: AiReference, documentTitle: String?) {
-        id = reference.id
-        let trimmedTitle = documentTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.documentTitle = trimmedTitle?.isEmpty == false ? trimmedTitle : nil
+    private enum CodingKeys: String, CodingKey {
+        case id, kind, label, page, documentTitle, delivery
+    }
+
+    init(
+        reference: AiReference,
+        documentTitle: String?,
+        delivery: Delivery = .sent
+    ) {
+        id = Self.boundedMetadata(reference.id, max: Self.maxIdCharacters)
+        if id.isEmpty { id = UUID().uuidString.lowercased() }
+        self.documentTitle = Self.optionalBounded(
+            documentTitle,
+            max: Self.maxDocumentTitleCharacters
+        )
+        self.delivery = delivery
         switch reference.kind {
         case let .selection(text, page):
             kind = .selection
@@ -99,9 +125,43 @@ struct AiMessageReference: Codable, Equatable, Identifiable, Sendable {
             page = nil
         case let .image(_, name):
             kind = .image
-            label = name
+            label = Self.boundedMetadata(name, max: Self.maxLabelCharacters)
             page = nil
         }
+        label = Self.boundedMetadata(label, max: Self.maxLabelCharacters)
+        self.page = self.page.flatMap { $0 > 0 ? min($0, 1_000_000) : nil }
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        let rawId = try values.decodeIfPresent(String.self, forKey: .id) ?? ""
+        id = Self.boundedMetadata(rawId, max: Self.maxIdCharacters)
+        if id.isEmpty { id = UUID().uuidString.lowercased() }
+        kind = try values.decode(Kind.self, forKey: .kind)
+        label = Self.boundedMetadata(
+            try values.decodeIfPresent(String.self, forKey: .label) ?? "",
+            max: Self.maxLabelCharacters
+        )
+        let decodedPage = try values.decodeIfPresent(Int.self, forKey: .page)
+        page = decodedPage.flatMap { $0 > 0 ? min($0, 1_000_000) : nil }
+        documentTitle = Self.optionalBounded(
+            try values.decodeIfPresent(String.self, forKey: .documentTitle),
+            max: Self.maxDocumentTitleCharacters
+        )
+        delivery = try values.decodeIfPresent(Delivery.self, forKey: .delivery) ?? .sent
+    }
+
+    func normalized() -> Self {
+        var copy = self
+        copy.id = Self.boundedMetadata(copy.id, max: Self.maxIdCharacters)
+        if copy.id.isEmpty { copy.id = UUID().uuidString.lowercased() }
+        copy.label = Self.boundedMetadata(copy.label, max: Self.maxLabelCharacters)
+        copy.page = copy.page.flatMap { $0 > 0 ? min($0, 1_000_000) : nil }
+        copy.documentTitle = Self.optionalBounded(
+            copy.documentTitle,
+            max: Self.maxDocumentTitleCharacters
+        )
+        return copy
     }
 
     private static func collapsed(_ text: String) -> String {
@@ -111,6 +171,29 @@ struct AiMessageReference: Codable, Equatable, Identifiable, Sendable {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard collapsed.count > 80 else { return collapsed }
         return String(collapsed.prefix(77)) + "…"
+    }
+
+    private static func optionalBounded(_ value: String?, max: Int) -> String? {
+        guard let value else { return nil }
+        let bounded = boundedMetadata(value, max: max)
+        return bounded.isEmpty ? nil : bounded
+    }
+
+    private static func boundedMetadata(_ value: String, max: Int) -> String {
+        let cleaned = value
+            .replacingOccurrences(
+                of: "[\\p{Cc}\\p{Cf}]",
+                with: " ",
+                options: .regularExpression
+            )
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return bounded(cleaned, max: max)
+    }
+
+    private static func bounded(_ value: String, max: Int) -> String {
+        guard value.count > max else { return value }
+        return String(value.prefix(max))
     }
 }
 
@@ -143,7 +226,9 @@ struct AiMessage: Codable, Equatable, Identifiable, Sendable {
         self.content = content
         self.createdAt = createdAt
         self.usage = usage
-        self.references = references
+        self.references = Array(
+            references.prefix(AiMessageReference.maxPerMessage).map { $0.normalized() }
+        )
     }
 
     init(from decoder: Decoder) throws {
@@ -153,7 +238,19 @@ struct AiMessage: Codable, Equatable, Identifiable, Sendable {
         content = try values.decode(String.self, forKey: .content)
         createdAt = try values.decode(String.self, forKey: .createdAt)
         usage = try values.decodeIfPresent(AiUsage.self, forKey: .usage)
-        references = try values.decodeIfPresent([AiMessageReference].self, forKey: .references) ?? []
+        references = Array(
+            (try values.decodeIfPresent([AiMessageReference].self, forKey: .references) ?? [])
+                .prefix(AiMessageReference.maxPerMessage)
+                .map { $0.normalized() }
+        )
+    }
+
+    func normalizedReferenceMetadata() -> Self {
+        var copy = self
+        copy.references = Array(
+            references.prefix(AiMessageReference.maxPerMessage).map { $0.normalized() }
+        )
+        return copy
     }
 }
 
@@ -175,6 +272,7 @@ enum AiActivity: Equatable, Sendable {
 /// or a quote pulled from a previous AI reply. Rendered as chips in the
 /// composer and folded into the prompt / image inputs at send time.
 struct AiReference: Identifiable, Equatable, Sendable {
+    static let maxImageNameCharacters = 160
     /// `page` is meaningful for web documents too: the injected content script
     /// paginates an archived page into virtual pages (it reports pageCount and
     /// per-page text, and the AI's scroll/read tools address those numbers), so
@@ -205,6 +303,36 @@ struct AiReference: Identifiable, Equatable, Sendable {
         case let .region(image, _), let .pageSnapshot(image, _), let .image(image, _): return image
         default: return nil
         }
+    }
+
+    func normalizedMetadata() -> Self {
+        var normalizedId = String(
+            id
+                .replacingOccurrences(
+                    of: "[\\p{Cc}\\p{Cf}\\s]",
+                    with: "",
+                    options: .regularExpression
+                )
+                .prefix(AiMessageReference.maxIdCharacters)
+        )
+        if normalizedId.isEmpty { normalizedId = UUID().uuidString.lowercased() }
+        var normalizedKind = kind
+        if case let .image(image, name) = kind {
+            let cleaned = name
+                .replacingOccurrences(
+                    of: "[\\p{Cc}\\p{Cf}]",
+                    with: " ",
+                    options: .regularExpression
+                )
+                .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let fallback = cleaned.isEmpty ? "Image" : cleaned
+            normalizedKind = .image(
+                image: image,
+                name: String(fallback.prefix(Self.maxImageNameCharacters))
+            )
+        }
+        return Self(id: normalizedId, kind: normalizedKind)
     }
 }
 
@@ -257,6 +385,16 @@ struct AiContextSnapshot: Sendable {
     var currentPageImage: AiPageImageSnapshot?
     /// User-attached references (selection / highlight / snapshot / quote).
     var references: [AiReference] = []
+}
+
+/// Exact destination captured before an async reference operation starts.
+/// A pane reuses one AiStore across tabs, so both the session and document
+/// identity must still match after an await before bytes can enter the composer.
+struct AiReferenceTarget: Equatable, Sendable {
+    var sessionId: String
+    var kind: DocumentKind
+    var path: String
+    var documentId: String?
 }
 
 /// Result of locating a phrase in a document (PDF text layer or web content
@@ -313,9 +451,10 @@ final class AiStore {
     /// Context the user has attached to the next message (selection, highlight,
     /// snapshot, or an AI-reply quote). Rendered as chips in the composer.
     private(set) var composerReferences: [AiReference] = []
-    /// Monotonic request observed by the AppKit-backed composer. A counter (not
-    /// a Bool) means repeated "Add to AI Chat" actions always refocus it.
-    private(set) var composerFocusRequest = 0
+    /// One-shot, store-namespaced request observed by the AppKit composer.
+    /// Consumption clears it in the store, so inspector remounts cannot replay
+    /// an old focus request and a different split pane cannot collide with it.
+    private(set) var composerFocusRequest: String?
 
     /// Registered by the PDF viewer: locate a verbatim phrase on a page at
     /// zoom 1 in top-left-origin PDF points (lib/highlight-locator.ts).
@@ -434,6 +573,11 @@ final class AiStore {
 
     /// Attach a reference and reveal the AI panel so the user sees it land.
     func addReference(_ reference: AiReference) {
+        guard composerReferences.count < AiMessageReference.maxPerMessage else {
+            error = "You can attach at most \(AiMessageReference.maxPerMessage) references to one message."
+            return
+        }
+        let reference = reference.normalizedMetadata()
         if reference.image != nil, !canAttachMoreImages {
             error = "You can attach at most \(Self.maxImageReferences) images to one message."
             return
@@ -441,7 +585,34 @@ final class AiStore {
         composerReferences.append(reference)
         app?.workspace?.sidebarTab = .ai
         app?.workspace?.sidebarOpen = true
-        composerFocusRequest &+= 1
+        composerFocusRequest = UUID().uuidString.lowercased()
+    }
+
+    func consumeComposerFocusRequest(_ request: String) {
+        guard composerFocusRequest == request else { return }
+        composerFocusRequest = nil
+    }
+
+    func currentReferenceTarget() -> AiReferenceTarget? {
+        guard let app,
+              let sessionId = app.activeTabId,
+              let document = app.document
+        else { return nil }
+        return AiReferenceTarget(
+            sessionId: sessionId,
+            kind: document.kind,
+            path: document.pdfPath,
+            documentId: document.docId
+        )
+    }
+
+    /// Commit bytes produced by an async page/region capture only if the pane is
+    /// still showing the exact tab and document that initiated it.
+    @discardableResult
+    func addCapturedReference(_ reference: AiReference, target: AiReferenceTarget) -> Bool {
+        guard let current = currentReferenceTarget(), current == target else { return false }
+        addReference(reference)
+        return true
     }
 
     func removeReference(id: String) {
@@ -658,6 +829,25 @@ final class AiStore {
         return Array(messages[..<lastUserIndex])
     }
 
+    private static func selectedModel(in settings: AiSettings) -> String {
+        switch settings.provider {
+        case .gemini: settings.model
+        case .openai: settings.openaiModel
+        case .openrouter: settings.openrouterModel
+        case .chatgpt: settings.chatgptModel
+        case .opencode: settings.opencodeModel
+        case .opencodeGo: settings.opencodeGoModel
+        }
+    }
+
+    private func supportsImages(in settings: AiSettings) -> Bool {
+        AiModelCatalog.supportsVision(
+            provider: settings.provider,
+            model: Self.selectedModel(in: settings),
+            catalog: openRouterCatalog
+        )
+    }
+
     /// Full send pipeline: key check, context block, provider dispatch, tool
     /// loop, persistence — see SPECS-ai.md "sendMessage pipeline".
     func sendMessage(_ input: String, context: AiContextSnapshot) async {
@@ -700,13 +890,20 @@ final class AiStore {
             return
         }
 
-        let sentReferences = context.references.map {
-            AiMessageReference(reference: $0, documentTitle: documentAtStart.title)
+        let supportsImagesAtStart = supportsImages(in: settingsAtStart)
+        let referencePlan = AiPrompts.planReferences(
+            context.references,
+            supportsImages: supportsImagesAtStart,
+            documentTitle: documentAtStart.title
+        )
+        context.references = referencePlan.included
+        if !supportsImagesAtStart {
+            context.currentPageImage = nil
         }
         let userMessage = AiPersistence.makeMessage(
             role: .user,
             content: trimmed,
-            references: sentReferences
+            references: referencePlan.provenance
         )
         messages.append(userMessage)
         // Empty assistant placeholder the stream fills in-place. Kept out of the
@@ -825,15 +1022,13 @@ final class AiStore {
                 }
                 // Unknown ids (stale cache) default to permissive so we never
                 // silently strip a capability the model actually has.
-                let supportsVision = AiModelCatalog.supportsVision(
-                    provider: .openrouter, model: model, catalog: openRouterCatalog)
                 let supportsTools = openRouterCatalog?.model(for: model)?.supportsTools ?? true
                 result = try await OpenRouterClient().generate(
                     apiKey: settingsAtStart.openrouterApiKey.trimmingCharacters(in: .whitespacesAndNewlines),
                     model: model,
                     systemPrompt: try AiPrompts.nativeSystemPrompt(),
                     prompt: prompt,
-                    images: supportsVision ? images : [],
+                    images: supportsImagesAtStart ? images : [],
                     allowTools: supportsTools,
                     thinkingMode: settingsAtStart.reasoningEffort,
                     sessionIdAtStart: sessionIdAtStart,
@@ -868,8 +1063,7 @@ final class AiStore {
                     // Only text-only open models drop the images (page snapshot +
                     // user-attached references); the gateway rejects image parts
                     // for models that can't read them.
-                    images: AiModelCatalog.supportsVision(
-                        provider: .opencode, model: model, catalog: openRouterCatalog) ? images : [],
+                    images: supportsImagesAtStart ? images : [],
                     thinkingMode: settingsAtStart.reasoningEffort,
                     sessionIdAtStart: sessionIdAtStart,
                     toolEngine: engine,
@@ -885,8 +1079,7 @@ final class AiStore {
                     model: model,
                     systemPrompt: try AiPrompts.nativeSystemPrompt(),
                     prompt: prompt,
-                    images: AiModelCatalog.supportsVision(
-                        provider: .opencodeGo, model: model, catalog: openRouterCatalog) ? images : [],
+                    images: supportsImagesAtStart ? images : [],
                     thinkingMode: settingsAtStart.reasoningEffort,
                     sessionIdAtStart: sessionIdAtStart,
                     toolEngine: engine,

--- a/Vellum/Views/AI/AiPanel.swift
+++ b/Vellum/Views/AI/AiPanel.swift
@@ -81,11 +81,18 @@ struct AiPanel: View {
                 Image(systemName: "sparkles")
                     .font(.system(size: 15))
                     .foregroundStyle(palette.primary)
-                Text("AI Assistant")
-                    .font(.system(size: 14, weight: .medium))
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("AI Assistant")
+                        .font(.system(size: 14, weight: .medium))
+                    Text(documentScopeTitle)
+                        .font(.caption)
+                        .foregroundStyle(palette.mutedForeground)
+                }
+                .lineLimit(1)
+                .truncationMode(.tail)
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("AI Assistant for \(documentScopeTitle)")
             Spacer(minLength: 8)
             HStack(spacing: 2) {
                 IconButton(
@@ -174,6 +181,11 @@ struct AiPanel: View {
             .padding(.horizontal, 4)
 
             messageBubble(message)
+
+            if message.role == .user, !message.references.isEmpty {
+                SentReferenceChipRow(references: message.references)
+                    .accessibilityIdentifier("aiMessage.sentReferences")
+            }
 
             if message.role == .assistant, !message.content.isEmpty {
                 messageActions(message)
@@ -351,6 +363,7 @@ struct AiPanel: View {
             ComposerTextView(
                 text: $input,
                 placeholder: "Ask about this document…",
+                focusRequest: aiStore.composerFocusRequest,
                 onSubmit: submit,
                 // The composer's NSTextView is a registered drag destination and
                 // AppKit hands it any drop over its bounds before SwiftUI's
@@ -373,6 +386,13 @@ struct AiPanel: View {
             .accessibilityLabel("Send message")
             .accessibilityIdentifier("aiPanel.send")
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Message composer for \(documentScopeTitle)")
+    }
+
+    private var documentScopeTitle: String {
+        let title = appStore.document?.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return title?.isEmpty == false ? title! : "current document"
     }
 
     /// "+" attach menu: a current-page snapshot or drag-to-crop region of the
@@ -547,6 +567,7 @@ private struct AnimatedDots: View {
 private struct ComposerTextView: View {
     @Binding var text: String
     let placeholder: String
+    let focusRequest: Int
     let onSubmit: () -> Void
     /// A file or image dropped onto the field itself; nil disables interception, so
     /// AppKit's own drag handling (text, file paths) is left alone.
@@ -564,6 +585,7 @@ private struct ComposerTextView: View {
         ComposerTextViewRep(
             text: $text,
             placeholder: placeholder,
+            focusRequest: focusRequest,
             onSubmit: onSubmit,
             onAttachmentDrop: onAttachmentDrop,
             onDropTargeted: onDropTargeted,
@@ -576,6 +598,7 @@ private struct ComposerTextView: View {
 private struct ComposerTextViewRep: NSViewRepresentable {
     @Binding var text: String
     let placeholder: String
+    let focusRequest: Int
     let onSubmit: () -> Void
     let onAttachmentDrop: ((AttachmentDropPayload) -> Void)?
     let onDropTargeted: (Bool) -> Void
@@ -596,6 +619,7 @@ private struct ComposerTextViewRep: NSViewRepresentable {
         textView.onDropTargeted = onDropTargeted
         textView.updateDragTypeRegistration()
         textView.placeholder = placeholder
+        textView.setAccessibilityIdentifier("aiPanel.composer")
         textView.drawsBackground = false
         textView.font = .systemFont(ofSize: 14)
         textView.alignment = .left
@@ -629,11 +653,19 @@ private struct ComposerTextViewRep: NSViewRepresentable {
         if textView.string != text { textView.string = text }
         textView.needsDisplay = true
         context.coordinator.publishHeight(for: textView)
+        if focusRequest != context.coordinator.fulfilledFocusRequest {
+            context.coordinator.fulfilledFocusRequest = focusRequest
+            Task { @MainActor [weak textView] in
+                guard let textView, let window = textView.window else { return }
+                window.makeFirstResponder(textView)
+            }
+        }
     }
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: ComposerTextViewRep
+        var fulfilledFocusRequest = 0
         init(parent: ComposerTextViewRep) { self.parent = parent }
 
         func textDidChange(_ notification: Notification) {

--- a/Vellum/Views/AI/AiPanel.swift
+++ b/Vellum/Views/AI/AiPanel.swift
@@ -364,6 +364,7 @@ struct AiPanel: View {
                 text: $input,
                 placeholder: "Ask about this document…",
                 focusRequest: aiStore.composerFocusRequest,
+                onFocusRequestConsumed: aiStore.consumeComposerFocusRequest,
                 onSubmit: submit,
                 // The composer's NSTextView is a registered drag destination and
                 // AppKit hands it any drop over its bounds before SwiftUI's
@@ -443,9 +444,15 @@ struct AiPanel: View {
 
     private func attachCurrentPage() {
         let page = appStore.currentPage
+        guard let target = aiStore.currentReferenceTarget(),
+              let capturePage = aiStore.capturePageImageHandler
+        else { return }
         Task {
-            guard let image = await aiStore.capturePageImageHandler?(page) else { return }
-            aiStore.addReference(AiReference(kind: .pageSnapshot(image: image, page: page)))
+            guard let image = await capturePage(page) else { return }
+            aiStore.addCapturedReference(
+                AiReference(kind: .pageSnapshot(image: image, page: page)),
+                target: target
+            )
         }
     }
 
@@ -567,7 +574,8 @@ private struct AnimatedDots: View {
 private struct ComposerTextView: View {
     @Binding var text: String
     let placeholder: String
-    let focusRequest: Int
+    let focusRequest: String?
+    let onFocusRequestConsumed: (String) -> Void
     let onSubmit: () -> Void
     /// A file or image dropped onto the field itself; nil disables interception, so
     /// AppKit's own drag handling (text, file paths) is left alone.
@@ -586,6 +594,7 @@ private struct ComposerTextView: View {
             text: $text,
             placeholder: placeholder,
             focusRequest: focusRequest,
+            onFocusRequestConsumed: onFocusRequestConsumed,
             onSubmit: onSubmit,
             onAttachmentDrop: onAttachmentDrop,
             onDropTargeted: onDropTargeted,
@@ -598,7 +607,8 @@ private struct ComposerTextView: View {
 private struct ComposerTextViewRep: NSViewRepresentable {
     @Binding var text: String
     let placeholder: String
-    let focusRequest: Int
+    let focusRequest: String?
+    let onFocusRequestConsumed: (String) -> Void
     let onSubmit: () -> Void
     let onAttachmentDrop: ((AttachmentDropPayload) -> Void)?
     let onDropTargeted: (Bool) -> Void
@@ -653,11 +663,14 @@ private struct ComposerTextViewRep: NSViewRepresentable {
         if textView.string != text { textView.string = text }
         textView.needsDisplay = true
         context.coordinator.publishHeight(for: textView)
-        if focusRequest != context.coordinator.fulfilledFocusRequest {
+        if let focusRequest,
+           focusRequest != context.coordinator.fulfilledFocusRequest {
             context.coordinator.fulfilledFocusRequest = focusRequest
+            let onFocusRequestConsumed = onFocusRequestConsumed
             Task { @MainActor [weak textView] in
                 guard let textView, let window = textView.window else { return }
-                window.makeFirstResponder(textView)
+                guard window.makeFirstResponder(textView) else { return }
+                onFocusRequestConsumed(focusRequest)
             }
         }
     }
@@ -665,7 +678,7 @@ private struct ComposerTextViewRep: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: ComposerTextViewRep
-        var fulfilledFocusRequest = 0
+        var fulfilledFocusRequest: String?
         init(parent: ComposerTextViewRep) { self.parent = parent }
 
         func textDidChange(_ notification: Notification) {

--- a/Vellum/Views/AI/ComposerReferences.swift
+++ b/Vellum/Views/AI/ComposerReferences.swift
@@ -39,7 +39,7 @@ struct SentReferenceChipRow: View {
         }
         .frame(maxHeight: 34)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("References sent with this message")
+        .accessibilityLabel("Reference delivery for this message")
     }
 }
 
@@ -57,7 +57,7 @@ private struct SentReferenceChip: View {
             Image(systemName: icon)
         }
         .font(.system(size: 11))
-        .foregroundStyle(palette.mutedForeground)
+        .foregroundStyle(isSent ? palette.mutedForeground : Color.orange)
         .padding(.horizontal, 8)
         .padding(.vertical, 5)
         .background(.quaternary.opacity(0.35), in: Capsule())
@@ -68,23 +68,44 @@ private struct SentReferenceChip: View {
     private var summary: String {
         let source = reference.documentTitle.flatMap { $0.isEmpty ? nil : $0 }
         let locator = reference.page.map { "p.\($0)" }
-        return [reference.label, locator, source].compactMap { $0 }.joined(separator: " · ")
+        return [reference.label, locator, source, deliverySummary].compactMap { $0 }.joined(separator: " · ")
     }
 
     private var accessibilitySummary: String {
         let page = reference.page.map { ", page \($0)" } ?? ""
         let document = reference.documentTitle.map { ", from \($0)" } ?? ""
-        return "\(reference.kind.accessibilityName): \(reference.label)\(page)\(document)"
+        return "\(reference.kind.accessibilityName): \(reference.label)\(page)\(document), \(deliveryAccessibilitySummary)"
     }
 
     private var icon: String {
-        switch reference.kind {
+        guard isSent else { return "exclamationmark.triangle" }
+        return switch reference.kind {
         case .selection: "text.quote"
         case .highlight: "highlighter"
         case .region: "square.dashed"
         case .pageSnapshot: "doc.richtext"
         case .quote: "quote.bubble"
         case .image: "photo"
+        }
+    }
+
+    private var isSent: Bool {
+        reference.delivery == .sent
+    }
+
+    private var deliverySummary: String? {
+        switch reference.delivery {
+        case .sent: nil
+        case .omittedBudget: "Not sent: context limit"
+        case .omittedUnsupportedImage: "Not sent: model cannot read images"
+        }
+    }
+
+    private var deliveryAccessibilitySummary: String {
+        switch reference.delivery {
+        case .sent: "sent"
+        case .omittedBudget: "not sent because the context limit was reached"
+        case .omittedUnsupportedImage: "not sent because the selected model cannot read images"
         }
     }
 }

--- a/Vellum/Views/AI/ComposerReferences.swift
+++ b/Vellum/Views/AI/ComposerReferences.swift
@@ -22,6 +22,86 @@ struct ReferenceChipRow: View {
     }
 }
 
+/// Immutable provenance shown beneath a sent user message. Unlike composer
+/// chips these have no remove affordance because they describe what was already
+/// sent, not what will be sent next.
+struct SentReferenceChipRow: View {
+    let references: [AiMessageReference]
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(references) { reference in
+                    SentReferenceChip(reference: reference)
+                }
+            }
+            .padding(.horizontal, 2)
+        }
+        .frame(maxHeight: 34)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("References sent with this message")
+    }
+}
+
+private struct SentReferenceChip: View {
+    let reference: AiMessageReference
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Label {
+            Text(summary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        } icon: {
+            Image(systemName: icon)
+        }
+        .font(.system(size: 11))
+        .foregroundStyle(palette.mutedForeground)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(.quaternary.opacity(0.35), in: Capsule())
+        .overlay { Capsule().strokeBorder(palette.border) }
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    private var summary: String {
+        let source = reference.documentTitle.flatMap { $0.isEmpty ? nil : $0 }
+        let locator = reference.page.map { "p.\($0)" }
+        return [reference.label, locator, source].compactMap { $0 }.joined(separator: " · ")
+    }
+
+    private var accessibilitySummary: String {
+        let page = reference.page.map { ", page \($0)" } ?? ""
+        let document = reference.documentTitle.map { ", from \($0)" } ?? ""
+        return "\(reference.kind.accessibilityName): \(reference.label)\(page)\(document)"
+    }
+
+    private var icon: String {
+        switch reference.kind {
+        case .selection: "text.quote"
+        case .highlight: "highlighter"
+        case .region: "square.dashed"
+        case .pageSnapshot: "doc.richtext"
+        case .quote: "quote.bubble"
+        case .image: "photo"
+        }
+    }
+}
+
+private extension AiMessageReference.Kind {
+    var accessibilityName: String {
+        switch self {
+        case .selection: "Text selection"
+        case .highlight: "Highlight"
+        case .region: "Document region"
+        case .pageSnapshot: "Page snapshot"
+        case .quote: "Assistant quote"
+        case .image: "Attached image"
+        }
+    }
+}
+
 private struct ReferenceChip: View {
     let reference: AiReference
     let onRemove: () -> Void

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -225,13 +225,17 @@ struct WebViewerView: View {
     private func captureRegion(_ rect: CGRect) {
         switch appStore.regionCaptureTarget {
         case .ai:
+            guard let target = aiStore.currentReferenceTarget() else { return }
             Task {
                 // A web capture always stamps the virtual page it was taken on,
                 // so the snapshot's optional page is always populated here.
                 guard let snapshot = await controller.captureRegionImage(viewerRect: rect),
                       let page = snapshot.pageNumber
                 else { return }
-                aiStore.addReference(AiReference(kind: .region(image: snapshot, page: page)))
+                aiStore.addCapturedReference(
+                    AiReference(kind: .region(image: snapshot, page: page)),
+                    target: target
+                )
             }
         case .scratchpad:
             Task {


### PR DESCRIPTION
## Summary
- make Add/Ask AI select the panel and issue a repeatable AppKit composer-focus request
- retain removable pending reference chips and persist immutable provenance chips on sent user messages
- store compact document/page/type metadata without persisting image payloads
- expose the current document scope in panel and composer accessibility labels

## Verification
- 44 AI pipeline and sidebar routing tests passed
- 20 AttachmentDropTests passed
- exact Debug build succeeded
- hosted AppKit first-responder test verifies real composer focus
- live Computer Use was blocked by local Vellum authorization and indistinguishable same-bundle-id instances, so the agent stopped rather than operate the wrong app

## Audit
Implements Issues #56 and #58 as one coherent reference/focus flow from the 2026-07-27 audit.