### PR TITLE
Make AI answers and source traces responsive

### DIFF
--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -13,21 +13,22 @@ final class AiPipelineTests: XCTestCase {
     // MARK: - §1 Retrieval persistence
 
     /// Raw tool output carries a unique marker; the persisted assistant content
-    /// is composed from compact receipts, so the marker must never survive into
-    /// the message — or, transitively, into the next request's prompt.
+    /// is kept separate from compact summaries, so the marker must never survive
+    /// into the message — or, transitively, into the next request's prompt.
     func testRawRetrievalOutputCannotReachTheNextPrompt() {
         let marker = "UNIQUE-RETRIEVAL-MARKER-93b1f2"
         // What the tool loop saw (transient, provider-side only):
         let rawToolOutput = "Page 20:\nlorem ipsum \(marker) dolor sit amet"
         XCTAssertTrue(rawToolOutput.contains(marker), "fixture sanity")
 
-        // What the store persists: reply + compact receipts.
+        // What the store persists as the answer (structured summaries live on
+        // the message separately).
         let persisted = AiStore.composeAssistantContent(
             reply: "Page 20 discusses the marker experiment.",
-            receipts: ["Read page 20.", "Searched the document for \"marker\"."]
+            receipts: [AiToolSummary(title: "Read page 20", destinationPage: 20)]
         )
         XCTAssertFalse(persisted.contains(marker))
-        XCTAssertTrue(persisted.contains("Read page 20."))
+        XCTAssertEqual(persisted, "Page 20 discusses the marker experiment.")
 
         // And the next turn's conversation block (built from persisted
         // messages) cannot resend it.

--- a/Tests/AiToolSummaryTests.swift
+++ b/Tests/AiToolSummaryTests.swift
@@ -131,6 +131,67 @@ struct AiToolSummaryTests {
         #expect(message.content == content)
     }
 
+    @Test("Ordinary Actions sections remain part of message content")
+    func legitimateActionsContentIsNotTreatedAsLegacyReceipts() {
+        let assistantContent = """
+        Here is the plan.
+
+        Actions:
+        - Review the introduction
+        - Compare the two arguments
+        """
+        let assistant = AiMessage(
+            id: "assistant-plan",
+            role: .assistant,
+            content: assistantContent,
+            createdAt: "now"
+        )
+        let userContent = """
+        Please remember this:
+
+        Actions:
+        - Read page 12.
+        """
+        let user = AiMessage(
+            id: "user-actions",
+            role: .user,
+            content: userContent,
+            createdAt: "now"
+        )
+
+        #expect(assistant.displayContent == assistantContent)
+        #expect(assistant.displayToolSummaries.isEmpty)
+        #expect(assistant.promptContent == assistantContent)
+        #expect(user.displayContent == userContent)
+        #expect(user.displayToolSummaries.isEmpty)
+        #expect(user.promptContent == userContent)
+    }
+
+    @Test("Legacy raw retrieval payloads become compact follow-up receipts")
+    func legacyRawPayloadIsCompactedForPrompt() {
+        let marker = "RAW-SOURCE-MARKER"
+        let message = AiMessage(
+            id: "legacy-raw",
+            role: .assistant,
+            content: """
+            The answer.
+
+            Actions:
+            - Found 2 pages with a match:
+            page 4 — "…\(marker) first…"
+            page 9 — "…\(marker) second…"
+            """,
+            createdAt: "now"
+        )
+
+        let prompt = message.promptContent
+
+        #expect(prompt.contains("The answer."))
+        #expect(prompt.contains("- Document search"))
+        #expect(prompt.contains(marker) == false)
+        #expect(prompt.contains("page 4 —") == false)
+    }
+
     @Test("Follow-up prompts retain compact tool receipts without source payloads")
     func followUpPromptUsesCompactToolReceipts() {
         var message = AiMessage(
@@ -155,5 +216,72 @@ struct AiToolSummaryTests {
         #expect(prompt.contains("- Searched for “register allocation”"))
         #expect(prompt.contains("8 pages") == false)
         #expect(prompt.contains("long source excerpt") == false)
+    }
+
+    @Test("Imported structured summaries are bounded at the shared persistence boundary")
+    func hostileImportedSummariesAreBounded() throws {
+        let huge = String(repeating: "oversized ", count: 2_000)
+        var message = AiMessage(
+            id: "hostile-import",
+            role: .assistant,
+            content: "answer",
+            createdAt: "now"
+        )
+        message.toolSummaries = (0..<(AiPersistence.maxToolSummariesPerMessage + 10)).map { index in
+            AiToolSummary(
+                id: huge,
+                title: "\(index)-\(huge)",
+                detail: huge,
+                sources: (0..<(AiPersistence.maxToolSourcesPerSummary + 5)).map { sourceIndex in
+                    .init(
+                        id: huge,
+                        page: sourceIndex == 0 ? Int.max : sourceIndex + 1,
+                        excerpt: huge
+                    )
+                },
+                destinationPage: Int.max
+            )
+        }
+
+        let boundedMessage = try #require(AiPersistence.limitedMessages([message]).first)
+        let summaries = try #require(boundedMessage.toolSummaries)
+        let first = try #require(summaries.first)
+
+        #expect(summaries.count == AiPersistence.maxToolSummariesPerMessage)
+        #expect(first.id.count <= AiPersistence.maxToolIdentifierCharacters)
+        #expect(first.title.count <= AiPersistence.maxToolSummaryTitleCharacters)
+        #expect((first.detail?.count ?? 0) <= AiPersistence.maxToolSummaryDetailCharacters)
+        #expect(first.sources.count == AiPersistence.maxToolSourcesPerSummary)
+        #expect(first.sources[0].id.count <= AiPersistence.maxToolIdentifierCharacters)
+        #expect(first.sources[0].excerpt.count <= AiPersistence.maxToolSourceExcerptCharacters)
+        #expect(first.destinationPage == nil)
+        #expect(first.sources[0].page == nil)
+        #expect(Set(summaries.map(\.id)).count == summaries.count)
+        #expect(Set(first.sources.map(\.id)).count == first.sources.count)
+        #expect(AiPersistence.sanitizeToolSummaries(summaries) == summaries)
+    }
+
+    @Test("Reparsed legacy summaries retain stable disclosure identity")
+    func legacySummaryIdentityIsStableAcrossRenders() throws {
+        let message = AiMessage(
+            id: "stable-message",
+            role: .assistant,
+            content: """
+            Answer.
+
+            Actions:
+            - Found 2 pages with a match:
+            page 2 — "…alpha…"
+            page 7 — "…beta…"
+            """,
+            createdAt: "now"
+        )
+
+        let firstRender = try #require(message.displayToolSummaries.first)
+        let secondRender = try #require(message.displayToolSummaries.first)
+
+        #expect(firstRender.id == secondRender.id)
+        #expect(firstRender.sources.map(\.id) == secondRender.sources.map(\.id))
+        #expect(Set(firstRender.sources.map(\.id)).count == firstRender.sources.count)
     }
 }

--- a/Tests/AiToolSummaryTests.swift
+++ b/Tests/AiToolSummaryTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import Vellum
+
+struct AiToolSummaryTests {
+    @Test(
+        "Assistant text follows the available inspector width",
+        arguments: [
+            (proposed: CGFloat(80), expected: CGFloat(120)),
+            (proposed: CGFloat(320), expected: CGFloat(320)),
+            (proposed: CGFloat(520), expected: CGFloat(520)),
+        ]
+    )
+    @MainActor
+    func assistantTextUsesResponsiveWidth(input: (proposed: CGFloat, expected: CGFloat)) {
+        #expect(SelectableMessageText.resolvedWidth(input.proposed) == input.expected)
+    }
+
+    @Test("Search results become bounded page sources")
+    func searchResultsBecomeBoundedPageSources() throws {
+        let longExcerpt = String(repeating: "evidence ", count: 80)
+        let action = AiToolAction(
+            tool: "searchDocument",
+            args: AiToolArguments(
+                pageNumber: nil,
+                text: "diffraction",
+                color: nil,
+                x: nil,
+                y: nil,
+                isRegex: false
+            )
+        )
+        let result = """
+        Found 2 pages with a match:
+        page 3 — "…first source…"
+        page 9 — "…\(longExcerpt)…"
+        """
+
+        let summary = try #require(AiToolSummary.make(action: action, result: result))
+
+        #expect(summary.title == "Searched for “diffraction”")
+        #expect(summary.detail == "2 pages")
+        #expect(summary.sources.map(\.page) == [3, 9])
+        #expect(summary.sources.allSatisfy { $0.excerpt.count <= 281 })
+        #expect(summary.sources[0].excerpt == "first source")
+    }
+
+    @Test("Page reads retain only a short excerpt and jump target")
+    func pageReadRetainsShortExcerptAndJumpTarget() throws {
+        let marker = String(repeating: "private payload ", count: 80)
+        let action = AiToolAction(
+            tool: "getPageText",
+            args: AiToolArguments(
+                pageNumber: 12,
+                text: nil,
+                color: nil,
+                x: nil,
+                y: nil,
+                isRegex: nil
+            )
+        )
+
+        let summary = try #require(
+            AiToolSummary.make(action: action, result: "Page 12:\n\(marker)")
+        )
+        let source = try #require(summary.sources.first)
+
+        #expect(summary.destinationPage == 12)
+        #expect(source.page == 12)
+        #expect(source.excerpt.count <= 281)
+        #expect(source.excerpt.hasSuffix("…"))
+    }
+
+    @Test("Structured summaries decode from new messages and remain optional for old messages")
+    func summariesAreBackwardCompatible() throws {
+        let legacy = Data(
+            #"{"id":"old","role":"assistant","content":"answer","createdAt":"now"}"#.utf8
+        )
+        let legacyMessage = try JSONDecoder().decode(AiMessage.self, from: legacy)
+        #expect(legacyMessage.toolSummaries == nil)
+
+        var current = AiMessage(
+            id: "new",
+            role: .assistant,
+            content: "answer",
+            createdAt: "now"
+        )
+        current.toolSummaries = [
+            AiToolSummary(title: "Read page 4", destinationPage: 4)
+        ]
+        let decoded = try JSONDecoder().decode(
+            AiMessage.self,
+            from: JSONEncoder().encode(current)
+        )
+        #expect(decoded == current)
+    }
+
+    @Test("Assistant answer is not mixed with tool summaries")
+    func conciseAnswerRemainsFirstAndIndependent() {
+        let summary = AiToolSummary(title: "Searched document", detail: "8 pages")
+        let content = AiStore.composeAssistantContent(
+            reply: "\n  The concise answer.  \n",
+            receipts: [summary]
+        )
+
+        #expect(content == "The concise answer.")
+        #expect(content.contains("8 pages") == false)
+    }
+
+    @Test("Legacy inline search traces collapse without rewriting stored content")
+    func legacyInlineSearchTraceGetsACompactPresentation() throws {
+        let content = """
+        Register allocation appears in several chapters.
+
+        Actions:
+        - Found 2 pages with a match:
+        page 12 — "…table of contents…"
+        page 369 — "…register coalescing…"
+        """
+        let message = AiMessage(
+            id: "legacy",
+            role: .assistant,
+            content: content,
+            createdAt: "now"
+        )
+
+        #expect(message.displayContent == "Register allocation appears in several chapters.")
+        let summary = try #require(message.displayToolSummaries.first)
+        #expect(summary.detail == "2 pages")
+        #expect(summary.sources.map(\.page) == [12, 369])
+        #expect(message.content == content)
+    }
+
+    @Test("Follow-up prompts retain compact tool receipts without source payloads")
+    func followUpPromptUsesCompactToolReceipts() {
+        var message = AiMessage(
+            id: "assistant",
+            role: .assistant,
+            content: "The concise answer.",
+            createdAt: "now"
+        )
+        message.toolSummaries = [
+            AiToolSummary(
+                title: "Searched for “register allocation”",
+                detail: "8 pages",
+                sources: [
+                    .init(page: 369, excerpt: "A long source excerpt that belongs in the expandable UI.")
+                ]
+            )
+        ]
+
+        let prompt = AiPrompts.buildConversationBlock([message])
+
+        #expect(prompt.contains("The concise answer."))
+        #expect(prompt.contains("- Searched for “register allocation”"))
+        #expect(prompt.contains("8 pages") == false)
+        #expect(prompt.contains("long source excerpt") == false)
+    }
+}

--- a/Tests/VellumBundleTests.swift
+++ b/Tests/VellumBundleTests.swift
@@ -286,6 +286,51 @@ final class VellumBundleTests: XCTestCase {
         XCTAssertEqual(DocumentDataStore.loadScratchpad(forKey: key), "the imported note")
     }
 
+    func testImportedConversationCapsNestedToolSummaries() throws {
+        let huge = String(repeating: "oversized ", count: 2_000)
+        var hostile = message(
+            id: "hostile",
+            role: .assistant,
+            content: "answer",
+            createdAt: "2026-01-01T00:00:00Z"
+        )
+        hostile.toolSummaries = (0..<(AiPersistence.maxToolSummariesPerMessage + 4)).map { index in
+            AiToolSummary(
+                id: huge,
+                title: "\(index)-\(huge)",
+                detail: huge,
+                sources: (0..<(AiPersistence.maxToolSourcesPerSummary + 4)).map {
+                    .init(id: huge, page: $0 == 0 ? Int.max : $0 + 1, excerpt: huge)
+                },
+                destinationPage: Int.max
+            )
+        }
+        let imported = VellumBundle.Imported(
+            manifest: validPdfManifest(documentBytes: Data("d".utf8)),
+            documentData: Data("d".utf8),
+            scratchpad: nil,
+            attachments: [],
+            conversations: try JSONEncoder().encode([hostile])
+        )
+        let key = "hostile-conversation"
+
+        try VellumBundle.installSidecar(imported, forKey: key) { _ in .keepLocal }
+
+        let data = try XCTUnwrap(DocumentDataStore.loadConversationsData(forKey: key))
+        let stored = try XCTUnwrap(JSONDecoder().decode([AiMessage].self, from: data).first)
+        let summaries = try XCTUnwrap(stored.toolSummaries)
+        let first = try XCTUnwrap(summaries.first)
+        XCTAssertEqual(summaries.count, AiPersistence.maxToolSummariesPerMessage)
+        XCTAssertLessThanOrEqual(first.title.count, AiPersistence.maxToolSummaryTitleCharacters)
+        XCTAssertEqual(first.sources.count, AiPersistence.maxToolSourcesPerSummary)
+        XCTAssertLessThanOrEqual(
+            first.sources.first?.excerpt.count ?? 0,
+            AiPersistence.maxToolSourceExcerptCharacters
+        )
+        XCTAssertNil(first.destinationPage)
+        XCTAssertNil(first.sources.first?.page)
+    }
+
     func testAttachmentNeverOverwritesExistingId() throws {
         let key = "attach-key"
         let dir = DocumentDataStore.attachmentsDir(forKey: key)

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		0CB718F359EABB9D0B724732 /* AiPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2423823E0BE86C417B6ABBC6 /* AiPanel.swift */; };
 		0F794D4A0D0E512001684D97 /* KaTeX_Math-BoldItalic.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = B313F26C338D071377D89FE9 /* KaTeX_Math-BoldItalic.woff2 */; };
 		115E39AAB39E90058E9718A7 /* PdfMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21D7E5EC3C32E20B0FDC7DB /* PdfMetadata.swift */; };
+		143FFEB4FBB9A94F4F582E96 /* AiToolSourceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9308A43A15E8D1EAAEC887 /* AiToolSourceRow.swift */; };
 		17AD2204484B61C7A2F1DCD6 /* KaTeX_Fraktur-Bold.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 96B5040705B954B3A0A26A2E /* KaTeX_Fraktur-Bold.woff2 */; };
 		17CEDFD80E708ADD26650928 /* RecentsResolveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB2C2905E4A08861E42C2EED /* RecentsResolveTests.swift */; };
 		18277300524A92AEDAAAEA7E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027E09C0BD7A98F4590A5878 /* ContentView.swift */; };
@@ -67,6 +68,7 @@
 		56FC925BB362E1EA594F963B /* StorageHousekeeping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FA50A523F4D87396EC11A8B /* StorageHousekeeping.swift */; };
 		5AA233123955997046F4F9EB /* WebNotePopovers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACABB2AAB4911563C0148AD6 /* WebNotePopovers.swift */; };
 		5FF82C62FE4C7CC82FD160FD /* AiConversationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327F0E350D7D13A26878EB77 /* AiConversationStoreTests.swift */; };
+		610646426C95711C3BAD33BA /* AiToolSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4DB73291B8E06F452CEBCD /* AiToolSummaryTests.swift */; };
 		65858805EE10C9DAA53531F5 /* KaTeX_Script-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 529B3D1901669D3F00BBCF74 /* KaTeX_Script-Regular.woff2 */; };
 		67B320CA1556DCBF8C2A8507 /* PdfGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102BFBC5EF5B66C15AC2BC86 /* PdfGeometry.swift */; };
 		6AF2B59C76A57D0A112B2015 /* KaTeX_Caligraphic-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = A7508380103E3495A82E0771 /* KaTeX_Caligraphic-Regular.woff2 */; };
@@ -106,10 +108,12 @@
 		AF8BDBA91282CA03F019C0F5 /* ScratchpadPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287B357B7A7C9503C3C1199C /* ScratchpadPersistence.swift */; };
 		B127FEC17DDF285AD902A52B /* OpenRouterCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */; };
 		B1EA8A76FD9FE32930829528 /* SessionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7280818785023514C87C04C9 /* SessionService.swift */; };
+		B21F8CA3F2E2DA85531167DE /* AiToolSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD3D09C89D224F5C322CE8BB /* AiToolSummaryView.swift */; };
 		B370CC64C56C8E29DC8A4C42 /* WebStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF653B1B8741B61DBE9B55EE /* WebStorage.swift */; };
 		B6535E25C5FC85D2DBE39DC3 /* PdfDocIdRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C33B518BE736FCF7077F63A /* PdfDocIdRegistry.swift */; };
 		B861F8FD72248FD16E1562D4 /* AttachmentDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFD2EC2ED5A947809EA139F /* AttachmentDrop.swift */; };
 		BB776BF184FBD5A0469377E2 /* AiPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90963B42EE17356826E8DE90 /* AiPrompts.swift */; };
+		BD31BC1F3FB2299BEC39F054 /* AiToolSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AF0117D296B571E62111BB /* AiToolSummary.swift */; };
 		BF75A2925C8FCE36AD43F41B /* KaTeX_Typewriter-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = E8C9F22335B2DEA99AF5ABF5 /* KaTeX_Typewriter-Regular.woff2 */; };
 		C4998709FBAE647C23BF3E5A /* KaTeX_Size3-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 511B978E41D84CD3B0C24FCB /* KaTeX_Size3-Regular.woff2 */; };
 		C529F97AB901B963D8DB4726 /* AiPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA459842CA86BEED9D34C1E /* AiPipelineTests.swift */; };
@@ -215,6 +219,7 @@
 		73294273D1991135AD0F100E /* index.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
 		775C6AD8C83907CD1B8F65B2 /* VellumTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VellumTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		78E2B3DF66E30481C363C740 /* ToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarView.swift; sourceTree = "<group>"; };
+		7A4DB73291B8E06F452CEBCD /* AiToolSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiToolSummaryTests.swift; sourceTree = "<group>"; };
 		7B43A2E8F7A54C9B8E4E160D /* ModelSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSelector.swift; sourceTree = "<group>"; };
 		7B4601C034B834B5E610FD84 /* SelectableMessageText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableMessageText.swift; sourceTree = "<group>"; };
 		7E4C07C56943274B9E062A70 /* RecentFilesService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentFilesService.swift; sourceTree = "<group>"; };
@@ -243,6 +248,7 @@
 		9BAF3F69842AC6333D1D9C38 /* WebProxyUrlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebProxyUrlTests.swift; sourceTree = "<group>"; };
 		9C5B78507B70CB73698D8DC4 /* OAuthLoopbackServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuthLoopbackServer.swift; sourceTree = "<group>"; };
 		9D58D6980122701CBA30200F /* Vellum.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vellum.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9E9308A43A15E8D1EAAEC887 /* AiToolSourceRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiToolSourceRow.swift; sourceTree = "<group>"; };
 		9F7F3D4199D08A3DEE3D8641 /* KaTeX_Caligraphic-Bold.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Caligraphic-Bold.woff2"; sourceTree = "<group>"; };
 		A17D3131ADA1819B327BDBB6 /* AiUsage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiUsage.swift; sourceTree = "<group>"; };
 		A5003641A54B311693588C6C /* PdfPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfPersistenceTests.swift; sourceTree = "<group>"; };
@@ -254,6 +260,7 @@
 		B18CA5A14795BD97D91F2056 /* AnnotationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationStore.swift; sourceTree = "<group>"; };
 		B1F8F1A0CB094398C5390128 /* ScratchpadDropRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadDropRegistrationTests.swift; sourceTree = "<group>"; };
 		B313F26C338D071377D89FE9 /* KaTeX_Math-BoldItalic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Math-BoldItalic.woff2"; sourceTree = "<group>"; };
+		B4AF0117D296B571E62111BB /* AiToolSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiToolSummary.swift; sourceTree = "<group>"; };
 		B6E95679B108A0702A0657D8 /* PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
 		B81C915E0D9617AFC8B14CF4 /* PdfBookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfBookmarks.swift; sourceTree = "<group>"; };
 		BA27035FFAE43080C7118AC4 /* katex.min.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = katex.min.css; sourceTree = "<group>"; };
@@ -274,6 +281,7 @@
 		C8B60F6CDB9021A07B1D678D /* SidebarDropCatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDropCatcher.swift; sourceTree = "<group>"; };
 		C8DCF286D5E58E45AB3FABA8 /* MathRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathRenderer.swift; sourceTree = "<group>"; };
 		CCBBA9A1DAB0373185D8F5EA /* DocumentIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIdentityTests.swift; sourceTree = "<group>"; };
+		CD3D09C89D224F5C322CE8BB /* AiToolSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiToolSummaryView.swift; sourceTree = "<group>"; };
 		D1784468C7F465AAEB5C63E9 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentSessionManager.swift; sourceTree = "<group>"; };
 		D3AD047DB403B0B0530AC89B /* KaTeX_Main-Bold.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-Bold.woff2"; sourceTree = "<group>"; };
@@ -317,6 +325,7 @@
 		0A893C9E10BE8275414AA01D /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				B4AF0117D296B571E62111BB /* AiToolSummary.swift */,
 				D1784468C7F465AAEB5C63E9 /* Models.swift */,
 				C7B863B676278E0E8D3C2EDB /* PaneTree.swift */,
 			);
@@ -382,6 +391,7 @@
 			children = (
 				327F0E350D7D13A26878EB77 /* AiConversationStoreTests.swift */,
 				4AA459842CA86BEED9D34C1E /* AiPipelineTests.swift */,
+				7A4DB73291B8E06F452CEBCD /* AiToolSummaryTests.swift */,
 				F125F1382328217B11BF1DB2 /* AttachmentDropTests.swift */,
 				E9CE9BA76EA961FB5939EDCE /* DocumentDataStoreTests.swift */,
 				CCBBA9A1DAB0373185D8F5EA /* DocumentIdentityTests.swift */,
@@ -423,6 +433,8 @@
 			children = (
 				2423823E0BE86C417B6ABBC6 /* AiPanel.swift */,
 				C4DE459571959DABFA99D4BB /* AiSettingsPanel.swift */,
+				9E9308A43A15E8D1EAAEC887 /* AiToolSourceRow.swift */,
+				CD3D09C89D224F5C322CE8BB /* AiToolSummaryView.swift */,
 				5DFD2EC2ED5A947809EA139F /* AttachmentDrop.swift */,
 				43D27ECCD653EDD01DC2A624 /* ComposerReferences.swift */,
 				8A774391C8C286453B790F75 /* MarkdownMessage.swift */,
@@ -800,6 +812,9 @@
 				D4A79DFDB08A01D35D47933A /* AiStore.swift in Sources */,
 				F9DA8014506FBB48C440F718 /* AiStreaming.swift in Sources */,
 				2759D19C5033A1DC130A9E15 /* AiToolEngine.swift in Sources */,
+				143FFEB4FBB9A94F4F582E96 /* AiToolSourceRow.swift in Sources */,
+				BD31BC1F3FB2299BEC39F054 /* AiToolSummary.swift in Sources */,
+				B21F8CA3F2E2DA85531167DE /* AiToolSummaryView.swift in Sources */,
 				30F9DFF4371A901244DAD7BE /* AiUsage.swift in Sources */,
 				9AC827DE4385CD8EC4201A49 /* AnnotationSidebar.swift in Sources */,
 				9C7F3F0B4C0CDEE7ED83CBB4 /* AnnotationStore.swift in Sources */,
@@ -886,6 +901,7 @@
 			files = (
 				5FF82C62FE4C7CC82FD160FD /* AiConversationStoreTests.swift in Sources */,
 				C529F97AB901B963D8DB4726 /* AiPipelineTests.swift in Sources */,
+				610646426C95711C3BAD33BA /* AiToolSummaryTests.swift in Sources */,
 				0A8D06EC43340A3149052C29 /* AttachmentDropTests.swift in Sources */,
 				252A859CBF3B6F40740EC8BB /* DocumentDataStoreTests.swift in Sources */,
 				53B7BE4E93C5CF617CF049D6 /* DocumentIdentityTests.swift in Sources */,

--- a/Vellum/Models/AiToolSummary.swift
+++ b/Vellum/Models/AiToolSummary.swift
@@ -49,9 +49,9 @@ struct AiToolSummary: Codable, Equatable, Identifiable, Sendable {
                 ? result.trimmingCharacters(in: .whitespacesAndNewlines)
                 : "\(count) \(count == 1 ? "page" : "pages")"
             return AiToolSummary(
-                title: "Searched for “\(query)”",
+                title: clipped("Searched for “\(query)”", limit: 240),
                 detail: clipped(detail, limit: 160),
-                sources: sources
+                sources: Array(sources.prefix(8))
             )
 
         case "getPageText":
@@ -85,42 +85,128 @@ struct AiToolSummary: Codable, Equatable, Identifiable, Sendable {
         }
     }
 
-    /// Converts the pre-structured "Actions:" suffix used by older Vellum
-    /// versions into the same compact presentation. This prevents an existing
-    /// multi-page retrieval transcript from remaining permanently oversized.
-    static func fromLegacyActions(_ text: String) -> [AiToolSummary] {
+    /// Strictly recognizes the receipt formats emitted by older Vellum builds.
+    /// Returning nil (rather than an empty list) is important: arbitrary prose
+    /// headed "Actions:" must remain ordinary message content.
+    static func parseLegacyActions(_ text: String, messageId: String) -> [AiToolSummary]? {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmed.isEmpty == false else { return [] }
-
-        let sources = searchSources(from: trimmed)
-        if sources.isEmpty == false {
-            let firstLine = trimmed.split(separator: "\n").first.map(String.init) ?? "Document search"
-            return [AiToolSummary(
-                title: firstLine.removingListMarker(),
-                detail: "\(sources.count) \(sources.count == 1 ? "page" : "pages")",
-                sources: sources
-            )]
-        }
-
+        guard trimmed.isEmpty == false else { return nil }
         let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
-        guard let first = lines.first.map(String.init) else { return [] }
-        let title = first.removingListMarker()
-        let page = pageNumber(from: title)
-        let excerpt = lines.dropFirst().joined(separator: "\n")
-        if excerpt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
-            return [AiToolSummary(
-                title: page.map { "Read page \($0)" } ?? title,
-                detail: "Document source",
-                sources: [Source(page: page, excerpt: clipped(excerpt, limit: 280))],
-                destinationPage: page
-            )]
+            .map(String.init)
+
+        // A short-lived older build persisted the raw search result. Accept only
+        // the exact header + page-source grammar, never arbitrary suffix text.
+        let sources = searchSources(from: trimmed)
+        if let first = lines.first,
+           fullMatch(first, pattern: #"- Found \d+ pages? with a match(?: \(showing first \d+\))?:"#),
+           firstInteger(in: first) == sources.count,
+           sources.isEmpty == false,
+           lines.dropFirst().allSatisfy({
+               $0.isEmpty || fullMatch($0, pattern: #"page \d+ — ["“].+["”]"#)
+           }) {
+            return assigningStableIds([
+                AiToolSummary(
+                    title: "Document search",
+                    detail: "\(sources.count) \(sources.count == 1 ? "page" : "pages")",
+                    sources: Array(sources.prefix(8))
+                )
+            ], messageId: messageId)
         }
 
-        return [AiToolSummary(
-            title: clipped(title, limit: 160),
+        // The long-lived format was a list of one-line receipts. Require every
+        // line to match a result string that the historical tool engine emitted.
+        let compact = lines.compactMap(legacyCompactSummary)
+        guard compact.count == lines.count, compact.isEmpty == false else { return nil }
+        return assigningStableIds(compact, messageId: messageId)
+    }
+
+    private static func legacyCompactSummary(_ line: String) -> AiToolSummary? {
+        guard line.hasPrefix("- ") else { return nil }
+        let receipt = String(line.dropFirst(2))
+
+        if fullMatch(receipt, pattern: #"Searched the document for “.+”\."#) {
+            return AiToolSummary(title: clipped(receipt, limit: 240), detail: "Document search")
+        }
+        if fullMatch(receipt, pattern: #"Read page \d+\."#) {
+            let page = pageNumber(from: receipt)
+            return AiToolSummary(
+                title: page.map { "Read page \($0)" } ?? "Read a page",
+                detail: "Document source",
+                destinationPage: page
+            )
+        }
+
+        let knownWritePatterns = [
+            #"Navigated to page \d+\."#,
+            #"Added note on page \d+\."#,
+            #"Highlighted ".+" on page \d+\."#,
+            #"Skipped addNote: empty text\."#,
+            #"Skipped addHighlight: no text provided to locate\."#,
+            #"Skipped addHighlight: couldn't find ".+" on page \d+\."#,
+            #"Skipped unknown tool: .+\."#,
+        ]
+        guard knownWritePatterns.contains(where: { fullMatch(receipt, pattern: $0) })
+        else { return nil }
+        return AiToolSummary(
+            title: clipped(receipt, limit: 240),
             detail: "Document action",
-            destinationPage: page
-        )]
+            destinationPage: pageNumber(from: receipt)
+        )
+    }
+
+    private static func assigningStableIds(
+        _ summaries: [AiToolSummary],
+        messageId: String
+    ) -> [AiToolSummary] {
+        summaries.enumerated().map { summaryIndex, original in
+            var summary = original
+            let signature = [
+                summary.title,
+                summary.detail ?? "",
+                summary.destinationPage.map(String.init) ?? "",
+            ].joined(separator: "\u{1f}")
+            summary.id = stableId("\(messageId)\u{1f}\(summaryIndex)\u{1f}\(signature)")
+            summary.sources = summary.sources.enumerated().map { sourceIndex, originalSource in
+                var source = originalSource
+                let sourceSignature = [
+                    source.page.map(String.init) ?? "",
+                    source.excerpt,
+                ].joined(separator: "\u{1f}")
+                source.id = stableId(
+                    "\(messageId)\u{1f}\(summaryIndex)\u{1f}\(sourceIndex)\u{1f}\(sourceSignature)"
+                )
+                return source
+            }
+            return summary
+        }
+    }
+
+    /// FNV-1a is deliberately simple and deterministic across launches. Swift's
+    /// `Hasher` is randomized and would recreate DisclosureGroup identity.
+    private static func stableId(_ value: String) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return "legacy-\(String(hash, radix: 16))"
+    }
+
+    private static func fullMatch(_ text: String, pattern: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: "^(?:\(pattern))$") else {
+            return false
+        }
+        return regex.firstMatch(
+            in: text,
+            range: NSRange(text.startIndex..<text.endIndex, in: text)
+        ) != nil
+    }
+
+    private static func firstInteger(in text: String) -> Int? {
+        guard let range = text.range(of: #"\d+"#, options: .regularExpression) else {
+            return nil
+        }
+        return Int(text[range])
     }
 
     private static func searchSources(from result: String) -> [Source] {
@@ -164,36 +250,51 @@ struct AiToolSummary: Codable, Equatable, Identifiable, Sendable {
 }
 
 extension AiMessage {
-    /// Answer text without the legacy inline tool-receipt suffix.
-    var displayContent: String {
-        guard toolSummaries == nil,
-              let range = content.range(of: "\n\nActions:\n", options: .backwards)
-        else { return content }
-        return String(content[..<range.lowerBound])
+    private var legacyReceipt: (answer: String, summaries: [AiToolSummary])? {
+        guard role == .assistant,
+              toolSummaries == nil,
+              let range = content.range(of: "\n\nActions:\n", options: .backwards),
+              let summaries = AiToolSummary.parseLegacyActions(
+                  String(content[range.upperBound...]),
+                  messageId: id
+              )
+        else { return nil }
+        let answer = String(content[..<range.lowerBound])
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (answer, summaries)
     }
 
-    /// New messages use persisted structured summaries. Older messages are
-    /// upgraded at presentation time, leaving their on-disk representation intact.
+    /// Answer text without a strictly recognized legacy tool-receipt suffix.
+    var displayContent: String {
+        legacyReceipt?.answer ?? content
+    }
+
+    /// New messages use persisted structured summaries. Recognized older
+    /// messages are upgraded at presentation time without changing their data.
     var displayToolSummaries: [AiToolSummary] {
         if let toolSummaries { return toolSummaries }
-        guard let range = content.range(of: "\n\nActions:\n", options: .backwards)
-        else { return [] }
-        return AiToolSummary.fromLegacyActions(String(content[range.upperBound...]))
+        return legacyReceipt?.summaries ?? []
     }
 
-    /// Keeps a compact receipt of prior tool use available to follow-up turns.
-    /// The model needs to know which document operations already ran, but not
-    /// the excerpts that were intentionally omitted from transcript storage.
+    /// Keeps compact prior tool use available to follow-up turns without
+    /// resending raw legacy search/page payloads.
     var promptContent: String {
-        guard let toolSummaries, toolSummaries.isEmpty == false else { return content }
-        let actions = toolSummaries.map { "- \($0.title)" }.joined(separator: "\n")
-        return "\(content)\n\nActions:\n\(actions)"
+        guard role == .assistant else { return content }
+        if let toolSummaries, toolSummaries.isEmpty == false {
+            return contentWithCompactActions(answer: content, summaries: toolSummaries)
+        }
+        guard let legacyReceipt else { return content }
+        return contentWithCompactActions(
+            answer: legacyReceipt.answer,
+            summaries: legacyReceipt.summaries
+        )
     }
-}
 
-private extension String {
-    func removingListMarker() -> String {
-        hasPrefix("- ") ? String(dropFirst(2)) : self
+    private func contentWithCompactActions(
+        answer: String,
+        summaries: [AiToolSummary]
+    ) -> String {
+        let actions = summaries.map { "- \($0.title)" }.joined(separator: "\n")
+        return "\(answer)\n\nActions:\n\(actions)"
     }
 }

--- a/Vellum/Models/AiToolSummary.swift
+++ b/Vellum/Models/AiToolSummary.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+/// A compact, persisted account of one document tool used to produce an AI reply.
+///
+/// Raw tool payloads can contain thousands of characters and are intentionally
+/// never stored here. Sources retain only a short excerpt and an optional page
+/// locator so the transcript stays readable and can offer an explicit jump.
+struct AiToolSummary: Codable, Equatable, Identifiable, Sendable {
+    struct Source: Codable, Equatable, Identifiable, Sendable {
+        var id: String
+        var page: Int?
+        var excerpt: String
+
+        init(id: String = UUID().uuidString.lowercased(), page: Int?, excerpt: String) {
+            self.id = id
+            self.page = page
+            self.excerpt = excerpt
+        }
+    }
+
+    var id: String
+    var title: String
+    var detail: String?
+    var sources: [Source]
+    var destinationPage: Int?
+
+    init(
+        id: String = UUID().uuidString.lowercased(),
+        title: String,
+        detail: String? = nil,
+        sources: [Source] = [],
+        destinationPage: Int? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.detail = detail
+        self.sources = sources
+        self.destinationPage = destinationPage
+    }
+
+    static func make(action: AiToolAction, result: String) -> AiToolSummary? {
+        switch action.tool {
+        case "searchDocument":
+            let query = (action.args.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            guard query.isEmpty == false else { return nil }
+            let sources = searchSources(from: result)
+            let count = sources.count
+            let detail = count == 0
+                ? result.trimmingCharacters(in: .whitespacesAndNewlines)
+                : "\(count) \(count == 1 ? "page" : "pages")"
+            return AiToolSummary(
+                title: "Searched for “\(query)”",
+                detail: clipped(detail, limit: 160),
+                sources: sources
+            )
+
+        case "getPageText":
+            let page = pageNumber(from: result) ?? roundedPage(action.args.pageNumber)
+            let body = result
+                .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
+                .dropFirst()
+                .first
+                .map(String.init) ?? ""
+            let source = Source(page: page, excerpt: clipped(body, limit: 280))
+            return AiToolSummary(
+                title: page.map { "Read page \($0)" } ?? "Read a page",
+                detail: "Document source",
+                sources: source.excerpt.isEmpty ? [] : [source],
+                destinationPage: page
+            )
+
+        case "getAnnotations":
+            return AiToolSummary(
+                title: "Read annotations",
+                detail: clipped(result, limit: 160)
+            )
+
+        default:
+            let page = pageNumber(from: result) ?? roundedPage(action.args.pageNumber)
+            return AiToolSummary(
+                title: clipped(result, limit: 160),
+                detail: "Document action",
+                destinationPage: page
+            )
+        }
+    }
+
+    /// Converts the pre-structured "Actions:" suffix used by older Vellum
+    /// versions into the same compact presentation. This prevents an existing
+    /// multi-page retrieval transcript from remaining permanently oversized.
+    static func fromLegacyActions(_ text: String) -> [AiToolSummary] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty == false else { return [] }
+
+        let sources = searchSources(from: trimmed)
+        if sources.isEmpty == false {
+            let firstLine = trimmed.split(separator: "\n").first.map(String.init) ?? "Document search"
+            return [AiToolSummary(
+                title: firstLine.removingListMarker(),
+                detail: "\(sources.count) \(sources.count == 1 ? "page" : "pages")",
+                sources: sources
+            )]
+        }
+
+        let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+        guard let first = lines.first.map(String.init) else { return [] }
+        let title = first.removingListMarker()
+        let page = pageNumber(from: title)
+        let excerpt = lines.dropFirst().joined(separator: "\n")
+        if excerpt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return [AiToolSummary(
+                title: page.map { "Read page \($0)" } ?? title,
+                detail: "Document source",
+                sources: [Source(page: page, excerpt: clipped(excerpt, limit: 280))],
+                destinationPage: page
+            )]
+        }
+
+        return [AiToolSummary(
+            title: clipped(title, limit: 160),
+            detail: "Document action",
+            destinationPage: page
+        )]
+    }
+
+    private static func searchSources(from result: String) -> [Source] {
+        result.split(separator: "\n").compactMap { rawLine in
+            let line = String(rawLine)
+            guard line.hasPrefix("page "),
+                  let separator = line.range(of: " — ") else { return nil }
+            let pageText = line[line.index(line.startIndex, offsetBy: 5)..<separator.lowerBound]
+            guard let page = Int(pageText) else { return nil }
+            var excerpt = String(line[separator.upperBound...])
+            excerpt = excerpt.trimmingCharacters(in: CharacterSet(charactersIn: "\"“”"))
+            if excerpt.hasPrefix("…") { excerpt.removeFirst() }
+            if excerpt.hasSuffix("…") { excerpt.removeLast() }
+            return Source(page: page, excerpt: clipped(excerpt, limit: 280))
+        }
+    }
+
+    private static func pageNumber(from result: String) -> Int? {
+        let pattern = #"(?:[Pp]age|page)\s+(\d+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                in: result,
+                range: NSRange(result.startIndex..<result.endIndex, in: result)
+              ),
+              let range = Range(match.range(at: 1), in: result) else { return nil }
+        return Int(result[range])
+    }
+
+    private static func roundedPage(_ value: Double?) -> Int? {
+        guard let value, value.isFinite else { return nil }
+        return max(1, Int(value.rounded()))
+    }
+
+    private static func clipped(_ text: String, limit: Int) -> String {
+        let normalized = text
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalized.count > limit else { return normalized }
+        return String(normalized.prefix(limit)).trimmingCharacters(in: .whitespaces) + "…"
+    }
+}
+
+extension AiMessage {
+    /// Answer text without the legacy inline tool-receipt suffix.
+    var displayContent: String {
+        guard toolSummaries == nil,
+              let range = content.range(of: "\n\nActions:\n", options: .backwards)
+        else { return content }
+        return String(content[..<range.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// New messages use persisted structured summaries. Older messages are
+    /// upgraded at presentation time, leaving their on-disk representation intact.
+    var displayToolSummaries: [AiToolSummary] {
+        if let toolSummaries { return toolSummaries }
+        guard let range = content.range(of: "\n\nActions:\n", options: .backwards)
+        else { return [] }
+        return AiToolSummary.fromLegacyActions(String(content[range.upperBound...]))
+    }
+
+    /// Keeps a compact receipt of prior tool use available to follow-up turns.
+    /// The model needs to know which document operations already ran, but not
+    /// the excerpts that were intentionally omitted from transcript storage.
+    var promptContent: String {
+        guard let toolSummaries, toolSummaries.isEmpty == false else { return content }
+        let actions = toolSummaries.map { "- \($0.title)" }.joined(separator: "\n")
+        return "\(content)\n\nActions:\n\(actions)"
+    }
+}
+
+private extension String {
+    func removingListMarker() -> String {
+        hasPrefix("- ") ? String(dropFirst(2)) : self
+    }
+}

--- a/Vellum/Services/Ai/AiPersistence.swift
+++ b/Vellum/Services/Ai/AiPersistence.swift
@@ -14,6 +14,13 @@ enum AiPersistence {
     static let conversationsKey = "research-reader-ai-conversations-v1"
     static let maxMessagesPerDocument = 120
     static let maxMessageCharacters = 12_000
+    static let maxToolSummariesPerMessage = 24
+    static let maxToolSourcesPerSummary = 8
+    static let maxToolSummaryTitleCharacters = 240
+    static let maxToolSummaryDetailCharacters = 160
+    static let maxToolSourceExcerptCharacters = 280
+    static let maxToolIdentifierCharacters = 128
+    static let maxToolPageNumber = 1_000_000
 
     private struct ConversationEntry: Sendable {
         var key: String
@@ -171,7 +178,7 @@ enum AiPersistence {
 
     @MainActor static func saveConversation(for document: DocumentInfo?, messages: [AiMessage]) {
         guard let document, let key = storageKey(for: document) else { return }
-        let limited = limit(messages)
+        let limited = limitedMessages(messages)
         cache[key] = limited
         // A non-empty conversation is real class-B data; ensure meta.json exists
         // so recents can re-resolve the document by its docId later. The actual
@@ -278,7 +285,7 @@ enum AiPersistence {
         guard let data = DocumentDataStore.loadConversationsData(forKey: key),
               let messages = try? JSONDecoder().decode([AiMessage].self, from: data)
         else { return [] }
-        return limit(messages)
+        return limitedMessages(messages)
     }
 
     /// Await any scheduled write — called from applicationShouldTerminate.
@@ -376,15 +383,89 @@ enum AiPersistence {
         writeConversations(entries)
     }
 
-    private static func limit(_ messages: [AiMessage]) -> [AiMessage] {
+    /// The single conversation boundary used by live saves, cold loads, legacy
+    /// migration, and `.vellum` imports. Structured fields must be bounded here
+    /// as well as message content so nested JSON cannot bypass storage/UI caps.
+    static func limitedMessages(_ messages: [AiMessage]) -> [AiMessage] {
         messages.suffix(maxMessagesPerDocument).map { message in
             var message = message
             if message.content.count > maxMessageCharacters {
                 let end = message.content.index(message.content.startIndex, offsetBy: maxMessageCharacters)
                 message.content = String(message.content[..<end]) + "\n[truncated]"
             }
+            if let summaries = message.toolSummaries {
+                message.toolSummaries = sanitizeToolSummaries(summaries)
+            }
             return message
         }
+    }
+
+    static func sanitizeToolSummaries(_ summaries: [AiToolSummary]) -> [AiToolSummary] {
+        var seenSummaryIds = Set<String>()
+        var sanitized: [AiToolSummary] = []
+        for (summaryIndex, original) in summaries.prefix(maxToolSummariesPerMessage).enumerated() {
+            var summary = original
+            summary.title = bounded(summary.title, limit: maxToolSummaryTitleCharacters)
+            guard summary.title.isEmpty == false else { continue }
+            summary.id = uniqueIdentifier(
+                summary.id,
+                fallback: "summary-\(summaryIndex)",
+                seen: &seenSummaryIds
+            )
+            summary.detail = summary.detail.map {
+                bounded($0, limit: maxToolSummaryDetailCharacters)
+            }
+            summary.destinationPage = boundedPage(summary.destinationPage)
+            var seenSourceIds = Set<String>()
+            summary.sources = summary.sources.prefix(maxToolSourcesPerSummary)
+                .enumerated()
+                .map { sourceIndex, originalSource in
+                var source = originalSource
+                source.id = uniqueIdentifier(
+                    source.id,
+                    fallback: "source-\(sourceIndex)",
+                    seen: &seenSourceIds
+                )
+                source.page = boundedPage(source.page)
+                source.excerpt = bounded(
+                    source.excerpt,
+                    limit: maxToolSourceExcerptCharacters
+                )
+                return source
+            }
+            sanitized.append(summary)
+        }
+        return sanitized
+    }
+
+    private static func uniqueIdentifier(
+        _ value: String,
+        fallback: String,
+        seen: inout Set<String>
+    ) -> String {
+        let candidate = bounded(value, limit: maxToolIdentifierCharacters)
+        if candidate.isEmpty == false, seen.insert(candidate).inserted {
+            return candidate
+        }
+        var attempt = 0
+        while true {
+            let suffix = attempt == 0 ? fallback : "\(fallback)-\(attempt)"
+            let identifier = bounded(suffix, limit: maxToolIdentifierCharacters)
+            if seen.insert(identifier).inserted { return identifier }
+            attempt += 1
+        }
+    }
+
+    private static func bounded(_ value: String, limit: Int) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > limit else { return trimmed }
+        return String(trimmed.prefix(limit))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func boundedPage(_ page: Int?) -> Int? {
+        guard let page, (1...maxToolPageNumber).contains(page) else { return nil }
+        return page
     }
 
     private static func readConversations() -> [ConversationEntry] {
@@ -398,7 +479,7 @@ enum AiPersistence {
         for key in orderedKeys where object[key] is [Any] {
             guard let values = object[key] as? [Any] else { continue }
             let messages = values.compactMap(sanitizeMessage)
-            let bounded = limit(messages)
+            let bounded = limitedMessages(messages)
             if !bounded.isEmpty {
                 entries.append(ConversationEntry(key: key, messages: bounded))
             }
@@ -406,7 +487,7 @@ enum AiPersistence {
         // A malformed order scan should not discard otherwise readable data.
         for key in object.keys.sorted() where !entries.contains(where: { $0.key == key }) {
             guard let values = object[key] as? [Any] else { continue }
-            let bounded = limit(values.compactMap(sanitizeMessage))
+            let bounded = limitedMessages(values.compactMap(sanitizeMessage))
             if !bounded.isEmpty { entries.append(ConversationEntry(key: key, messages: bounded)) }
         }
         // No cap: return every entry so lazy migration can find any document,

--- a/Vellum/Services/Ai/AiPrompts.swift
+++ b/Vellum/Services/Ai/AiPrompts.swift
@@ -60,7 +60,7 @@ enum AiPrompts {
     }
 
     static func buildConversationBlock(_ messages: [AiMessage]) -> String {
-        messages.suffix(10).map { "\($0.role.rawValue.uppercased()): \($0.content)" }
+        messages.suffix(10).map { "\($0.role.rawValue.uppercased()): \($0.promptContent)" }
             .joined(separator: "\n")
     }
 

--- a/Vellum/Services/Ai/AiToolEngine.swift
+++ b/Vellum/Services/Ai/AiToolEngine.swift
@@ -39,11 +39,9 @@ final class AiToolEngine {
     private var writeCount = 0
     private var readCount = 0
 
-    /// One-line summaries of what ran, for the "Actions:" list under the reply.
-    /// Write tools keep their full result line; read tools get a compact
-    /// summary so a multi-KB search/page-text payload (which only the model
-    /// needs) never lands in the visible chat bubble.
-    private(set) var displayActions: [String] = []
+    /// Structured, compact summaries of what ran. Raw tool results remain
+    /// model-only; the transcript receives only short excerpts and page locators.
+    private(set) var displayActions: [AiToolSummary] = []
 
     init(store: AiStore, app: AppStore, annotations: AnnotationStore) {
         self.store = store
@@ -69,28 +67,15 @@ final class AiToolEngine {
             let result = try await execute(action)
             if isRead {
                 readCount += 1
-                if let summary = readSummary(action) { displayActions.append(summary) }
             } else {
                 writeCount += 1
-                displayActions.append(result)
+            }
+            if let summary = AiToolSummary.make(action: action, result: result) {
+                displayActions.append(summary)
             }
             return result
         } catch {
             return "Action failed: \(String(describing: error))"
-        }
-    }
-
-    /// Compact user-facing line for a read tool (the full result goes only to
-    /// the model).
-    private func readSummary(_ action: AiToolAction) -> String? {
-        switch action.tool {
-        case "searchDocument":
-            let query = (action.args.text ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-            return query.isEmpty ? nil : "Searched the document for “\(query)”."
-        case "getPageText":
-            return "Read page \(clampPage(action.args.pageNumber))."
-        default:
-            return nil
         }
     }
 

--- a/Vellum/Services/VellumBundle.swift
+++ b/Vellum/Services/VellumBundle.swift
@@ -440,24 +440,9 @@ enum VellumBundle {
             merged.append(message)
         }
         merged.sort { $0.createdAt < $1.createdAt }
-        let capped = capConversation(merged)
+        let capped = AiPersistence.limitedMessages(merged)
         guard !capped.isEmpty else { return }
         let data = try JSONEncoder().encode(capped)
         try DocumentDataStore.saveConversationsData(forKey: key, data: data)
-    }
-
-    /// The per-document conversation caps (mirrors AiPersistence.limit, using its
-    /// public constants so the two never drift): keep the newest N, truncate
-    /// over-long content.
-    private static func capConversation(_ messages: [AiMessage]) -> [AiMessage] {
-        messages.suffix(AiPersistence.maxMessagesPerDocument).map { message in
-            var message = message
-            if message.content.count > AiPersistence.maxMessageCharacters {
-                let end = message.content.index(
-                    message.content.startIndex, offsetBy: AiPersistence.maxMessageCharacters)
-                message.content = String(message.content[..<end]) + "\n[truncated]"
-            }
-            return message
-        }
     }
 }

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -798,10 +798,12 @@ final class AiStore {
                 content: finalContent,
                 id: assistantId
             )
-            assistantMessage.toolSummaries = engine.displayActions.isEmpty ? nil : engine.displayActions
-            let completed = messagesWithUser + [
+            assistantMessage.toolSummaries = engine.displayActions.isEmpty
+                ? nil
+                : AiPersistence.sanitizeToolSummaries(engine.displayActions)
+            let completed = AiPersistence.limitedMessages(messagesWithUser + [
                 assistantMessage
-            ]
+            ])
             AiPersistence.saveConversation(for: documentForPersist, messages: completed)
             if app.activeTabId == sessionIdAtStart {
                 messages = completed

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -60,6 +60,9 @@ struct AiMessage: Codable, Equatable, Identifiable, Sendable {
     /// Per-response token/cost telemetry; absent on messages persisted
     /// before telemetry existed and on user messages.
     var usage: AiUsage? = nil
+    /// Compact, structured sources and document actions used for this reply.
+    /// Optional so conversations persisted before this UI existed decode unchanged.
+    var toolSummaries: [AiToolSummary]? = nil
 }
 
 /// Coarse phase of an in-flight request, surfaced by the panel's activity
@@ -538,15 +541,10 @@ final class AiStore {
         (pageText?.count ?? 0) < autoPageImageTextThreshold
     }
 
-    /// Persisted assistant content = reply + compact per-action receipts.
-    /// Raw tool payloads (full page text / search results) must never reach
-    /// the persisted message — only these one-line receipts do.
-    static func composeAssistantContent(reply: String, receipts: [String]) -> String {
-        guard !receipts.isEmpty else {
-            return reply.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        return (reply + "\n\nActions:\n" + receipts.map { "- \($0)" }.joined(separator: "\n"))
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+    /// The reply is persisted independently from its structured tool summaries
+    /// so the useful answer renders first and sources can stay collapsed.
+    nonisolated static func composeAssistantContent(reply: String, receipts _: [AiToolSummary]) -> String {
+        reply.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// The conversation-block slice: everything BEFORE the newest user message.
@@ -792,12 +790,17 @@ final class AiStore {
             // drop the result without persisting or re-appending messages.
             guard !Task.isCancelled else { return }
 
-            // Show the engine's compact per-action summaries, not the raw tool
-            // results in `result.actionResults` — those carry full search/page
-            // payloads that only the model should see.
+            // Keep the concise response independent from its compact structured
+            // sources/actions. Raw payloads remain model-only.
             let finalContent = Self.composeAssistantContent(reply: result.reply, receipts: engine.displayActions)
+            var assistantMessage = AiPersistence.makeMessage(
+                role: .assistant,
+                content: finalContent,
+                id: assistantId
+            )
+            assistantMessage.toolSummaries = engine.displayActions.isEmpty ? nil : engine.displayActions
             let completed = messagesWithUser + [
-                AiPersistence.makeMessage(role: .assistant, content: finalContent, id: assistantId)
+                assistantMessage
             ]
             AiPersistence.saveConversation(for: documentForPersist, messages: completed)
             if app.activeTabId == sessionIdAtStart {

--- a/Vellum/Views/AI/AiPanel.swift
+++ b/Vellum/Views/AI/AiPanel.swift
@@ -176,6 +176,10 @@ struct AiPanel: View {
             messageBubble(message)
 
             if message.role == .assistant, !message.content.isEmpty {
+                let summaries = message.displayToolSummaries
+                if summaries.isEmpty == false {
+                    toolSummaries(summaries)
+                }
                 messageActions(message)
             }
         }
@@ -187,7 +191,7 @@ struct AiPanel: View {
         Group {
             if message.role == .assistant {
                 SelectableMessageText(
-                    content: message.content,
+                    content: message.displayContent,
                     color: palette.foreground,
                     secondary: palette.mutedForeground,
                     onQuote: { text in
@@ -200,14 +204,17 @@ struct AiPanel: View {
                     onDropTargeted: { dropTargeted = $0 }
                 )
             } else {
-                MarkdownMessage(content: message.content, textColor: palette.primaryForeground)
+                MarkdownMessage(content: message.displayContent, textColor: palette.primaryForeground)
                     .font(.system(size: 14))
                     .foregroundStyle(palette.primaryForeground)
             }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .frame(maxWidth: 272, alignment: .leading)
+        .frame(
+            maxWidth: message.role == .assistant ? .infinity : 360,
+            alignment: message.role == .user ? .trailing : .leading
+        )
         .background(
             message.role == .user
                 ? AnyShapeStyle(.tint)
@@ -220,23 +227,42 @@ struct AiPanel: View {
         ))
     }
 
+    private func toolSummaries(_ summaries: [AiToolSummary]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Sources & actions")
+                .font(.caption)
+                .foregroundStyle(palette.mutedForeground)
+                .padding(.horizontal, 4)
+
+            ForEach(summaries) { summary in
+                AiToolSummaryView(summary: summary, onJumpToPage: appStore.goToPage)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Sources and actions")
+    }
+
     /// Copy / Quote / Add-as-note row under each assistant reply.
     private func messageActions(_ message: AiMessage) -> some View {
         HStack(spacing: 2) {
-            IconButton(help: "Copy", action: { copyToPasteboard(message.content) }) {
+            IconButton(help: "Copy answer", action: { copyToPasteboard(message.displayContent) }) {
                 Image(systemName: "doc.on.doc").font(.system(size: 12))
             }
             .accessibilityIdentifier("aiMessage.copy")
 
             IconButton(help: "Quote in reply", action: {
-                aiStore.addReference(AiReference(kind: .quote(text: message.content, messageId: message.id)))
+                aiStore.addReference(AiReference(kind: .quote(
+                    text: message.displayContent,
+                    messageId: message.id
+                )))
             }) {
                 Image(systemName: "quote.bubble").font(.system(size: 12))
             }
             .accessibilityIdentifier("aiMessage.quote")
 
             IconButton(help: "Add as note — click on the page to place it", action: {
-                appStore.beginNoteWithContent(message.content)
+                appStore.beginNoteWithContent(message.displayContent)
             }) {
                 Image(systemName: "note.text.badge.plus").font(.system(size: 12))
             }

--- a/Vellum/Views/AI/AiToolSourceRow.swift
+++ b/Vellum/Views/AI/AiToolSourceRow.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct AiToolSourceRow: View {
+    let source: AiToolSummary.Source
+    let onJumpToPage: (Int) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let page = source.page {
+                Button("Page \(page)", systemImage: "arrow.right.circle") {
+                    onJumpToPage(page)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.tint)
+                .accessibilityHint("Moves the document to page \(page)")
+                .accessibilityIdentifier("aiToolSource.jumpToPage")
+            }
+
+            Text(source.excerpt)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .lineLimit(4)
+                .textSelection(.enabled)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(8)
+        .background(.quaternary, in: RoundedRectangle(cornerRadius: Radius.sm))
+    }
+}

--- a/Vellum/Views/AI/AiToolSummaryView.swift
+++ b/Vellum/Views/AI/AiToolSummaryView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct AiToolSummaryView: View {
+    let summary: AiToolSummary
+    let onJumpToPage: (Int) -> Void
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(summary.sources) { source in
+                    AiToolSourceRow(source: source, onJumpToPage: onJumpToPage)
+                }
+                if summary.sources.isEmpty, let page = summary.destinationPage {
+                    Button("Jump to page \(page)", systemImage: "arrow.right.circle") {
+                        onJumpToPage(page)
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.tint)
+                    .accessibilityHint("Moves the document to page \(page)")
+                    .accessibilityIdentifier("aiToolSummary.jumpToPage")
+                }
+            }
+            .padding(.top, 6)
+        } label: {
+            Label {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(summary.title)
+                        .lineLimit(1)
+                    if let detail = summary.detail, detail.isEmpty == false {
+                        Text(detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            } icon: {
+                Image(systemName: summary.sources.isEmpty ? "wrench.and.screwdriver" : "doc.text.magnifyingglass")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.callout)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: Radius.md))
+        .accessibilityIdentifier("aiToolSummary")
+        .accessibilityHint(isExpanded ? "Collapses source details" : "Expands source details")
+    }
+}

--- a/Vellum/Views/AI/SelectableMessageText.swift
+++ b/Vellum/Views/AI/SelectableMessageText.swift
@@ -59,9 +59,15 @@ struct SelectableMessageText: NSViewRepresentable {
     }
 
     func sizeThatFits(_ proposal: ProposedViewSize, nsView: MessageContainerView, context: Context) -> CGSize? {
-        let width = proposal.width ?? 248
-        let clamped = min(max(width, 80), 248)
+        let clamped = Self.resolvedWidth(proposal.width)
         return CGSize(width: clamped, height: nsView.height(forWidth: clamped))
+    }
+
+    /// The answer follows the inspector's proposed width instead of retaining
+    /// the old 248-point ceiling. The floor prevents pathological text layout
+    /// if AppKit briefly proposes a near-zero width during a resize.
+    static func resolvedWidth(_ proposed: CGFloat?) -> CGFloat {
+        max(proposed ?? 248, 120)
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {


### PR DESCRIPTION
## Summary
- render concise assistant answers at the full available inspector width
- persist tool/source output separately and collapse traces by default
- show short source excerpts and accessible jump-to-page actions
- keep legacy transcripts compact and exclude raw source payloads from follow-up prompts
- keep Copy, Quote, and Add Note scoped to the answer

## Verification
- focused AI/layout test groups passed
- full macOS suite passed in 51.85 seconds
- exact-build computer-use verified narrow, default, and wide widths with accessible actions
- historical 106 MB PDF remained stuck at Opening, so live trace expansion on that fixture was blocked; deterministic tests cover expand/jump data paths

## Audit
Implements the responsive AI conversation/tool-output redesign from the 2026-07-27 audit.