### PR TITLE
Cut iPad battery drain from ink writes and web-page observers

### DIFF
--- a/Tests/InkPersistenceTests.swift
+++ b/Tests/InkPersistenceTests.swift
@@ -181,11 +181,12 @@ final class InkPersistenceTests: XCTestCase {
 
         // Exercise the production writer, including the iPadOS 26 main-actor
         // PDFKit compatibility path and the shared non-reentrant file gate.
-        async let inkDone: Void = InkDiskWriter().write(
+        async let inkDone: Bool = InkDiskWriter().write(
             drawings: [1: inkDrawing], path: inkPath)
 
         let created = try await annotation
-        _ = await inkDone
+        let inkWrote = await inkDone
+        XCTAssertTrue(inkWrote, "ink write reported success")
 
         // Reload from disk: BOTH writes must have survived.
         let reloaded = try await PdfSessionBackend().open(path: url.path, sessionId: UUID().uuidString)
@@ -363,15 +364,127 @@ final class InkPersistenceTests: XCTestCase {
         await app.openFile(path: url.path)
         let controller = InkController_iOS()
         controller.app = app
-        // Ink, then erase it all again inside the same debounce window.
+
+        // Get real ink on disk FIRST — otherwise the erase assertion below is
+        // vacuous: a blank page reads as un-inked whether the write happened or
+        // not, so the test would pass even if persistence were broken entirely.
+        controller.drawingChanged(sampleDrawing(), page: 1)
+        await controller.flushPendingInkAndWait()
+        let afterInk = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertTrue(
+            PdfInk.hasInk(on: try XCTUnwrap(afterInk.page(at: 0))),
+            "precondition: the first drawing must actually reach disk")
+
+        // Now ink and erase inside one window: the empty drawing is newest.
         controller.drawingChanged(sampleDrawing(), page: 1)
         controller.drawingChanged(PKDrawing(), page: 1)
-
         await controller.flushPendingInkAndWait()
 
         let reloaded = try XCTUnwrap(PDFDocument(url: url))
         let page = try XCTUnwrap(reloaded.page(at: 0))
         XCTAssertFalse(PdfInk.hasInk(on: page), "the empty drawing was the newest state")
+    }
+
+    /// Two documents dirty at once (a tab switch mid-debounce) must not merge:
+    /// `pendingDrawings` is keyed by path precisely so page 1 of document A
+    /// cannot be written into page 1 of document B.
+    @MainActor
+    func testPendingInkForTwoDocumentsStaysWithItsOwnFile() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-twodoc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let first = dir.appendingPathComponent("first.pdf")
+        let second = dir.appendingPathComponent("second.pdf")
+        try writeBlankDocument(pageCount: 1, to: first)
+        try writeBlankDocument(pageCount: 1, to: second)
+
+        let app = AppStore(sessions: DocumentSessionManager())
+        let controller = InkController_iOS()
+        controller.app = app
+
+        // Dirty page 1 of the first document, then switch documents before it
+        // drains and dirty page 1 of the second.
+        await app.openFile(path: first.path)
+        controller.drawingChanged(sampleDrawing(), page: 1)
+        await app.openFile(path: second.path)
+        controller.drawingChanged(sampleDrawing(), page: 1)
+
+        await controller.flushPendingInkAndWait()
+
+        for url in [first, second] {
+            let reloaded = try XCTUnwrap(PDFDocument(url: url), "reload \(url.lastPathComponent)")
+            XCTAssertTrue(
+                PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 0))),
+                "\(url.lastPathComponent) kept its own ink")
+        }
+    }
+
+    /// A write that fails must NOT discard the batch. Batching means one
+    /// transient failure would otherwise take a whole debounce window's strokes
+    /// with it, so the pages go back to pending and a later flush retries them.
+    @MainActor
+    func testFailedWriteKeepsInkPendingForRetry() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-retry-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("retry.pdf")
+        try writeBlankDocument(pageCount: 1, to: url)
+
+        let app = AppStore(sessions: DocumentSessionManager())
+        await app.openFile(path: url.path)
+        let controller = InkController_iOS()
+        controller.app = app
+        controller.drawingChanged(sampleDrawing(), page: 1)
+
+        // Make the write fail the way an iCloud eviction would: the path is
+        // suddenly unreadable. The strokes must survive in memory.
+        try FileManager.default.removeItem(at: url)
+        await controller.flushPendingInkAndWait()
+
+        // Restore the file; the retained batch must now reach disk.
+        try writeBlankDocument(pageCount: 1, to: url)
+        await controller.flushPendingInkAndWait()
+
+        let reloaded = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertTrue(
+            PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 0))),
+            "ink survived a failed write and landed on the retry")
+    }
+
+    /// The debounce must fire on its own — nothing in the app calls
+    /// `flushPendingInk` on a timer, so if the scheduled write never ran, ink
+    /// would only ever reach disk via an explicit flush.
+    @MainActor
+    func testDebouncedWriteLandsWithoutAnExplicitFlush() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-debounce-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("debounce.pdf")
+        try writeBlankDocument(pageCount: 1, to: url)
+
+        let app = AppStore(sessions: DocumentSessionManager())
+        await app.openFile(path: url.path)
+        let controller = InkController_iOS()
+        controller.app = app
+        controller.drawingChanged(sampleDrawing(), page: 1)
+
+        // Poll rather than sleeping the full debounce once: keeps the test
+        // honest about the deadline without making it flaky on a loaded machine.
+        let deadline = Date().addingTimeInterval(20)
+        var landed = false
+        while Date() < deadline, !landed {
+            try? await Task.sleep(for: .milliseconds(250))
+            if let doc = PDFDocument(url: url), let page = doc.page(at: 0) {
+                landed = PdfInk.hasInk(on: page)
+            }
+        }
+        XCTAssertTrue(landed, "the debounced write reached disk on its own")
     }
 }
 #endif

--- a/Tests/InkPersistenceTests.swift
+++ b/Tests/InkPersistenceTests.swift
@@ -23,6 +23,20 @@ final class InkPersistenceTests: XCTestCase {
         return (document, page)
     }
 
+    /// A multi-page US-Letter PDF, written to `url`.
+    private func writeBlankDocument(pageCount: Int, to url: URL) throws {
+        let bounds = CGRect(x: 0, y: 0, width: 612, height: 792)
+        let renderer = UIGraphicsPDFRenderer(bounds: bounds)
+        let data: Data = renderer.pdfData { ctx in
+            for _ in 0..<pageCount {
+                ctx.beginPage()
+                UIColor.white.setFill()
+                UIRectFill(bounds)
+            }
+        }
+        try data.write(to: url)
+    }
+
     private func sampleDrawing() -> PKDrawing {
         var points: [PKStrokePoint] = []
         for i in 0..<10 {
@@ -151,7 +165,7 @@ final class InkPersistenceTests: XCTestCase {
 
         let session = try await PdfSessionBackend().open(path: url.path, sessionId: UUID().uuidString)
 
-        let inkData = sampleDrawing().dataRepresentation()
+        let inkDrawing = sampleDrawing()
         let inkPath = url.path
 
         // Run the two writers concurrently against the same file.
@@ -168,7 +182,7 @@ final class InkPersistenceTests: XCTestCase {
         // Exercise the production writer, including the iPadOS 26 main-actor
         // PDFKit compatibility path and the shared non-reentrant file gate.
         async let inkDone: Void = InkDiskWriter().write(
-            data: inkData, page: 1, path: inkPath)
+            drawings: [1: inkDrawing], path: inkPath)
 
         let created = try await annotation
         _ = await inkDone
@@ -212,10 +226,7 @@ final class InkPersistenceTests: XCTestCase {
                 startOffset: nil, endOffset: nil, prefix: nil, suffix: nil,
                 viewportOffset: nil)))
 
-        await InkDiskWriter().write(
-            data: sampleDrawing().dataRepresentation(),
-            page: 1,
-            path: url.path)
+        await InkDiskWriter().write(drawings: [1: sampleDrawing()], path: url.path)
 
         let reloaded = try await PdfSessionBackend().open(
             path: url.path,
@@ -262,6 +273,105 @@ final class InkPersistenceTests: XCTestCase {
         let reloaded = try XCTUnwrap(PDFDocument(url: url))
         let page = try XCTUnwrap(reloaded.page(at: 0))
         XCTAssertTrue(PdfInk.hasInk(on: page))
+    }
+
+    /// Every dirty page is folded into ONE read-modify-write of the PDF. A
+    /// per-page loop re-read, re-parsed, re-serialized and rewrote the whole
+    /// file once per page, which on a large document was the app's single
+    /// biggest energy cost while taking notes.
+    @MainActor
+    func testBatchedWriteAppliesInkToEveryDirtyPage() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-batch-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("batch.pdf")
+        try writeBlankDocument(pageCount: 3, to: url)
+
+        await InkDiskWriter().write(
+            drawings: [1: sampleDrawing(), 3: sampleDrawing()],
+            path: url.path)
+
+        let reloaded = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertEqual(reloaded.pageCount, 3)
+        XCTAssertTrue(PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 0))), "page 1 ink")
+        XCTAssertFalse(PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 1))), "page 2 untouched")
+        XCTAssertTrue(PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 2))), "page 3 ink")
+    }
+
+    /// An out-of-range page must not discard the pages that ARE valid — the
+    /// batch writer applies what it can rather than bailing on the whole file.
+    @MainActor
+    func testBatchedWriteSkipsOutOfRangePagesWithoutLosingValidOnes() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-range-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("range.pdf")
+        try writeBlankDocument(pageCount: 2, to: url)
+
+        await InkDiskWriter().write(
+            drawings: [1: sampleDrawing(), 99: sampleDrawing()],
+            path: url.path)
+
+        let reloaded = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertTrue(PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 0))))
+    }
+
+    /// Inking two pages inside one debounce window must persist both. The
+    /// controller now keeps a single coalesced batch rather than a task per
+    /// page, so this pins down that neither page is dropped.
+    @MainActor
+    func testFlushPersistsEveryPageDirtiedInOneWindow() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-multipage-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("multipage.pdf")
+        try writeBlankDocument(pageCount: 2, to: url)
+
+        let app = AppStore(sessions: DocumentSessionManager())
+        await app.openFile(path: url.path)
+        let controller = InkController_iOS()
+        controller.app = app
+        controller.drawingChanged(sampleDrawing(), page: 1)
+        controller.drawingChanged(sampleDrawing(), page: 2)
+
+        await controller.flushPendingInkAndWait()
+
+        let reloaded = try XCTUnwrap(PDFDocument(url: url))
+        XCTAssertTrue(PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 0))), "page 1 ink")
+        XCTAssertTrue(PdfInk.hasInk(on: try XCTUnwrap(reloaded.page(at: 1))), "page 2 ink")
+    }
+
+    /// The last drawing wins: a page re-inked before the debounce elapses must
+    /// persist its newest state, not the one that was pending first.
+    @MainActor
+    func testLatestDrawingForAPageWins() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vellum-ink-latest-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("latest.pdf")
+        try writeBlankDocument(pageCount: 1, to: url)
+
+        let app = AppStore(sessions: DocumentSessionManager())
+        await app.openFile(path: url.path)
+        let controller = InkController_iOS()
+        controller.app = app
+        // Ink, then erase it all again inside the same debounce window.
+        controller.drawingChanged(sampleDrawing(), page: 1)
+        controller.drawingChanged(PKDrawing(), page: 1)
+
+        await controller.flushPendingInkAndWait()
+
+        let reloaded = try XCTUnwrap(PDFDocument(url: url))
+        let page = try XCTUnwrap(reloaded.page(at: 0))
+        XCTAssertFalse(PdfInk.hasInk(on: page), "the empty drawing was the newest state")
     }
 }
 #endif

--- a/Vellum/Platform/iOS/InkController_iOS.swift
+++ b/Vellum/Platform/iOS/InkController_iOS.swift
@@ -222,6 +222,11 @@ final class InkController_iOS {
     /// debounce had too. This makes the crash window strictly bounded.
     @ObservationIgnored private static let maxDirtyAge = Duration.seconds(15)
 
+    /// How many times `flushPendingInkAndWait` re-drains before giving up. A
+    /// failed write returns its pages to `pendingDrawings`, so this is what
+    /// stops a file that cannot be written at all from spinning the flush.
+    @ObservationIgnored private static let maxDrainAttempts = 3
+
     /// Pages whose canvas has changed but whose ink is not yet on disk, grouped
     /// by the file they belong to (switching tabs mid-debounce can leave two
     /// documents dirty at once).
@@ -386,10 +391,12 @@ final class InkController_iOS {
     /// The scene-background task uses this before iPadOS is allowed to suspend
     /// the app, so a stroke made immediately before pressing Home cannot vanish.
     func flushPendingInkAndWait() async {
-        // A stroke can arrive while an earlier flush is suspended in PDFKit.
-        // Keep joining/draining until there is neither an active drain nor new
-        // pending state.
-        while let task = ensureDrainTask() {
+        // A stroke can arrive while an earlier flush is suspended in PDFKit, so
+        // join/drain repeatedly. Bounded, not `while`: a drain that fails puts
+        // its batch back, and an unwritable file would otherwise spin here
+        // forever while the scene-suspend assertion is running.
+        for _ in 0..<Self.maxDrainAttempts {
+            guard let task = ensureDrainTask() else { return }
             await task.value
         }
     }
@@ -419,10 +426,30 @@ final class InkController_iOS {
             let batch = pendingDrawings
             pendingDrawings.removeAll()
             oldestDirtyAt = nil
-            for (path, pages) in batch {
-                await Self.writer.write(drawings: pages, path: path)
+            var failed = false
+            for (path, pages) in batch where await !Self.writer.write(drawings: pages, path: path) {
+                // The file was unreadable, or PDFKit refused to serialize it.
+                // The batch has already been taken out of `pendingDrawings`, so
+                // without this the user's strokes would be gone for good on a
+                // failure as transient as an iCloud eviction mid-write.
+                requeue(pages, path: path)
+                failed = true
             }
+            // Leave a failing file to the next stroke or flush rather than
+            // retrying in a tight loop against the disk.
+            if failed { return }
         }
+    }
+
+    /// Put a failed batch back, without burying a newer drawing that landed
+    /// while the write was in flight — newest-wins still holds.
+    private func requeue(_ pages: [Int: PKDrawing], path: String) {
+        var current = pendingDrawings[path] ?? [:]
+        for (page, drawing) in pages where current[page] == nil {
+            current[page] = drawing
+        }
+        pendingDrawings[path] = current
+        if oldestDirtyAt == nil { oldestDirtyAt = ContinuousClock.now }
     }
 
     private func persist(drawing: PKDrawing, page: Int) {
@@ -474,17 +501,22 @@ struct InkDiskWriter {
     /// it a second time to rehydrate them. Writing pages one at a time paid all
     /// of that per page, so inking across a spread cost two full rewrites of a
     /// document that might be tens of MB.
-    func write(drawings: [Int: PKDrawing], path: String) async {
-        guard !drawings.isEmpty else { return }
-        await PdfFileGate.shared.perform {
+    /// - Returns: whether the pages are durable. `false` means the caller must
+    ///   keep them pending — every failure mode here (unreadable file, PDFKit
+    ///   declining to serialize, a throwing rewrite) used to be swallowed, which
+    ///   with batching would discard a whole window of strokes at once.
+    @discardableResult
+    func write(drawings: [Int: PKDrawing], path: String) async -> Bool {
+        guard !drawings.isEmpty else { return true }
+        return await PdfFileGate.shared.perform {
             Self.writeSync(drawings: drawings, path: path)
         }
     }
 
-    private static func writeSync(drawings: [Int: PKDrawing], path: String) {
+    private static func writeSync(drawings: [Int: PKDrawing], path: String) -> Bool {
         let url = URL(fileURLWithPath: path)
         guard let originalData = try? Data(contentsOf: url),
-              let document = PDFDocument(data: originalData) else { return }
+              let document = PDFDocument(data: originalData) else { return false }
         var didApply = false
         for (page, drawing) in drawings {
             guard page >= 1, page <= document.pageCount,
@@ -492,12 +524,19 @@ struct InkDiskWriter {
             PdfInk.apply(drawing, to: pdfPage)
             didApply = true
         }
-        // Nothing landed (every page out of range): don't pay the rewrite.
-        guard didApply, let rewritten = document.dataRepresentation() else { return }
-        try? PdfDocumentSession.persistPdfKitRewrite(
-            rewritten,
-            preservingMetadataFrom: originalData,
-            path: path)
+        // Every page was out of range: nothing to write, and nothing to retry
+        // either — retrying would fail identically.
+        guard didApply else { return true }
+        guard let rewritten = document.dataRepresentation() else { return false }
+        do {
+            try PdfDocumentSession.persistPdfKitRewrite(
+                rewritten,
+                preservingMetadataFrom: originalData,
+                path: path)
+            return true
+        } catch {
+            return false
+        }
     }
 }
 #endif

--- a/Vellum/Platform/iOS/InkController_iOS.swift
+++ b/Vellum/Platform/iOS/InkController_iOS.swift
@@ -204,14 +204,46 @@ final class InkController_iOS {
         drawingChanged(PKDrawing(), page: page)
     }
 
-    /// Debounce state per page — each page's canvas persists independently, so
-    /// inking two pages inside one debounce window must not drop either write.
-    @ObservationIgnored private var persistTasks: [Int: Task<Void, Never>] = [:]
-    @ObservationIgnored private var pendingWrites: [Int: (data: Data, path: String)] = [:]
-    /// Retains the active immediate flush. Backgrounding joins this exact task
-    /// instead of seeing emptied dictionaries and ending its assertion while a
-    /// previously launched PDF rewrite is still running.
-    @ObservationIgnored private var flushTask: Task<Void, Never>?
+    /// How long the canvas must stay quiet before ink is written to disk.
+    ///
+    /// Every write is a full read-modify-write of the PDF (see `InkDiskWriter`),
+    /// so on a large document each one costs tens of MB of I/O plus two complete
+    /// parses. At the previous 700ms the natural pauses between words triggered
+    /// a rewrite more or less continuously while taking notes, which was a
+    /// significant battery cost. Durability does not rest on this value: ink is
+    /// flushed unconditionally when ink mode turns off (`flushPendingInk`) and
+    /// before the scene suspends (`flushPendingInkAndWait`), so it bounds only
+    /// the window a hard crash could lose.
+    @ObservationIgnored private static let persistDebounce = Duration.milliseconds(2500)
+
+    /// Ceiling on how long a page may stay dirty. Uninterrupted drawing keeps
+    /// resetting the debounce, so without this a long unbroken passage would
+    /// never reach disk at all — an unbounded window the previous per-page
+    /// debounce had too. This makes the crash window strictly bounded.
+    @ObservationIgnored private static let maxDirtyAge = Duration.seconds(15)
+
+    /// Pages whose canvas has changed but whose ink is not yet on disk, grouped
+    /// by the file they belong to (switching tabs mid-debounce can leave two
+    /// documents dirty at once).
+    ///
+    /// This holds the `PKDrawing` itself — a `Sendable` value type — rather than
+    /// its encoded bytes, which keeps `dataRepresentation()` off the per-stroke
+    /// path. That call serializes *every* stroke on the page, and PencilKit
+    /// invokes `canvasViewDrawingDidChange` repeatedly *during* a stroke, so
+    /// encoding inline cost O(strokes already on the page) of main-actor work at
+    /// Pencil input rate — up to 120Hz on a ProMotion display.
+    @ObservationIgnored private var pendingDrawings: [String: [Int: PKDrawing]] = [:]
+
+    /// When the oldest currently-unwritten change arrived, for `maxDirtyAge`.
+    @ObservationIgnored private var oldestDirtyAt: ContinuousClock.Instant?
+
+    /// The pending debounce timer. Cancelled and restarted on every change.
+    @ObservationIgnored private var debounceTask: Task<Void, Never>?
+
+    /// Retains the active drain. Backgrounding joins this exact task instead of
+    /// seeing emptied dictionaries and ending its assertion while a previously
+    /// launched PDF rewrite is still running.
+    @ObservationIgnored private var drainTask: Task<Void, Never>?
 
     var activeColor: Color {
         get { tool == .highlighter ? highlighterColor : penColor }
@@ -339,15 +371,15 @@ final class InkController_iOS {
     /// no display-document mutation here.
     func drawingChanged(_ drawing: PKDrawing, page: Int) {
         drawingVersion &+= 1
-        persist(drawing: drawing, page: page, debounce: true)
+        persist(drawing: drawing, page: page)
     }
 
     // MARK: - Persistence to the on-disk PDF
 
-    /// Write all pending debounced ink immediately (no 700ms wait). Called when
-    /// ink mode turns off so a fast app-kill can't drop the last strokes.
+    /// Write all pending debounced ink immediately (no debounce wait). Called
+    /// when ink mode turns off so a fast app-kill can't drop the last strokes.
     func flushPendingInk() {
-        _ = ensureFlushTask()
+        _ = ensureDrainTask()
     }
 
     /// Cancel the debounce and wait until every pending page rewrite is durable.
@@ -355,58 +387,62 @@ final class InkController_iOS {
     /// the app, so a stroke made immediately before pressing Home cannot vanish.
     func flushPendingInkAndWait() async {
         // A stroke can arrive while an earlier flush is suspended in PDFKit.
-        // Keep joining/draining until there is neither an active flush nor new
+        // Keep joining/draining until there is neither an active drain nor new
         // pending state.
-        while let task = ensureFlushTask() {
+        while let task = ensureDrainTask() {
             await task.value
         }
     }
 
-    private func ensureFlushTask() -> Task<Void, Never>? {
-        if let flushTask { return flushTask }
-        guard !pendingWrites.isEmpty || !persistTasks.isEmpty else { return nil }
+    private func ensureDrainTask() -> Task<Void, Never>? {
+        // The debounce has been superseded: whatever it was waiting to write is
+        // still in `pendingDrawings` and the drain below picks it up.
+        debounceTask?.cancel()
+        debounceTask = nil
+        if let drainTask { return drainTask }
+        guard !pendingDrawings.isEmpty else { return nil }
         let task = Task { [weak self] in
             guard let self else { return }
             await self.drainPendingInk()
-            self.flushTask = nil
+            self.drainTask = nil
         }
-        flushTask = task
+        drainTask = task
         return task
     }
 
     private func drainPendingInk() async {
-        while !pendingWrites.isEmpty || !persistTasks.isEmpty {
-            let pending = pendingWrites
-            let scheduled = Array(persistTasks.values)
-            for task in scheduled { task.cancel() }
-            persistTasks.removeAll()
-            pendingWrites.removeAll()
-
-            // Cancellation does not interrupt a writer that already passed its
-            // debounce. Join those tasks before the background assertion ends;
-            // writing the captured latest page state again is intentional and
-            // leaves the newest drawing authoritative.
-            for task in scheduled { await task.value }
-            for (page, write) in pending {
-                await Self.writer.write(data: write.data, page: page, path: write.path)
+        // A stroke can land while an earlier batch is inside PDFKit, so keep
+        // draining until nothing new has arrived.
+        while !pendingDrawings.isEmpty {
+            let batch = pendingDrawings
+            pendingDrawings.removeAll()
+            oldestDirtyAt = nil
+            for (path, pages) in batch {
+                await Self.writer.write(drawings: pages, path: path)
             }
         }
     }
 
-    private func persist(drawing: PKDrawing, page: Int, debounce: Bool = false) {
-        guard let path = app?.document?.pdfPath else { return }
-        persistTasks[page]?.cancel()
-        let data = drawing.dataRepresentation()
-        pendingWrites[page] = (data, path)
-        persistTasks[page] = Task { [weak self] in
-            if debounce {
-                try? await Task.sleep(for: .milliseconds(700))
-                if Task.isCancelled { return }
-            }
-            await Self.writer.write(data: data, page: page, path: path)
-            if Task.isCancelled { return }
-            self?.pendingWrites.removeValue(forKey: page)
-            self?.persistTasks.removeValue(forKey: page)
+    private func persist(drawing: PKDrawing, page: Int) {
+        guard let path = app?.document?.pdfPath, page >= 1 else { return }
+        // O(1): just retain the drawing. Encoding happens once per write, off
+        // the main actor — see `pendingDrawings`.
+        pendingDrawings[path, default: [:]][page] = drawing
+        let now = ContinuousClock.now
+        let dirtiedAt = oldestDirtyAt ?? now
+        oldestDirtyAt = dirtiedAt
+        // Continuous drawing keeps resetting the debounce below, so stop
+        // deferring once the batch has been dirty for `maxDirtyAge`.
+        guard now - dirtiedAt < Self.maxDirtyAge else {
+            flushPendingInk()
+            return
+        }
+        debounceTask?.cancel()
+        debounceTask = Task { [weak self] in
+            try? await Task.sleep(for: Self.persistDebounce)
+            guard !Task.isCancelled else { return }
+            self?.debounceTask = nil
+            self?.flushPendingInk()
         }
     }
 
@@ -417,28 +453,40 @@ final class InkController_iOS {
 }
 
 /// Loads a FRESH copy of the on-disk PDF (so the highlight/note annotations
-/// written by the atomic writer are preserved), replaces one page's ink, and
-/// atomically writes it back. Every ink write is routed through the shared
-/// `PdfFileGate` so it can never interleave with an annotation/metadata rewrite
-/// of the same file (both are full read-modify-writes; interleaving would lose
-/// one side's changes). The gate also runs the PDFKit mutation + write off the
-/// main thread.
+/// written by the atomic writer are preserved), replaces the ink on every dirty
+/// page, and atomically writes it back. Every ink write is routed through the
+/// shared `PdfFileGate` so it can never interleave with an annotation/metadata
+/// rewrite of the same file (both are full read-modify-writes; interleaving
+/// would lose one side's changes). The gate also runs the PDFKit mutation +
+/// write off the main thread.
 struct InkDiskWriter {
-    func write(data: Data, page: Int, path: String) async {
+    /// Apply every dirty page's ink in ONE read-modify-write cycle.
+    ///
+    /// A rewrite re-reads the whole file, re-parses it, re-serializes it, and —
+    /// on iPadOS 26, where PDFKit drops Vellum's custom annotation keys — parses
+    /// it a second time to rehydrate them. Writing pages one at a time paid all
+    /// of that per page, so inking across a spread cost two full rewrites of a
+    /// document that might be tens of MB.
+    func write(drawings: [Int: PKDrawing], path: String) async {
+        guard !drawings.isEmpty else { return }
         await PdfFileGate.shared.perform {
-            Self.writeSync(data: data, page: page, path: path)
+            Self.writeSync(drawings: drawings, path: path)
         }
     }
 
-    private static func writeSync(data: Data, page: Int, path: String) {
+    private static func writeSync(drawings: [Int: PKDrawing], path: String) {
         let url = URL(fileURLWithPath: path)
         guard let originalData = try? Data(contentsOf: url),
-              let document = PDFDocument(data: originalData),
-              page >= 1, page <= document.pageCount,
-              let pdfPage = document.page(at: page - 1) else { return }
-        let drawing = (try? PKDrawing(data: data)) ?? PKDrawing()
-        PdfInk.apply(drawing, to: pdfPage)
-        guard let rewritten = document.dataRepresentation() else { return }
+              let document = PDFDocument(data: originalData) else { return }
+        var didApply = false
+        for (page, drawing) in drawings {
+            guard page >= 1, page <= document.pageCount,
+                  let pdfPage = document.page(at: page - 1) else { continue }
+            PdfInk.apply(drawing, to: pdfPage)
+            didApply = true
+        }
+        // Nothing landed (every page out of range): don't pay the rewrite.
+        guard didApply, let rewritten = document.dataRepresentation() else { return }
         try? PdfDocumentSession.persistPdfKitRewrite(
             rewritten,
             preservingMetadataFrom: originalData,

--- a/Vellum/Platform/iOS/InkController_iOS.swift
+++ b/Vellum/Platform/iOS/InkController_iOS.swift
@@ -401,8 +401,10 @@ final class InkController_iOS {
         debounceTask = nil
         if let drainTask { return drainTask }
         guard !pendingDrawings.isEmpty else { return nil }
-        let task = Task { [weak self] in
-            guard let self else { return }
+        // Strong `self` for the same reason as the debounce task: the batch this
+        // is about to write lives on this object, and the task body doesn't
+        // start until the next main-actor turn. The retain ends with the drain.
+        let task = Task {
             await self.drainPendingInk()
             self.drainTask = nil
         }
@@ -438,11 +440,16 @@ final class InkController_iOS {
             return
         }
         debounceTask?.cancel()
-        debounceTask = Task { [weak self] in
+        // Strong `self` on purpose. The pending drawings live on this object, so
+        // a weak capture would silently drop them if the controller went away
+        // during the debounce window — closing a tab mid-stroke would lose ink.
+        // The retain is bounded: the task ends after `persistDebounce` (or is
+        // cancelled by the next stroke), and releasing it breaks the cycle.
+        debounceTask = Task {
             try? await Task.sleep(for: Self.persistDebounce)
             guard !Task.isCancelled else { return }
-            self?.debounceTask = nil
-            self?.flushPendingInk()
+            self.debounceTask = nil
+            self.flushPendingInk()
         }
     }
 

--- a/Vellum/Platform/iOS/PaneView_iOS.swift
+++ b/Vellum/Platform/iOS/PaneView_iOS.swift
@@ -92,7 +92,14 @@ struct PaneView_iOS: View {
         })
         .task(id: documentIdentity) { await loadDocumentState() }
         .onAppear { inkRegistry.register(ink, for: pane.id) }
-        .onDisappear { inkRegistry.remove(pane.id) }
+        .onDisappear {
+            // Flush BEFORE deregistering. The scene-background flush drains the
+            // registry, so a controller with debounced ink that has already been
+            // removed would never be reached — closing a split pane moments
+            // before pressing Home would drop the last strokes.
+            ink.flushPendingInk()
+            inkRegistry.remove(pane.id)
+        }
         .onReceive(NotificationCenter.default.publisher(for: .vellumAnnotationsUpdated)) { _ in
             guard app.document != nil else { return }
             Task { await pane.annotations.loadAnnotations() }

--- a/Vellum/Views/Web/WebContentScript.swift
+++ b/Vellum/Views/Web/WebContentScript.swift
@@ -1400,15 +1400,51 @@ enum WebContentScript {
   }
 
   var scrollTicking = false;
+  var scrollGestureActive = false;
+  var scrollIdleTimer = null;
+  var lastScrollReportAt = 0;
+  var scrollTrailingTimer = null;
+  // Viewport reporting drives the page-number readout and the bookmark star,
+  // and each call forces layout once per resolved bookmark. Neither consumer
+  // needs anything close to the 120Hz a ProMotion scroll delivers.
+  var SCROLL_REPORT_MS = 66;
+  // How long the page must stop moving before the next scroll counts as a new
+  // gesture for "viewport-scrolled" purposes.
+  var SCROLL_GESTURE_IDLE_MS = 150;
+
   function onScroll() {
+    // The app shell handles "viewport-scrolled" by dismissing viewport-anchored
+    // transient UI (selection popover, context menu, note viewer). That only
+    // needs to happen when a scroll STARTS — the handler is idempotent, so
+    // firing it every frame woke the app process 120×/s to redo nothing.
+    if (!scrollGestureActive) {
+      scrollGestureActive = true;
+      post("viewport-scrolled");
+    }
+    if (scrollIdleTimer) clearTimeout(scrollIdleTimer);
+    scrollIdleTimer = setTimeout(function () {
+      scrollIdleTimer = null;
+      scrollGestureActive = false;
+    }, SCROLL_GESTURE_IDLE_MS);
+
     if (scrollTicking) return;
     scrollTicking = true;
     requestAnimationFrame(function () {
       scrollTicking = false;
-      // Unconditional (reportScroll dedupes): the app shell hides the
-      // selection popover, whose position is viewport-anchored.
-      post("viewport-scrolled");
-      reportScroll(false);
+      var now = Date.now();
+      var since = now - lastScrollReportAt;
+      if (since >= SCROLL_REPORT_MS) {
+        lastScrollReportAt = now;
+        reportScroll(false);
+      } else if (!scrollTrailingTimer) {
+        // Always report the resting position, even when the gesture ends inside
+        // the throttle window.
+        scrollTrailingTimer = setTimeout(function () {
+          scrollTrailingTimer = null;
+          lastScrollReportAt = Date.now();
+          reportScroll(false);
+        }, SCROLL_REPORT_MS - since);
+      }
     });
   }
 
@@ -2056,12 +2092,54 @@ enum WebContentScript {
     // on subtree mutations, ignoring our own overlay churn. Observing the
     // documentElement survives full <body> replacement.
     if (window.MutationObserver) {
-      var remap = debounce(function () {
+      // A remap re-walks the entire DOM, rebuilds a per-character index of the
+      // whole page, and tears down and re-lays-out every highlight. On a page
+      // with a live region — a clock, a ticker, a video timestamp, a chat feed —
+      // mutations never stop, so a fixed 600ms debounce meant paying that
+      // forever at ~1.7Hz for as long as the tab stayed open.
+      //
+      // So: throttle rather than debounce, and let the interval adapt. A page
+      // that churns straight through a remap gets backed off geometrically; a
+      // page that had gone quiet — the SPA route change this observer exists for
+      // — keeps the responsive floor.
+      var REMAP_MIN_MS = 600;
+      var REMAP_MAX_MS = 10000;
+      var remapDelay = REMAP_MIN_MS;
+      var remapTimer = null;
+      var lastRemapAt = 0;
+      var remapWhenVisible = false;
+
+      function runRemap() {
+        remapTimer = null;
+        lastRemapAt = Date.now();
+        // A hidden page (background tab, off-screen split pane) is displaying
+        // none of this. Skip the work and catch up when it's looked at again.
+        if (document.visibilityState === "hidden") {
+          remapWhenVisible = true;
+          return;
+        }
         initialize(false); // resends init only if the text changed >15%
         pageTops = null;
         renderHighlights();
         reportScroll(true);
-      }, 600);
+      }
+
+      function remap() {
+        if (remapTimer) return; // already queued — it will see this mutation too
+        var quietFor = Date.now() - lastRemapAt;
+        remapDelay =
+          quietFor > remapDelay * 2
+            ? REMAP_MIN_MS
+            : Math.min(remapDelay * 2, REMAP_MAX_MS);
+        remapTimer = setTimeout(runRemap, remapDelay);
+      }
+
+      document.addEventListener("visibilitychange", function () {
+        if (document.visibilityState !== "visible" || !remapWhenVisible) return;
+        remapWhenVisible = false;
+        lastRemapAt = 0; // becoming visible is not "churn" — remap promptly
+        remap();
+      });
       // Our own transient drag chrome (the resize shield + user-select lock
       // style) is added/removed on document.body/head during a drag; those
       // mutations must not trigger a re-extract that rebuilds the handles

--- a/Vellum/Views/Web/WebContentScript.swift
+++ b/Vellum/Views/Web/WebContentScript.swift
@@ -1400,32 +1400,37 @@ enum WebContentScript {
   }
 
   var scrollTicking = false;
-  var scrollGestureActive = false;
   var scrollIdleTimer = null;
+  var lastDismissPostAt = 0;
   var lastScrollReportAt = 0;
   var scrollTrailingTimer = null;
   // Viewport reporting drives the page-number readout and the bookmark star,
   // and each call forces layout once per resolved bookmark. Neither consumer
   // needs anything close to the 120Hz a ProMotion scroll delivers.
   var SCROLL_REPORT_MS = 66;
-  // How long the page must stop moving before the next scroll counts as a new
-  // gesture for "viewport-scrolled" purposes.
-  var SCROLL_GESTURE_IDLE_MS = 150;
+  // The app shell dismisses viewport-anchored transient UI on "viewport-scrolled".
+  // It is ALMOST idempotent — a note composer younger than 0.4s is deliberately
+  // kept — so this cannot be a pure leading-edge post: during one long fling the
+  // composer would age past its grace period with no further event to dismiss
+  // it, and would sit pinned while the content scrolled out from under it.
+  // Re-posting a few times a second preserves that behavior at ~1/50th the
+  // wakeups of the per-frame post this replaces.
+  var SCROLL_DISMISS_MS = 400;
 
   function onScroll() {
-    // The app shell handles "viewport-scrolled" by dismissing viewport-anchored
-    // transient UI (selection popover, context menu, note viewer). That only
-    // needs to happen when a scroll STARTS — the handler is idempotent, so
-    // firing it every frame woke the app process 120×/s to redo nothing.
-    if (!scrollGestureActive) {
-      scrollGestureActive = true;
+    var dismissNow = Date.now();
+    if (dismissNow - lastDismissPostAt >= SCROLL_DISMISS_MS) {
+      lastDismissPostAt = dismissNow;
       post("viewport-scrolled");
     }
+    // Re-arm on the resting position too, so a gesture that ends inside the
+    // window still leaves the shell with a final dismissal.
     if (scrollIdleTimer) clearTimeout(scrollIdleTimer);
     scrollIdleTimer = setTimeout(function () {
       scrollIdleTimer = null;
-      scrollGestureActive = false;
-    }, SCROLL_GESTURE_IDLE_MS);
+      lastDismissPostAt = Date.now();
+      post("viewport-scrolled");
+    }, SCROLL_DISMISS_MS);
 
     if (scrollTicking) return;
     scrollTicking = true;
@@ -2107,6 +2112,13 @@ enum WebContentScript {
       // highlight can sit stale on a page that both re-renders AND churns
       // continuously, so it stays modest rather than maximally thrifty.
       var REMAP_MAX_MS = 5000;
+      // Quiet period after which the next mutation is treated as a fresh burst
+      // rather than continued churn. A FIXED constant, deliberately: scaling it
+      // off the current delay meant a page already backed off to REMAP_MAX_MS
+      // needed 2x that much silence to recover, so an SPA route change on a
+      // chatty page — exactly what this observer exists for — would remap at
+      // the 5s ceiling instead of the floor.
+      var REMAP_RESET_MS = 1500;
       var remapDelay = REMAP_MIN_MS;
       var remapTimer = null;
       var lastRemapAt = 0;
@@ -2115,8 +2127,11 @@ enum WebContentScript {
       function runRemap() {
         remapTimer = null;
         lastRemapAt = Date.now();
-        // A hidden page (background tab, off-screen split pane) is displaying
-        // none of this. Skip the work and catch up when it's looked at again.
+        // Nothing here is on screen while the page is hidden, so skip it and
+        // catch up on visibilitychange. NB: an inactive tab's web view is torn
+        // down rather than hidden, so in practice this fires for app
+        // backgrounding — where WebKit already throttles us — and is a
+        // belt-and-braces guard rather than a measured win.
         if (document.visibilityState === "hidden") {
           remapWhenVisible = true;
           return;
@@ -2131,7 +2146,7 @@ enum WebContentScript {
         if (remapTimer) return; // already queued — it will see this mutation too
         var quietFor = Date.now() - lastRemapAt;
         remapDelay =
-          quietFor > remapDelay * 2
+          quietFor > REMAP_RESET_MS
             ? REMAP_MIN_MS
             : Math.min(remapDelay * 2, REMAP_MAX_MS);
         remapTimer = setTimeout(runRemap, remapDelay);

--- a/Vellum/Views/Web/WebContentScript.swift
+++ b/Vellum/Views/Web/WebContentScript.swift
@@ -2103,7 +2103,10 @@ enum WebContentScript {
       // page that had gone quiet — the SPA route change this observer exists for
       // — keeps the responsive floor.
       var REMAP_MIN_MS = 600;
-      var REMAP_MAX_MS = 10000;
+      // Ceiling on the backoff. This is also the worst case for how long a
+      // highlight can sit stale on a page that both re-renders AND churns
+      // continuously, so it stays modest rather than maximally thrifty.
+      var REMAP_MAX_MS = 5000;
       var remapDelay = REMAP_MIN_MS;
       var remapTimer = null;
       var lastRemapAt = 0;


### PR DESCRIPTION
Investigation of the iPad battery drain, plus fixes for what it turned up.

## What the audit found

Good news first: there are **no repeating `Timer`s, no `CADisplayLink`, no JS `setInterval`, no background modes, and no `isIdleTimerDisabled`** anywhere in the iOS target. Nothing idles badly. The drain is work that's too expensive for how often it runs.

| # | What | When it fires | Cost |
|---|------|---------------|------|
| 1 | Whole-PDF rewrite per ink pause | ~every 1s while writing | Very high — disk + CPU |
| 2 | `dataRepresentation()` on main actor mid-stroke | up to 120 Hz while the Pencil moves | High — CPU, on the hot path |
| 3 | Full-page DOM re-extraction on any mutation | every 600 ms on live pages, forever | High — CPU, per open web tab |
| 4 | Per-frame IPC + forced layout while scrolling | every frame of every web scroll | Moderate |

---

# Design decisions

This section records *why* each change is shaped the way it is, including the background needed to evaluate it. Skip to "The changes" if you only want the diff summary.

## Background: what happens on every Pencil stroke

Vellum draws ink with **PencilKit**. A `PKCanvasView` sits over each visible PDF page; a `PKDrawing` (a Swift `struct`) holds *all* strokes on that canvas.

The load-bearing fact: **`canvasViewDrawingDidChange` is not a "stroke finished" callback.** PencilKit fires it repeatedly *while* a single stroke is being drawn, as the live stroke is progressively committed. On a 120 Hz ProMotion display that is many calls per second.

Each call used to run:

```
persist(drawing:page:)
  ├─ let data = drawing.dataRepresentation()   ← SERIALIZE, synchronously, on the main actor
  └─ Task { sleep 700ms; write to disk }        ← debounced
```

And "write to disk" (`InkDiskWriter.writeSync`) meant:

```
Data(contentsOf: url)              // read the ENTIRE pdf off disk
PDFDocument(data: originalData)    // parse the ENTIRE pdf
PdfInk.apply(drawing, to: pdfPage) // the actual change — one page
document.dataRepresentation()      // re-serialize the ENTIRE pdf
  // then, on iPadOS 26 (pdfKitDropsCustomKeys):
  ClassicPdfFile(data:)            // parse the whole thing AGAIN
  rehydrateAnnotationMetadata      // restore Vellum's custom keys
  rehydrateBookmarkMetadata
  restoreInfoDictionary
writeAndRefreshCache(data, path:)  // write the ENTIRE pdf back to disk
```

The whole-file rewrite is not gratuitous: PDFKit offers no in-place single-page mutation here, `dataRepresentation()` serializes the whole document, and on iPadOS 26 that rewrite *drops application-defined keys* — so Vellum's custom annotation fields have to be parsed back in afterwards. On a 30 MB textbook, one pause in handwriting cost ~30 MB read + ~30 MB written + two full parses.

## Decision 1 — Why `@MainActor` made the encoding so expensive

`InkController_iOS` is annotated `@MainActor`, which pins **every method and property on the class to the main thread**. That is the correct default for something driving UI (it's why `drawingVersion &+= 1` can safely trigger a SwiftUI re-render), but it is not a free annotation — it's a promise that everything in the class is cheap enough to run on the render thread.

The main thread produces frames. At 120 Hz that is an **8.3 ms budget per frame**. Work done in a `@MainActor` method is subtracted directly from it.

`drawing.dataRepresentation()` violated that promise twice over:

- **It is O(everything on the page), not O(what changed).** A `PKDrawing` holds every stroke on the canvas; serializing walks all of them, including each stroke's full array of `PKStrokePoint`s (location, force, azimuth, altitude, timestamp per sample). Cost therefore *grows as you write* — the 50th stroke on a page costs roughly 50× what the 1st did.
- **It is synchronous.** No `await`, no yield. The main thread does the work before proceeding.

Combined with the callback firing mid-stroke, the actual behaviour was: *for every PencilKit callback, on the main thread, serialize every stroke on the page* — while the display is rendering at 120 Hz and the digitizer is sampling at its maximum rate.

**Why this is a battery problem and not only a stutter problem:** a CPU is most efficient when it can finish and idle between frames, and dynamic power scales roughly with voltage² × frequency, with the governor raising the clock when it sees a saturated thread. A short burst of work repeated 100+ times a second is energetically much worse than the same total work done once — it both prevents the core from sleeping and pushes it to a higher-voltage operating point. So "do it once per write, off the main actor" is a battery fix, not just a smoothness fix.

**What changed:**

```swift
// before: [Int: (data: Data, path: String)]  — encoded bytes
// after:  [String: [Int: PKDrawing]]         — the drawing itself
```

The callback now performs a dictionary insert (O(1), no encoding). Serialization moved to where the write happens, inside `PdfFileGate`, off the main thread.

**Why this is legal:** `PKDrawing` is a `struct` declared `Sendable` in the SDK — `PencilKit.swiftinterface` reads `public struct PKDrawing : Swift::Sendable` — so it is safe to hand across a concurrency boundary. If it weren't, we'd be stuck encoding on the main actor purely to have something safe to pass, which is very likely why the original code was written that way.

**Bonus that fell out:** the old writer received `Data` and called `PKDrawing(data:)` to decode it back before applying. Passing the drawing straight through removes both halves of a pointless round-trip.

## Decision 2 — Why the pending map is keyed by path, not just page

The type is `[String: [Int: PKDrawing]]` — file path, then page number. The nesting is not incidental: switching tabs mid-debounce can leave two different documents dirty simultaneously, and page 1 of document A must never be written into page 1 of document B. The old per-page map carried the path alongside each entry; grouping by path instead is what makes single-cycle batching per file possible.

## Decision 3 — Batching, and an honest bound on its value

`InkDiskWriter.write` now takes `[Int: PKDrawing]` and applies every dirty page while the document is open, serializing once, instead of paying the entire read → parse → serialize → re-parse → write cycle per page.

**Caveat, stated deliberately:** this win is smaller in practice than it sounds. You normally write on one page at a time, so most debounce windows contain a single dirty page and there is nothing to batch. This removes a worst case, not the common case. The genuinely large wins here are Decision 1 (main-actor encoding) and Decision 4 (fewer writes).

## Decision 4 — Debounce 700ms → 2500ms, and why `maxDirtyAge` makes durability *better*

**Debounce vs throttle** matters here. A *debounce* waits for N ms of silence then acts; every new event restarts the timer. A *throttle* acts at most once per N ms. The critical property of a debounce: **on a stream that never goes quiet, it may never fire at all.**

At 700 ms, the ordinary pauses between words were long enough to trigger a full-file rewrite, so writing a paragraph produced a near-continuous stream of them.

The obvious objection is durability. Two things answer it:

1. **Durability does not rest on the debounce.** Ink is flushed unconditionally when ink mode turns off (`flushPendingInk`), when a pane closes, and before the scene suspends (`flushPendingInkAndWait`, from the `beginBackgroundTask` window in `VellumApp_iOS`). The debounce bounds only what a *hard crash* could lose.

2. **`maxDirtyAge` makes the worst case strictly better than before.** Because a debounce restarts on every event, uninterrupted writing under the old code would **never write at all** — an unbounded window. The new cap forces a write once the batch has been dirty for 15 s regardless:

```swift
let now = ContinuousClock.now
let dirtiedAt = oldestDirtyAt ?? now
oldestDirtyAt = dirtiedAt
guard now - dirtiedAt < Self.maxDirtyAge else {
    flushPendingInk()      // stop deferring — write now
    return
}
```

Worst-case dirty-to-disk latency is now `maxDirtyAge + persistDebounce` ≈ 17.5 s, where it was previously unbounded. **Changing a debounce is never purely a performance decision** — this one is a durability change that happens to also reduce writes.

## Decision 5 — Why the web remap became a throttle instead of a debounce

The content script observes `document.documentElement` with `{childList, subtree, characterData}` — the widest possible scope — because SPA re-renders detach the text nodes highlights are anchored to.

Each remap runs `buildTextMap()` (a `TreeWalker` over the whole DOM, concatenating all text, then building `normMap` — an array with **one entry per character**; a 200 KB article means a ~200,000-element array rebuilt from scratch), `buildPages()`, and `renderHighlights()` (tears down and rebuilds every highlight div, calling `getClientRects()` per highlight — a forced synchronous layout).

At a fixed 600 ms debounce this ran at ~1.7 Hz *forever* on any page with a live region — a clock, ticker, video timestamp, or chat feed — since mutations arrive in bursts and never stop.

**Why a throttle:** bounded rate and bounded latency under a continuous stream, which is exactly the failure mode. **Why adaptive:** a fixed long interval would punish the quiet SPA-navigation case this observer exists for.

```js
var REMAP_MIN_MS = 600;      // responsive floor
var REMAP_MAX_MS = 5000;     // backoff ceiling
var REMAP_RESET_MS = 1500;   // quiet period that counts as a fresh burst
```

A page that churns straight through a remap doubles its interval (600 → 1200 → 2400 → 5000, settling there). A page that had gone quiet longer than `REMAP_RESET_MS` resets to the floor, so an SPA route change still remaps promptly.

**Why the ceiling is 5 s and not larger:** that ceiling is also the worst case for how long a highlight can sit stale on a page that both re-renders *and* churns. It is deliberately not maximally thrifty.

## Decision 6 — Scroll: two different consumers, two different rates

`WKWebView` runs web content in a **separate process**; JS→Swift messages cross via IPC and **each crossing wakes the receiving process**. `requestAnimationFrame` correctly limited the old code to once per rendered frame — but that is 120/s on ProMotion.

The two consumers have genuinely different requirements, so they now have different rates:

- `viewport-scrolled` (dismiss transient UI): ~2.5 Hz — `SCROLL_DISMISS_MS = 400`
- `reportScroll` (page-number readout, bookmark star; forces layout once per resolved bookmark): ~15 Hz — `SCROLL_REPORT_MS = 66`

Both have trailing calls so the resting position is always reported.

**Why not leading-edge-only for `viewport-scrolled`** — see Decision 9; that was the original design and it was wrong.

## Decision 7 — Why a failed write must requeue, and why the retry is bounded

`drainPendingInk` clears `pendingDrawings` *before* awaiting the write, and every failure path in `writeSync` used to be silently swallowed (`try?`, bare `guard ... else { return }`). Batching made this materially worse: previously one failure lost one page's strokes; batched, one transient read failure — an iCloud eviction mid-write — takes a whole window's work.

`write` now returns `Bool` and failed pages go back:

```swift
private func requeue(_ pages: [Int: PKDrawing], path: String) {
    var current = pendingDrawings[path] ?? [:]
    for (page, drawing) in pages where current[page] == nil {   // ← don't bury a NEWER drawing
        current[page] = drawing
    }
    pendingDrawings[path] = current
    if oldestDirtyAt == nil { oldestDirtyAt = ContinuousClock.now }
}
```

`where current[page] == nil` is load-bearing. Actors are **reentrant across `await`** — a stroke can land while the failed write was in flight — so requeuing must never overwrite a newer drawing with the older copy.

The retry is deliberately **not** a loop. Retrying tightly would spin against the disk, and `flushPendingInkAndWait`'s `while` would never terminate on a permanently unwritable file — *while the app holds a scene-suspend assertion*. So the drain returns on failure and the flush is bounded by `maxDrainAttempts`.

## Decision 8 — Why the task captures are strong, not `[weak self]`

Both the debounce task and the drain task capture `self` **strongly**, which looks wrong at first glance.

The pending drawings live *on the controller*. A `[weak self]` capture would silently drop them if the controller went away during the window — closing a tab moments after a stroke would lose ink. The old code was safe here by accident: its per-page tasks captured the encoded `Data` and path *by value* and called a `static` writer, so they completed even after the controller died. Moving the pending state onto `self` quietly removed that guarantee.

The retain is bounded, so it is not a leak: the debounce task ends after `persistDebounce` or is cancelled by the next stroke, the drain ends with its writes, and a completed `Task` releases its closure — which breaks the cycle.

## Decision 9 — Corrections made during review

Three of my own design claims turned out to be wrong. Recording them because the reasoning matters more than the diff:

**"The `viewport-scrolled` handler is idempotent, so fire only on the leading edge."** Not quite true — it deliberately *keeps* a note composer younger than 0.4 s, so the placement tap's own scroll nudge doesn't dismiss what you just opened. With leading-edge-only firing, during one long fling the composer would age past that grace period with no further event to dismiss it, and would sit pinned while content scrolled beneath it. Hence the 400 ms periodic re-post.

**The backoff reset threshold was self-defeating.** It was originally `quietFor > remapDelay * 2` — scaled off the *current* delay — so a page already at the 5 s ceiling needed 10 s of silence to recover. An SPA route change on a chatty page would remap at 5 s, i.e. the observer would be slowest on exactly the case it exists for. Now a fixed `REMAP_RESET_MS`.

**`testLatestDrawingForAPageWins` was vacuous.** It asserted `hasInk == false` on a document that began with *no ink*, so it passed whether or not anything was ever written — it could not distinguish "last write wins" from "persistence is entirely broken". It now establishes the positive first. General rule: a test asserting a negative is only meaningful once you've proven the positive was achievable.

## Decision 10 — What was deliberately NOT changed

**The per-page `PKCanvasView` cache.** The initial investigation flagged this as a memory problem: `containers` never evicts, and canvases are super-sampled up to 4× (16× the pixel area) for crispness under zoom.

Reading `InkOverlayProvider_iOS.swift` in full corrected that. `willEndDisplayingOverlayView` **already** drops off-screen pages back to `K=1`, so only the handful of on-screen canvases ever hold a large bitmap; the retained cost per visited page is far smaller than claimed.

Implementing eviction would also be actively hazardous: `cachedStrokes(forPage:)` feeds the sidebar's Handwriting chips, and evicting a canvas whose ink hasn't flushed would **lose strokes**. Real hazard, small benefit — so the finding was corrected rather than a change shipped to justify it.

**One review finding was rejected.** The reviewer flagged the `PKDrawing`-is-`Sendable` comment as asserted-but-unverified. It was verified before being written: the iOS 27 SDK's `PencilKit.swiftinterface` declares `public struct PKDrawing : Swift::Sendable`.

---

# The changes

**1 — Batch ink writes into one file cycle.** `InkDiskWriter` takes `[page: PKDrawing]` and applies every dirty page in a single read-modify-write.

**2 — Stop serializing the drawing on the main actor mid-stroke.** Pending state holds the `PKDrawing`; encoding happens once per write, off the main actor. Removes the `PKDrawing(data:)` round-trip too.

**3 — Debounce 700 ms → 2.5 s, plus a 15 s `maxDirtyAge` cap** that bounds the crash window where it previously wasn't bounded.

**4 — Adaptive remap throttle** for the page-mutation observer (600 ms floor, 5 s ceiling, 1.5 s reset), skipping hidden pages.

**5 — Scroll rate limits** — `viewport-scrolled` at ~2.5 Hz, `reportScroll` at ~15 Hz, both with trailing calls.

**6 — Data-loss fixes from review** — flush before pane deregistration; requeue failed writes without burying newer drawings; bounded flush retries; strong task captures.

## Commits

| Commit | What |
|---|---|
| `3e1491b` | The four battery fixes |
| `39c51af` | Self-review: strong `self` captures; backoff ceiling 10 s → 5 s |
| `ecb44d6` | Independent review: four defects, two of them data-loss |

## Caveats

- **The ranking above is from reading the code, not measuring it.** Confirm with Instruments before assuming the ordering: *File Activity* during Pencil annotation for #1 (you should see the full document size written repeatedly — the clearest possible confirmation), *Time Profiler* on the main thread for #2.
- Decisions 5 and 6 are in the shared content script, so they affect macOS too. Both are wins on either platform.
- **Not yet verified on a physical iPad** — the ink path in particular deserves a real-device pass.

## Tests

`InkPersistenceTests` 16/16 green; full suite was 148/148 at the first commit. New cases cover multi-page batching, out-of-range pages not discarding valid ones, both pages of a two-page debounce window persisting, last-write-wins within a window, two documents dirty at once staying with their own files, a failed write retrying successfully, and the debounce firing without an explicit flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
