### PR TITLE
Harden AI Markdown rendering

### DIFF
--- a/Tests/AiMarkdownRegressionTests.swift
+++ b/Tests/AiMarkdownRegressionTests.swift
@@ -192,6 +192,33 @@ final class AiMarkdownRegressionTests: XCTestCase {
         XCTAssertFalse(visible.contains("*"))
     }
 
+    func testMalformedEmphasisRecoveryPreservesLiteralOperatorsCodeAndWhitespace() {
+        let source = """
+        2 * 3 and **bold**
+        `a*b` stays code
+
+        **What **FOR UPDATE** does**
+        """
+        let pieces = InlineMarkdown.pieces(in: source)
+        let visible = pieces.compactMap { piece -> String? in
+            guard case .prose(let prose) = piece else { return nil }
+            return String(prose.characters)
+        }.joined()
+
+        XCTAssertEqual(
+            visible,
+            """
+            2 * 3 and bold
+            a*b stays code
+
+            What FOR UPDATE does
+            """
+        )
+        XCTAssertTrue(visible.contains("2 * 3"))
+        XCTAssertTrue(visible.contains("a*b"))
+        XCTAssertTrue(visible.contains("\n\n"))
+    }
+
     func testCorpusLayoutIsFiniteAtNarrowAndDefaultWidths() {
         let attributed = AiAttributedRenderer.attributedString(
             for: Self.corpus,
@@ -215,6 +242,111 @@ final class AiMarkdownRegressionTests: XCTestCase {
             guard let attachment = value as? NSTextAttachment else { return }
             XCTAssertLessThanOrEqual(attachment.bounds.width, 120)
         }
+    }
+
+    func testNestedListAttachmentsFitIndentedLineFragments() {
+        let source = """
+        - Parent
+            - A deliberately wide equation $\\frac{abcdefghijklmnopqrstuvwxyz}{1234567890}$
+        """
+        let attributed = AiAttributedRenderer.attributedString(
+            for: source,
+            color: .labelColor,
+            secondary: .secondaryLabelColor
+        )
+
+        for width in [248.0, 120.0] as [CGFloat] {
+            let fitted = MessageContainerView.fittedAttachments(
+                in: attributed,
+                width: width
+            )
+            let storage = NSTextStorage(attributedString: fitted)
+            let container = NSTextContainer(
+                size: NSSize(width: width, height: .greatestFiniteMagnitude)
+            )
+            container.lineFragmentPadding = 0
+            let layout = NSLayoutManager()
+            layout.addTextContainer(container)
+            storage.addLayoutManager(layout)
+            layout.ensureLayout(for: container)
+
+            fitted.enumerateAttribute(
+                .attachment,
+                in: NSRange(location: 0, length: fitted.length)
+            ) { value, range, _ in
+                guard let attachment = value as? NSTextAttachment else { return }
+                let paragraph = fitted.attribute(
+                    .paragraphStyle,
+                    at: range.location,
+                    effectiveRange: nil
+                ) as? NSParagraphStyle
+                let available = width - max(
+                    paragraph?.firstLineHeadIndent ?? 0,
+                    paragraph?.headIndent ?? 0
+                )
+                XCTAssertLessThanOrEqual(
+                    attachment.bounds.width,
+                    available + 0.5,
+                    "attachment exceeds indented line width at \(width)"
+                )
+
+                let glyphRange = layout.glyphRange(
+                    forCharacterRange: range,
+                    actualCharacterRange: nil
+                )
+                guard glyphRange.length > 0 else {
+                    return XCTFail("attachment produced no glyph")
+                }
+                let attachmentRect = layout.boundingRect(
+                    forGlyphRange: glyphRange,
+                    in: container
+                )
+                let lineRect = layout.lineFragmentUsedRect(
+                    forGlyphAt: glyphRange.location,
+                    effectiveRange: nil
+                )
+                XCTAssertLessThanOrEqual(
+                    attachmentRect.maxX,
+                    lineRect.maxX + 0.5,
+                    "attachment clips its line fragment at \(width)"
+                )
+                XCTAssertLessThanOrEqual(attachmentRect.maxX, width + 0.5)
+            }
+        }
+    }
+
+    func testDecorativeRuleDoesNotLeakIntoQuotesOrAccessibility() {
+        let attributed = AiAttributedRenderer.attributedString(
+            for: "Before\n\n---\n\nAfter",
+            color: .labelColor,
+            secondary: .secondaryLabelColor
+        )
+        XCTAssertTrue(attributed.string.contains("\u{FFFC}"))
+
+        let plain = MessageContainerView.plainText(
+            in: attributed,
+            range: NSRange(location: 0, length: attributed.length),
+            mathDelimiters: true
+        )
+        XCTAssertFalse(plain.contains("\u{FFFC}"))
+        XCTAssertEqual(
+            plain.split(whereSeparator: \.isWhitespace).joined(separator: " "),
+            "Before After"
+        )
+
+        let view = MessageContainerView(
+            frame: NSRect(x: 0, y: 0, width: 248, height: 80)
+        )
+        view.setAttributed(
+            attributed,
+            content: "Before\n\n---\n\nAfter",
+            color: .labelColor,
+            secondary: .secondaryLabelColor
+        )
+        let accessibilityValue = view.textView.accessibilityValue() as? String
+        XCTAssertNotNil(accessibilityValue)
+        XCTAssertFalse(accessibilityValue?.contains("\u{FFFC}") ?? true)
+        XCTAssertFalse(accessibilityValue?.contains("---") ?? true)
     }
 
     func testLiveTextViewUsesSameLayoutEngineAsMeasurement() {

--- a/Tests/AiMarkdownRegressionTests.swift
+++ b/Tests/AiMarkdownRegressionTests.swift
@@ -1,0 +1,227 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Vellum
+
+/// A content-shaped regression corpus for issue #57. These tests exercise the
+/// same parser and AppKit renderer used by assistant messages, including the
+/// incomplete prefixes seen while a response is streaming.
+@MainActor
+final class AiMarkdownRegressionTests: XCTestCase {
+    private static let corpus = #"""
+    # Model comparison
+
+    This is **bold**, *italic*, and `inline code`.
+
+    ### Probability
+
+    The model learns **the probability of $Y$ given $X$**.
+
+    ---
+
+    - Parent
+      - Nested child with $x^2$
+        1. Deep ordered child
+    - Sibling
+
+    $$
+    P(Y \mid X) = \frac{P(X,Y)}{P(X)}
+    $$
+
+    ```swift
+    let value = "**not emphasis inside code**"
+    ```
+
+    | Model | Learns |
+    |:------|-------:|
+    | Discriminative | $P(Y \mid X)$ |
+    | Generative | $P(X,Y)$ |
+    """#
+
+    func testCorpusContainsEveryExpectedBlockKind() {
+        let blocks = MarkdownParser.parse(Self.corpus)
+        XCTAssertTrue(blocks.contains { if case .heading = $0 { true } else { false } })
+        XCTAssertTrue(blocks.contains(.rule))
+        XCTAssertTrue(blocks.contains { if case .list = $0 { true } else { false } })
+        XCTAssertTrue(blocks.contains { if case .math = $0 { true } else { false } })
+        XCTAssertTrue(blocks.contains { if case .code = $0 { true } else { false } })
+        XCTAssertTrue(blocks.contains { if case .table = $0 { true } else { false } })
+    }
+
+    func testAllSixHeadingLevelsAndRuleVariants() {
+        for level in 1...6 {
+            let source = "\(String(repeating: "#", count: level)) Heading"
+            XCTAssertEqual(MarkdownParser.parse(source), [.heading(level, "Heading")])
+        }
+        for source in ["---", "***", "___", "- - -", "  -----  "] {
+            XCTAssertEqual(MarkdownParser.parse(source), [.rule], source)
+        }
+    }
+
+    func testEmphasisCanCrossMultipleInlineEquations() {
+        let pieces = InlineMarkdown.pieces(in: "**the probability of $Y$ given $X$**")
+        let proseRuns = pieces.flatMap { piece -> [(String, Bool)] in
+            guard case .prose(let attributed) = piece else { return [] }
+            return attributed.runs.map { run in
+                (
+                    String(attributed[run.range].characters),
+                    run.inlinePresentationIntent?.contains(.stronglyEmphasized) ?? false
+                )
+            }
+        }
+        XCTAssertFalse(proseRuns.contains { $0.0.contains("*") }, "\(proseRuns)")
+        XCTAssertTrue(proseRuns.filter { !$0.0.isEmpty }.allSatisfy(\.1), "\(proseRuns)")
+        XCTAssertEqual(pieces.compactMap {
+            if case .math(let latex) = $0 { latex } else { nil }
+        }, ["Y", "X"])
+    }
+
+    func testNestedAndMixedListsPreserveDepthAndMarkers() {
+        let blocks = MarkdownParser.parse(
+            "- Parent\n  - Child\n    3. Deep child\n- Sibling"
+        )
+        guard case .list(let items) = blocks.first else {
+            return XCTFail("expected semantic nested list, got \(blocks)")
+        }
+        XCTAssertEqual(items.map(\.depth), [0, 1, 2, 0])
+        XCTAssertEqual(items.map(\.marker), [
+            .unordered, .unordered, .ordered(3), .unordered,
+        ])
+        XCTAssertEqual(items.map(\.text), ["Parent", "Child", "Deep child", "Sibling"])
+        guard case .list(let customNumbered) = MarkdownParser.parse("3. Three").first else {
+            return XCTFail("custom list numbering must be preserved")
+        }
+        XCTAssertEqual(customNumbered.first?.marker, .ordered(3))
+    }
+
+    func testCodeAndTableContentRemainLiteralAndStructured() {
+        XCTAssertEqual(
+            MarkdownParser.parse("```swift\n# not a heading\n**not bold**\n```"),
+            [.code("# not a heading\n**not bold**")]
+        )
+        let blocks = MarkdownParser.parse("| A | B |\n|---|:---:|\n| 1 | 2 |")
+        guard case .table(let table) = blocks.first else {
+            return XCTFail("expected table, got \(blocks)")
+        }
+        XCTAssertTrue(table.contains("A"))
+        XCTAssertTrue(table.contains("2"))
+        XCTAssertFalse(table.contains("---"))
+    }
+
+    func testDisplayAndInlineMathRenderOrDegradeWithoutLosingSource() {
+        XCTAssertEqual(
+            MarkdownParser.parse("$$\nP(Y \\mid X)\n$$"),
+            [.math("P(Y \\mid X)")]
+        )
+        XCTAssertEqual(
+            MarkdownParser.parse("before $x^2$ after"),
+            [.paragraph("before $x^2$ after")]
+        )
+        XCTAssertNotNil(
+            MathRenderer.render(
+                latex: "x_1, x_2, \\dots, x_n",
+                fontSize: 16,
+                color: .labelColor,
+                display: true
+            )
+        )
+    }
+
+    func testStreamingBoundariesAlwaysProduceRenderableOutput() {
+        let prefixes = [
+            "#", "# ", "# Heading\n\n**",
+            "# Heading\n\n**bold",
+            "# Heading\n\n**bold $x",
+            "# Heading\n\n**bold $x$ text**\n\n$",
+            "# Heading\n\n**bold $x$ text**\n\n$$\n\\frac{a}",
+            "# Heading\n\n**bold $x$ text**\n\n$$\n\\frac{a}{b}\n$$",
+            Self.corpus,
+        ]
+        for prefix in prefixes {
+            let blocks = MarkdownParser.parse(prefix)
+            XCTAssertFalse(blocks.isEmpty, prefix.debugDescription)
+            let rendered = AiAttributedRenderer.attributedString(
+                for: prefix,
+                color: .labelColor,
+                secondary: .secondaryLabelColor
+            )
+            XCTAssertGreaterThan(rendered.length, 0, prefix.debugDescription)
+        }
+    }
+
+    func testMalformedMarkdownDegradesToReadableText() {
+        let malformed = [
+            "**unclosed emphasis",
+            "[broken link](https://example.com",
+            "```\nunclosed code",
+            "$$\n\\frac{a}{b}",
+            "| header | only",
+            "-",
+            "####### not a heading",
+        ]
+        for source in malformed {
+            let rendered = AiAttributedRenderer.attributedString(
+                for: source,
+                color: .labelColor,
+                secondary: .secondaryLabelColor
+            )
+            XCTAssertGreaterThan(rendered.length, 0, source)
+            XCTAssertTrue(
+                MessageContainerView.measureHeight(rendered, width: 120).isFinite,
+                source
+            )
+        }
+        XCTAssertEqual(
+            MarkdownParser.parse("$$\n\\frac{a}{b}"),
+            [.code("\\frac{a}{b}")]
+        )
+    }
+
+    func testOverlappingModelEmphasisDoesNotLeakSyntax() {
+        let pieces = InlineMarkdown.pieces(
+            in: "**What **FOR UPDATE SKIP LOCKED** does** and *an *overlap* here*"
+        )
+        let visible = pieces.compactMap { piece -> String? in
+            guard case .prose(let prose) = piece else { return nil }
+            return String(prose.characters)
+        }.joined()
+        XCTAssertEqual(
+            visible,
+            "What FOR UPDATE SKIP LOCKED does and an overlap here"
+        )
+        XCTAssertFalse(visible.contains("*"))
+    }
+
+    func testCorpusLayoutIsFiniteAtNarrowAndDefaultWidths() {
+        let attributed = AiAttributedRenderer.attributedString(
+            for: Self.corpus,
+            color: .labelColor,
+            secondary: .secondaryLabelColor
+        )
+        for width in [120.0, 248.0] as [CGFloat] {
+            let height = MessageContainerView.measureHeight(attributed, width: width)
+            XCTAssertTrue(height.isFinite, "non-finite height at \(width)")
+            XCTAssertGreaterThan(height, 100, "corpus unexpectedly collapsed at \(width)")
+        }
+
+        let narrow = MessageContainerView.fittedAttachments(
+            in: attributed,
+            width: 120
+        )
+        narrow.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: narrow.length)
+        ) { value, _, _ in
+            guard let attachment = value as? NSTextAttachment else { return }
+            XCTAssertLessThanOrEqual(attachment.bounds.width, 120)
+        }
+    }
+
+    func testLiveTextViewUsesSameLayoutEngineAsMeasurement() {
+        let container = MessageContainerView(
+            frame: NSRect(x: 0, y: 0, width: 248, height: 10)
+        )
+        XCTAssertNil(container.textView.textLayoutManager)
+        XCTAssertNotNil(container.textView.layoutManager)
+    }
+}

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		43C780BABA587B2775DFC01E /* StorageInventory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F3FC8BBC540C8F18FE3B31 /* StorageInventory.swift */; };
 		4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */; };
 		46937483DA3925D41C984167 /* KaTeX_SansSerif-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = F8BEC014138483BE0B9DC274 /* KaTeX_SansSerif-Regular.woff2 */; };
+		49311DE585F9B39D74851556 /* InlineMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 722D70E7D214B32DC645357B /* InlineMarkdown.swift */; };
 		4B759FBB179307FE097DA861 /* StorageLocationChoiceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */; };
 		4E8BAA1F3AEC100D4C768AFA /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B863B676278E0E8D3C2EDB /* PaneTree.swift */; };
 		4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */; };
@@ -142,6 +143,7 @@
 		F375A6682F4CEFF5406ADD9D /* OAuthLoopbackServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C5B78507B70CB73698D8DC4 /* OAuthLoopbackServer.swift */; };
 		F5DFB55D5AEB2B65E76E5613 /* AppStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8909CC21C72AF947D20B4B6C /* AppStore.swift */; };
 		F9DA8014506FBB48C440F718 /* AiStreaming.swift in Sources */ = {isa = PBXBuildFile; fileRef = E201F2530645C6348ECC59AA /* AiStreaming.swift */; };
+		FDB49717936F016C08257C07 /* AiMarkdownRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9455F4672DDB4CED6E04F89C /* AiMarkdownRegressionTests.swift */; };
 		FE3F6412427EE4948EC38358 /* katex.min.css in Resources */ = {isa = PBXBuildFile; fileRef = BA27035FFAE43080C7118AC4 /* katex.min.css */; };
 		FE7D8E1CF0734B927687D5AF /* OpenRouterClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96768879872A93B8FD39C342 /* OpenRouterClient.swift */; };
 		FF8B0D4EDFA98B3310F21727 /* VellumBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95809D33AB6DF0D9BCF1BE88 /* VellumBundle.swift */; };
@@ -210,6 +212,7 @@
 		6F791F226FCC023AA19F7365 /* PdfSessionBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfSessionBackend.swift; sourceTree = "<group>"; };
 		709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableMessageTests.swift; sourceTree = "<group>"; };
 		71A415874AABA26AABBEF9B8 /* KaTeX_Size4-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Size4-Regular.woff2"; sourceTree = "<group>"; };
+		722D70E7D214B32DC645357B /* InlineMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMarkdown.swift; sourceTree = "<group>"; };
 		723EC058218A6DF8D994CC26 /* UpdateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateChecker.swift; sourceTree = "<group>"; };
 		7280818785023514C87C04C9 /* SessionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionService.swift; sourceTree = "<group>"; };
 		73294273D1991135AD0F100E /* index.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
@@ -236,6 +239,7 @@
 		90C50948404B30999979C84A /* VellumBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VellumBundleTests.swift; sourceTree = "<group>"; };
 		920042E47739D0327A193A1C /* KaTeX_AMS-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_AMS-Regular.woff2"; sourceTree = "<group>"; };
 		9304E8D40BBDAA6890D83939 /* KaTeX_Fraktur-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Fraktur-Regular.woff2"; sourceTree = "<group>"; };
+		9455F4672DDB4CED6E04F89C /* AiMarkdownRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiMarkdownRegressionTests.swift; sourceTree = "<group>"; };
 		95809D33AB6DF0D9BCF1BE88 /* VellumBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VellumBundle.swift; sourceTree = "<group>"; };
 		96768879872A93B8FD39C342 /* OpenRouterClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRouterClient.swift; sourceTree = "<group>"; };
 		96B5040705B954B3A0A26A2E /* KaTeX_Fraktur-Bold.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Fraktur-Bold.woff2"; sourceTree = "<group>"; };
@@ -381,6 +385,7 @@
 			isa = PBXGroup;
 			children = (
 				327F0E350D7D13A26878EB77 /* AiConversationStoreTests.swift */,
+				9455F4672DDB4CED6E04F89C /* AiMarkdownRegressionTests.swift */,
 				4AA459842CA86BEED9D34C1E /* AiPipelineTests.swift */,
 				F125F1382328217B11BF1DB2 /* AttachmentDropTests.swift */,
 				E9CE9BA76EA961FB5939EDCE /* DocumentDataStoreTests.swift */,
@@ -425,6 +430,7 @@
 				C4DE459571959DABFA99D4BB /* AiSettingsPanel.swift */,
 				5DFD2EC2ED5A947809EA139F /* AttachmentDrop.swift */,
 				43D27ECCD653EDD01DC2A624 /* ComposerReferences.swift */,
+				722D70E7D214B32DC645357B /* InlineMarkdown.swift */,
 				8A774391C8C286453B790F75 /* MarkdownMessage.swift */,
 				C8DCF286D5E58E45AB3FABA8 /* MathRenderer.swift */,
 				7B43A2E8F7A54C9B8E4E160D /* ModelSelector.swift */,
@@ -816,6 +822,7 @@
 				8DDA7D560DAB61C377817B0D /* FindBar.swift in Sources */,
 				4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */,
 				4FF972F2B1437D5D46AE6BA4 /* HighlightLayer.swift in Sources */,
+				49311DE585F9B39D74851556 /* InlineMarkdown.swift in Sources */,
 				D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */,
 				E5F120A320C5FC13A9026B70 /* MarkdownMessage.swift in Sources */,
 				ED7C505CE3E48CE35C600873 /* MathRenderer.swift in Sources */,
@@ -885,6 +892,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5FF82C62FE4C7CC82FD160FD /* AiConversationStoreTests.swift in Sources */,
+				FDB49717936F016C08257C07 /* AiMarkdownRegressionTests.swift in Sources */,
 				C529F97AB901B963D8DB4726 /* AiPipelineTests.swift in Sources */,
 				0A8D06EC43340A3149052C29 /* AttachmentDropTests.swift in Sources */,
 				252A859CBF3B6F40740EC8BB /* DocumentDataStoreTests.swift in Sources */,

--- a/Vellum/Views/AI/InlineMarkdown.swift
+++ b/Vellum/Views/AI/InlineMarkdown.swift
@@ -14,6 +14,19 @@ enum InlinePiece {
 enum InlineMarkdown {
     private static let placeholder: Character = "\u{FFFC}"
 
+    private struct Delimiter {
+        let range: Range<String.Index>
+        let marker: Character
+        let length: Int
+        let canOpen: Bool
+        let canClose: Bool
+    }
+
+    private struct DelimiterKind: Hashable {
+        let marker: Character
+        let length: Int
+    }
+
     nonisolated static func pieces(in source: String) -> [InlinePiece] {
         let segments = MathRenderer.segments(in: source)
         let equations = segments.compactMap { segment -> String? in
@@ -73,11 +86,10 @@ enum InlineMarkdown {
         )) ?? AttributedString(source)
 
         let rendered = String(parsed.characters)
-        let leakedStrong = source.contains("**") && rendered.contains("**")
-        let leakedUnderscoreStrong = source.contains("__") && rendered.contains("__")
-        let starCount = source.filter { $0 == "*" }.count
-        let leakedEmphasis = starCount >= 2 && rendered.contains("*")
-        guard leakedStrong || leakedUnderscoreStrong || leakedEmphasis else {
+        guard let repaired = repairedMalformedEmphasis(
+            in: source,
+            rendered: rendered
+        ) else {
             return parsed
         }
 
@@ -85,24 +97,145 @@ enum InlineMarkdown {
         // `**What **FOR UPDATE** does**`. CommonMark intentionally rejects that
         // shape and Foundation returns every marker literally. In a chat reply,
         // readable plain prose is a better failure mode than leaking syntax.
-        // Only run this recovery when Foundation demonstrably leaked markers;
-        // valid Markdown keeps all of its native attributes.
-        let escapedStar = "\u{E000}"
-        let escapedUnderscore = "\u{E001}"
-        var repaired = source
-            .replacingOccurrences(of: "\\*", with: escapedStar)
-            .replacingOccurrences(of: "\\_", with: escapedUnderscore)
-            .replacingOccurrences(of: "**", with: "")
-            .replacingOccurrences(of: "__", with: "")
-            .replacingOccurrences(of: "*", with: "")
-            .replacingOccurrences(of: escapedStar, with: "*")
-            .replacingOccurrences(of: escapedUnderscore, with: "_")
-        repaired = repaired.replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
+        // Recovery only removes balanced, context-valid delimiter runs that
+        // Foundation demonstrably leaked. Operators, escaped markers, code
+        // spans, intraword underscores, and all whitespace remain untouched.
         return (try? AttributedString(
             markdown: repaired,
             options: AttributedString.MarkdownParsingOptions(
                 interpretedSyntax: .inlineOnlyPreservingWhitespace
             )
         )) ?? AttributedString(repaired)
+    }
+
+    nonisolated private static func repairedMalformedEmphasis(
+        in source: String,
+        rendered: String
+    ) -> String? {
+        let delimiters = emphasisDelimiters(in: source)
+        let groups = Dictionary(grouping: delimiters) {
+            DelimiterKind(marker: $0.marker, length: $0.length)
+        }
+        let recoverable = groups.values.flatMap { group -> [Delimiter] in
+            guard group.count >= 2,
+                  group.count.isMultiple(of: 2),
+                  group.allSatisfy({ $0.canOpen || $0.canClose }),
+                  group.contains(where: \.canOpen),
+                  group.contains(where: \.canClose),
+                  let first = group.first else {
+                return []
+            }
+            let token = String(repeating: String(first.marker), count: first.length)
+            return rendered.contains(token) ? group : []
+        }
+        guard !recoverable.isEmpty else { return nil }
+
+        let removedRanges = Set(recoverable.map(\.range.lowerBound))
+        var result = ""
+        var index = source.startIndex
+        while index < source.endIndex {
+            if removedRanges.contains(index),
+               let delimiter = recoverable.first(where: { $0.range.lowerBound == index }) {
+                index = delimiter.range.upperBound
+            } else {
+                result.append(source[index])
+                index = source.index(after: index)
+            }
+        }
+        return result
+    }
+
+    nonisolated private static func emphasisDelimiters(in source: String) -> [Delimiter] {
+        var result: [Delimiter] = []
+        var index = source.startIndex
+        while index < source.endIndex {
+            let character = source[index]
+
+            if character == "\\" {
+                index = source.index(after: index)
+                if index < source.endIndex {
+                    index = source.index(after: index)
+                }
+                continue
+            }
+
+            if character == "`" {
+                let runEnd = endOfRun(in: source, from: index, matching: character)
+                let token = String(source[index..<runEnd])
+                if let closing = source.range(
+                    of: token,
+                    range: runEnd..<source.endIndex
+                ) {
+                    index = closing.upperBound
+                } else {
+                    index = runEnd
+                }
+                continue
+            }
+
+            guard character == "*" || character == "_" else {
+                index = source.index(after: index)
+                continue
+            }
+
+            let runEnd = endOfRun(in: source, from: index, matching: character)
+            let length = source.distance(from: index, to: runEnd)
+            guard length == 1 || length == 2 else {
+                index = runEnd
+                continue
+            }
+
+            let previous = index > source.startIndex
+                ? source[source.index(before: index)]
+                : nil
+            let next = runEnd < source.endIndex ? source[runEnd] : nil
+            let previousWhitespace = previous?.isWhitespace ?? true
+            let nextWhitespace = next?.isWhitespace ?? true
+            let previousPunctuation = isPunctuation(previous)
+            let nextPunctuation = isPunctuation(next)
+            let leftFlanking = !nextWhitespace
+                && (!nextPunctuation || previousWhitespace || previousPunctuation)
+            let rightFlanking = !previousWhitespace
+                && (!previousPunctuation || nextWhitespace || nextPunctuation)
+            let canOpen: Bool
+            let canClose: Bool
+            if character == "_" {
+                canOpen = leftFlanking && (!rightFlanking || previousPunctuation)
+                canClose = rightFlanking && (!leftFlanking || nextPunctuation)
+            } else {
+                canOpen = leftFlanking
+                canClose = rightFlanking
+            }
+            result.append(
+                Delimiter(
+                    range: index..<runEnd,
+                    marker: character,
+                    length: length,
+                    canOpen: canOpen,
+                    canClose: canClose
+                )
+            )
+            index = runEnd
+        }
+        return result
+    }
+
+    nonisolated private static func endOfRun(
+        in source: String,
+        from start: String.Index,
+        matching character: Character
+    ) -> String.Index {
+        var end = start
+        while end < source.endIndex, source[end] == character {
+            end = source.index(after: end)
+        }
+        return end
+    }
+
+    nonisolated private static func isPunctuation(_ character: Character?) -> Bool {
+        guard let character else { return false }
+        return character.unicodeScalars.allSatisfy {
+            CharacterSet.punctuationCharacters.contains($0)
+        }
     }
 }

--- a/Vellum/Views/AI/InlineMarkdown.swift
+++ b/Vellum/Views/AI/InlineMarkdown.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+enum InlinePiece {
+    case prose(AttributedString)
+    case math(String)
+}
+
+/// Parses inline Markdown without losing formatting that crosses a math span.
+///
+/// Equations are protected with the standard object-replacement character,
+/// the complete line is parsed once, and the equations are then spliced back
+/// into the attributed result. This keeps `**bold $x$ text**` bold instead of
+/// handing Foundation three unbalanced Markdown fragments.
+enum InlineMarkdown {
+    private static let placeholder: Character = "\u{FFFC}"
+
+    nonisolated static func pieces(in source: String) -> [InlinePiece] {
+        let segments = MathRenderer.segments(in: source)
+        let equations = segments.compactMap { segment -> String? in
+            guard case .math(let latex) = segment else { return nil }
+            return latex
+        }
+        guard !equations.isEmpty else { return [.prose(parse(source))] }
+
+        var protected = ""
+        for segment in segments {
+            switch segment {
+            case .text(let text):
+                protected.append(contentsOf: text.filter { $0 != placeholder })
+            case .math:
+                protected.append(placeholder)
+            }
+        }
+
+        let parsed = parse(protected)
+        guard parsed.characters.count(where: { $0 == placeholder }) == equations.count else {
+            return segments.map { segment in
+                switch segment {
+                case .text(let text): return .prose(parse(text))
+                case .math(let latex): return .math(latex)
+                }
+            }
+        }
+
+        var pieces: [InlinePiece] = []
+        var equationIndex = 0
+        var runStart = parsed.startIndex
+        var index = parsed.startIndex
+        while index < parsed.endIndex {
+            let next = parsed.index(afterCharacter: index)
+            if parsed.characters[index] == placeholder {
+                if runStart < index {
+                    pieces.append(.prose(AttributedString(parsed[runStart..<index])))
+                }
+                pieces.append(.math(equations[equationIndex]))
+                equationIndex += 1
+                runStart = next
+            }
+            index = next
+        }
+        if runStart < parsed.endIndex {
+            pieces.append(.prose(AttributedString(parsed[runStart...])))
+        }
+        return pieces
+    }
+
+    nonisolated private static func parse(_ source: String) -> AttributedString {
+        let parsed = (try? AttributedString(
+            markdown: source,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        )) ?? AttributedString(source)
+
+        let rendered = String(parsed.characters)
+        let leakedStrong = source.contains("**") && rendered.contains("**")
+        let leakedUnderscoreStrong = source.contains("__") && rendered.contains("__")
+        let starCount = source.filter { $0 == "*" }.count
+        let leakedEmphasis = starCount >= 2 && rendered.contains("*")
+        guard leakedStrong || leakedUnderscoreStrong || leakedEmphasis else {
+            return parsed
+        }
+
+        // Model streams sometimes produce overlapping/nested emphasis such as
+        // `**What **FOR UPDATE** does**`. CommonMark intentionally rejects that
+        // shape and Foundation returns every marker literally. In a chat reply,
+        // readable plain prose is a better failure mode than leaking syntax.
+        // Only run this recovery when Foundation demonstrably leaked markers;
+        // valid Markdown keeps all of its native attributes.
+        let escapedStar = "\u{E000}"
+        let escapedUnderscore = "\u{E001}"
+        var repaired = source
+            .replacingOccurrences(of: "\\*", with: escapedStar)
+            .replacingOccurrences(of: "\\_", with: escapedUnderscore)
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "__", with: "")
+            .replacingOccurrences(of: "*", with: "")
+            .replacingOccurrences(of: escapedStar, with: "*")
+            .replacingOccurrences(of: escapedUnderscore, with: "_")
+        repaired = repaired.replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
+        return (try? AttributedString(
+            markdown: repaired,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .inlineOnlyPreservingWhitespace
+            )
+        )) ?? AttributedString(repaired)
+    }
+}

--- a/Vellum/Views/AI/MarkdownMessage.swift
+++ b/Vellum/Views/AI/MarkdownMessage.swift
@@ -84,6 +84,30 @@ struct MarkdownMessage: View {
             .padding(.bottom, 8)
         case .math(let latex):
             mathBlockView(latex)
+        case .rule:
+            Rectangle()
+                .fill(palette.border)
+                .frame(height: 1)
+                .padding(.vertical, 4)
+                .padding(.bottom, 8)
+                .accessibilityHidden(true)
+        case .list(let items):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .firstTextBaseline, spacing: 7) {
+                        Text(item.marker.label)
+                            .foregroundStyle(.secondary)
+                            .accessibilityHidden(true)
+                        inlineText(item.text).lineSpacing(3)
+                    }
+                    .padding(.leading, CGFloat(item.depth) * 16)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(item.accessibilityLabel)
+                }
+            }
+            .font(.system(size: baseSize))
+            .padding(.leading, 12)
+            .padding(.bottom, 8)
         }
     }
 
@@ -119,13 +143,9 @@ struct MarkdownMessage: View {
         // everything else goes through native AttributedString markdown
         // (emphasis, strong, inline code, strikethrough, links).
         var result = Text(verbatim: "")
-        for segment in MathRenderer.segments(in: source) {
-            switch segment {
-            case .text(let text):
-                let attributed = (try? AttributedString(
-                    markdown: text,
-                    options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-                )) ?? AttributedString(text)
+        for piece in InlineMarkdown.pieces(in: source) {
+            switch piece {
+            case .prose(let attributed):
                 result = result + Text(attributed)
             case .math(let latex):
                 if let rendered = MathRenderer.render(
@@ -162,6 +182,49 @@ enum MarkdownBlock: Equatable {
     case table(String)
     /// Display math: the LaTeX between `$$...$$` or `\[...\]` delimiters.
     case math(String)
+    case rule
+    case list([MarkdownListItem])
+}
+
+struct MarkdownListItem: Equatable {
+    enum Marker: Equatable {
+        case unordered
+        case ordered(Int)
+
+        var label: String {
+            switch self {
+            case .unordered: return "•"
+            case .ordered(let number): return "\(number)."
+            }
+        }
+
+        var kind: Kind {
+            switch self {
+            case .unordered: return .unordered
+            case .ordered: return .ordered
+            }
+        }
+
+        enum Kind: Hashable {
+            case unordered
+            case ordered
+        }
+    }
+
+    let depth: Int
+    let marker: Marker
+    let text: String
+
+    var accessibilityLabel: String {
+        let kind = switch marker {
+        case .unordered: "List item"
+        case .ordered(let number): "Item \(number)"
+        }
+        let readableText = MarkdownParser.plainPreview(text)
+        return depth == 0
+            ? "\(kind), \(readableText)"
+            : "\(kind), level \(depth + 1), \(readableText)"
+    }
 }
 
 enum MarkdownParser {
@@ -189,7 +252,8 @@ enum MarkdownParser {
             }.joined()
         }.joined(separator: "\n")
         for pattern in [
-            #"(?m)^#{1,3}\s+"#,       // headings
+            #"(?m)^#{1,6}\s+"#,       // headings
+            #"(?m)^[ \t]*(?:-[ \t]*){3,}$|^[ \t]*(?:\*[ \t]*){3,}$|^[ \t]*(?:_[ \t]*){3,}$"#,
             #"(?m)^>\s?"#,            // quotes
             #"(?m)^[-*+]\s+"#,        // bullets
             #"(?m)^\d+\.\s+"#,        // ordered lists
@@ -242,9 +306,11 @@ enum MarkdownParser {
                 // guaranteed MathRenderer cache miss per token — show it as code until
                 // the closing delimiter arrives (same treatment as an unterminated
                 // code fence above).
-                blocks.append(closed ? .math(math) : .code(math))
+                let body = math.trimmingCharacters(in: .whitespacesAndNewlines)
+                blocks.append(closed ? .math(body) : .code(body))
                 continue
             }
+            if isRule(line) { blocks.append(.rule); index += 1; continue }
             if let heading = heading(line) { blocks.append(heading); index += 1; continue }
             if line.hasPrefix(">") {
                 var quoted: [String] = []
@@ -254,19 +320,28 @@ enum MarkdownParser {
                 blocks.append(.quote(quoted.joined(separator: "\n")))
                 continue
             }
-            if isUnordered(line) {
-                var items: [String] = []
-                while index < lines.count, isUnordered(lines[index]) {
-                    items.append(String(lines[index].dropFirst(2))); index += 1
+            if listItem(line) != nil {
+                var items: [MarkdownListItem] = []
+                while index < lines.count, let item = listItem(lines[index]) {
+                    items.append(item)
+                    index += 1
                 }
-                blocks.append(.unordered(items)); continue
-            }
-            if orderedText(line) != nil {
-                var items: [String] = []
-                while index < lines.count, let item = orderedText(lines[index]) {
-                    items.append(item); index += 1
+                let isNestedOrMixed = items.contains { $0.depth > 0 }
+                    || Set(items.map(\.marker.kind)).count > 1
+                let preservesCustomNumbering = items.enumerated().contains { index, item in
+                    if case .ordered(let number) = item.marker {
+                        return number != index + 1
+                    }
+                    return false
                 }
-                blocks.append(.ordered(items)); continue
+                if isNestedOrMixed || preservesCustomNumbering {
+                    blocks.append(.list(items))
+                } else if items.first?.marker.kind == .unordered {
+                    blocks.append(.unordered(items.map(\.text)))
+                } else {
+                    blocks.append(.ordered(items.map(\.text)))
+                }
+                continue
             }
             if line.contains("|"), index + 1 < lines.count, isTableSeparator(lines[index + 1]) {
                 var rows = [line]
@@ -289,15 +364,50 @@ enum MarkdownParser {
     }
 
     private static func heading(_ line: String) -> MarkdownBlock? {
-        for level in 1...3 {
+        for level in stride(from: 6, through: 1, by: -1) {
             let prefix = String(repeating: "#", count: level) + " "
-            if line.hasPrefix(prefix) { return .heading(level, String(line.dropFirst(prefix.count))) }
+            if line.hasPrefix(prefix) {
+                let text = String(line.dropFirst(prefix.count))
+                // During streaming, keep a marker-only prefix visible until
+                // the heading text arrives instead of rendering a zero-height
+                // block that makes the last token appear to vanish.
+                guard !text.isEmpty else { return nil }
+                return .heading(level, text)
+            }
         }
         return nil
     }
 
     private static func isUnordered(_ line: String) -> Bool {
         line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ")
+    }
+
+    private static func isRule(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard let marker = trimmed.first, "-*_".contains(marker) else { return false }
+        let markers = trimmed.filter { !$0.isWhitespace }
+        return markers.count >= 3 && markers.allSatisfy { $0 == marker }
+    }
+
+    private static func listItem(_ line: String) -> MarkdownListItem? {
+        guard let match = line.wholeMatch(
+            of: /^([ \t]*)([-+*]|\d+[.)])[ \t]+(.+)$/
+        ) else { return nil }
+        let indentation = match.1.reduce(into: 0) { count, character in
+            count += character == "\t" ? 4 : 1
+        }
+        let markerText = String(match.2)
+        let marker: MarkdownListItem.Marker
+        if let number = Int(markerText.dropLast()) {
+            marker = .ordered(number)
+        } else {
+            marker = .unordered
+        }
+        return MarkdownListItem(
+            depth: max(0, indentation / 2),
+            marker: marker,
+            text: String(match.3)
+        )
     }
 
     private static func orderedText(_ line: String) -> String? {
@@ -311,7 +421,7 @@ enum MarkdownParser {
 
     private static func startsBlock(_ line: String) -> Bool {
         line.hasPrefix("```") || line.hasPrefix("$$") || line.hasPrefix("\\[") || line.hasPrefix(">")
-            || heading(line) != nil || isUnordered(line) || orderedText(line) != nil
+            || heading(line) != nil || listItem(line) != nil || isRule(line)
     }
 
     private static func formatTable(_ rows: [String]) -> String {

--- a/Vellum/Views/AI/MathRenderer.swift
+++ b/Vellum/Views/AI/MathRenderer.swift
@@ -43,7 +43,7 @@ enum MathRenderer {
     /// Render a LaTeX string (no delimiters) to an image. Returns nil when the
     /// source fails to parse, so callers can fall back to styled plain text.
     static func render(latex: String, fontSize: CGFloat, color: NSColor, display: Bool) -> Rendered? {
-        let trimmed = latex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = normalizeCommands(latex.trimmingCharacters(in: .whitespacesAndNewlines))
         guard !trimmed.isEmpty else { return nil }
 
         // Resolve dynamic (catalog/appearance) colors to concrete sRGB so the
@@ -88,6 +88,21 @@ enum MathRenderer {
         let rendered = Rendered(image: image, descent: descent)
         cache.setObject(CachedRender(rendered), forKey: key)
         return rendered
+    }
+
+    /// SwiftMath does not implement the common modern `\dots` spelling. One
+    /// unknown command rejects the complete equation, so normalize it to the
+    /// equivalent `\ldots` that SwiftMath supports.
+    nonisolated private static let dotsRegex: NSRegularExpression? =
+        try? NSRegularExpression(pattern: #"\\dots(?![a-zA-Z])"#)
+
+    nonisolated private static func normalizeCommands(_ latex: String) -> String {
+        guard latex.contains("\\dots"), let regex = dotsRegex else { return latex }
+        return regex.stringByReplacingMatches(
+            in: latex,
+            range: NSRange(location: 0, length: (latex as NSString).length),
+            withTemplate: #"\\ldots"#
+        )
     }
 
     /// Compiled once: `segments(in:)` runs on every streamed delta, so building

--- a/Vellum/Views/AI/SelectableMessageText.swift
+++ b/Vellum/Views/AI/SelectableMessageText.swift
@@ -99,7 +99,7 @@ final class MessageContainerView: NSView {
     override var isFlipped: Bool { true }
 
     override init(frame frameRect: NSRect) {
-        textView = TranscriptTextView()
+        textView = TranscriptTextView(textKit1ContainerIn: frameRect.size)
         super.init(frame: frameRect)
         configureTextView()
         quoteButton.isHidden = true
@@ -129,12 +129,14 @@ final class MessageContainerView: NSView {
     private(set) var appliedContent: String?
     private(set) var appliedColor: NSColor?
     private(set) var appliedSecondary: NSColor?
+    private var renderedWidth: CGFloat?
 
     func setAttributed(_ attributed: NSAttributedString, content: String, color: NSColor, secondary: NSColor) {
         self.attributed = attributed
         self.appliedContent = content
         self.appliedColor = color
         self.appliedSecondary = secondary
+        renderedWidth = nil
         textView.textStorage?.setAttributedString(attributed)
         needsLayout = true
     }
@@ -144,7 +146,38 @@ final class MessageContainerView: NSView {
     /// layout pass, and driving `ensureLayout` on the on-screen view there
     /// tripped "-ensureLayoutForTextContainer while already performing layout".
     func height(forWidth width: CGFloat) -> CGFloat {
-        Self.measureHeight(attributed, width: max(1, width))
+        let width = max(1, width)
+        return Self.measureHeight(Self.fittedAttachments(in: attributed, width: width), width: width)
+    }
+
+    /// Image-backed equations and rules are authored at the default bubble
+    /// width. Scale copies for the actual proposed width so a narrow inspector
+    /// cannot clip them, while retaining the originals for a later expansion.
+    static func fittedAttachments(
+        in attributed: NSAttributedString,
+        width: CGFloat
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString(attributedString: attributed)
+        let available = max(1, width)
+        result.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: result.length)
+        ) { value, range, _ in
+            guard let attachment = value as? NSTextAttachment,
+                  attachment.bounds.width > available else { return }
+            let fitted = NSTextAttachment()
+            fitted.image = attachment.image
+            var bounds = attachment.bounds
+            let scale = available / bounds.width
+            bounds.size = CGSize(
+                width: available,
+                height: max(1, bounds.height * scale)
+            )
+            bounds.origin.y *= scale
+            fitted.bounds = bounds
+            result.addAttribute(.attachment, value: fitted, range: range)
+        }
+        return result
     }
 
     static func measureHeight(_ attributed: NSAttributedString, width: CGFloat) -> CGFloat {
@@ -162,6 +195,12 @@ final class MessageContainerView: NSView {
 
     override func layout() {
         super.layout()
+        if renderedWidth == nil || abs((renderedWidth ?? 0) - bounds.width) > 0.5 {
+            textView.textStorage?.setAttributedString(
+                Self.fittedAttachments(in: attributed, width: bounds.width)
+            )
+            renderedWidth = bounds.width
+        }
         textView.frame = bounds
         updateQuoteButton()
     }
@@ -201,6 +240,20 @@ final class TranscriptTextView: NSTextView {
         didSet { updateDragTypeRegistration() }
     }
     var onDropTargeted: ((Bool) -> Void)?
+
+    /// The sizing path uses TextKit 1. Keeping the live view on the same layout
+    /// engine avoids paragraph-spacing disagreements that otherwise leave a
+    /// large blank region below long Markdown replies.
+    convenience init(textKit1ContainerIn size: NSSize) {
+        let storage = NSTextStorage()
+        let layoutManager = NSLayoutManager()
+        let container = NSTextContainer(
+            size: NSSize(width: max(0, size.width), height: .greatestFiniteMagnitude)
+        )
+        storage.addLayoutManager(layoutManager)
+        layoutManager.addTextContainer(container)
+        self.init(frame: NSRect(origin: .zero, size: size), textContainer: container)
+    }
 
     /// AppKit funnels every re-registration through this (it runs on window entry
     /// and whenever editable/selectable/rich-text changes) and drops a read-only
@@ -339,7 +392,31 @@ enum AiAttributedRenderer {
 
         case let .math(latex):
             return displayMath(latex, color: color)
+
+        case .rule:
+            return rule(color: secondary)
+
+        case .list(let items):
+            return nestedList(items, color: color)
         }
+    }
+
+    private static func rule(color: NSColor) -> NSAttributedString {
+        let attachment = NSTextAttachment()
+        attachment.image = NSImage(size: CGSize(width: 240, height: 1), flipped: false) { rect in
+            color.withAlphaComponent(0.5).setFill()
+            rect.fill()
+            return true
+        }
+        attachment.bounds = CGRect(x: 0, y: 0, width: 240, height: 1)
+        let paragraph = paragraphStyle(lineSpacing: 0, spacingAfter: 12)
+        paragraph.paragraphSpacingBefore = 4
+        let result = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
+        result.addAttributes(
+            [.paragraphStyle: paragraph, .foregroundColor: color],
+            range: NSRange(location: 0, length: result.length)
+        )
+        return result
     }
 
     /// Display equation as a centered typeset image on its own paragraph;
@@ -412,6 +489,29 @@ enum AiAttributedRenderer {
         return result
     }
 
+    private static func nestedList(
+        _ items: [MarkdownListItem],
+        color: NSColor
+    ) -> NSAttributedString {
+        let result = NSMutableAttributedString()
+        for (index, item) in items.enumerated() {
+            let indent = CGFloat(4 + item.depth * 16)
+            let paragraph = paragraphStyle(lineSpacing: 3, spacingAfter: 4)
+            paragraph.firstLineHeadIndent = indent
+            paragraph.headIndent = indent + 16
+            let prefix = "\(item.marker.label)  "
+            let line = NSMutableAttributedString(string: prefix, attributes: [
+                .font: base, .foregroundColor: color, .paragraphStyle: paragraph,
+            ])
+            line.append(inline(item.text, font: base, color: color, paragraph: paragraph))
+            result.append(line)
+            if index < items.count - 1 {
+                result.append(NSAttributedString(string: "\n"))
+            }
+        }
+        return result
+    }
+
     /// Inline handling: math spans become baseline-aligned typeset attachments,
     /// the prose between them goes through Foundation's markdown parser for
     /// emphasis/strong/code/strikethrough/links, mapped onto concrete AppKit
@@ -423,10 +523,10 @@ enum AiAttributedRenderer {
         paragraph: NSParagraphStyle
     ) -> NSAttributedString {
         let result = NSMutableAttributedString()
-        for segment in MathRenderer.segments(in: source) {
-            switch segment {
-            case .text(let text):
-                result.append(inlineProse(text, font: font, color: color, paragraph: paragraph))
+        for piece in InlineMarkdown.pieces(in: source) {
+            switch piece {
+            case .prose(let attributed):
+                result.append(inlineProse(attributed, font: font, color: color, paragraph: paragraph))
             case .math(let latex):
                 if let rendered = MathRenderer.render(latex: latex, fontSize: font.pointSize, color: color, display: false) {
                     let math = NSMutableAttributedString(attributedString: attachment(for: rendered, maxWidth: 240, latex: latex))
@@ -448,20 +548,11 @@ enum AiAttributedRenderer {
     }
 
     private static func inlineProse(
-        _ source: String,
+        _ attributed: AttributedString,
         font: NSFont,
         color: NSColor,
         paragraph: NSParagraphStyle
     ) -> NSAttributedString {
-        guard let attributed = try? AttributedString(
-            markdown: source,
-            options: AttributedString.MarkdownParsingOptions(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        ) else {
-            return NSAttributedString(string: source, attributes: [
-                .font: font, .foregroundColor: color, .paragraphStyle: paragraph,
-            ])
-        }
-
         let result = NSMutableAttributedString()
         for run in attributed.runs {
             let substring = String(attributed[run.range].characters)

--- a/Vellum/Views/AI/SelectableMessageText.swift
+++ b/Vellum/Views/AI/SelectableMessageText.swift
@@ -1,6 +1,12 @@
 import AppKit
 import SwiftUI
 
+fileprivate extension NSAttributedString.Key {
+    static let vellumDecorativeRule = NSAttributedString.Key(
+        "com.vellum.ai.decorative-rule"
+    )
+}
+
 // Assistant-message renderer backed by an NSTextView so the user can select any
 // substring of a reply and quote it back into the composer (the floating "Quote"
 // button in the reference design). Reuses `MarkdownParser` for block structure
@@ -64,6 +70,7 @@ struct SelectableMessageText: NSViewRepresentable {
         return CGSize(width: clamped, height: nsView.height(forWidth: clamped))
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var onQuote: (String) -> Void
         weak var container: MessageContainerView?
@@ -75,10 +82,15 @@ struct SelectableMessageText: NSViewRepresentable {
         }
 
         func quoteCurrentSelection() {
-            guard let textView = container?.textView else { return }
+            guard let textView = container?.textView,
+                  let storage = textView.textStorage else { return }
             let range = textView.selectedRange()
             guard range.length > 0 else { return }
-            let text = (textView.string as NSString).substring(with: range)
+            let text = MessageContainerView.plainText(
+                in: storage,
+                range: range,
+                mathDelimiters: true
+            )
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else { return }
             onQuote(text)
@@ -138,6 +150,13 @@ final class MessageContainerView: NSView {
         self.appliedSecondary = secondary
         renderedWidth = nil
         textView.textStorage?.setAttributedString(attributed)
+        textView.setAccessibilityValue(
+            Self.plainText(
+                in: attributed,
+                range: NSRange(location: 0, length: attributed.length),
+                mathDelimiters: false
+            )
+        )
         needsLayout = true
     }
 
@@ -163,19 +182,76 @@ final class MessageContainerView: NSView {
             .attachment,
             in: NSRange(location: 0, length: result.length)
         ) { value, range, _ in
-            guard let attachment = value as? NSTextAttachment,
-                  attachment.bounds.width > available else { return }
+            guard let attachment = value as? NSTextAttachment else { return }
+            let paragraph = result.attribute(
+                .paragraphStyle,
+                at: range.location,
+                effectiveRange: nil
+            ) as? NSParagraphStyle
+            let lineWidth = availableLineWidth(
+                containerWidth: available,
+                paragraph: paragraph
+            )
+            guard attachment.bounds.width > lineWidth else { return }
             let fitted = NSTextAttachment()
             fitted.image = attachment.image
             var bounds = attachment.bounds
-            let scale = available / bounds.width
+            let scale = lineWidth / bounds.width
             bounds.size = CGSize(
-                width: available,
+                width: lineWidth,
                 height: max(1, bounds.height * scale)
             )
             bounds.origin.y *= scale
             fitted.bounds = bounds
             result.addAttribute(.attachment, value: fitted, range: range)
+        }
+        return result
+    }
+
+    private static func availableLineWidth(
+        containerWidth: CGFloat,
+        paragraph: NSParagraphStyle?
+    ) -> CGFloat {
+        guard let paragraph else { return max(1, containerWidth) }
+        let leading = max(
+            0,
+            max(paragraph.firstLineHeadIndent, paragraph.headIndent)
+        )
+        let trailingEdge = paragraph.tailIndent > 0
+            ? min(containerWidth, paragraph.tailIndent)
+            : containerWidth + paragraph.tailIndent
+        return max(1, trailingEdge - leading)
+    }
+
+    /// Converts attributed transcript content into text suitable for quoting or
+    /// AppKit accessibility. Decorative rules disappear; equations use their
+    /// LaTeX source instead of leaking the object-replacement character.
+    static func plainText(
+        in attributed: NSAttributedString,
+        range requestedRange: NSRange,
+        mathDelimiters: Bool
+    ) -> String {
+        let range = NSIntersectionRange(
+            requestedRange,
+            NSRange(location: 0, length: attributed.length)
+        )
+        guard range.length > 0 else { return "" }
+
+        var result = ""
+        attributed.enumerateAttributes(in: range) { attributes, runRange, _ in
+            if attributes[.vellumDecorativeRule] as? Bool == true {
+                return
+            }
+            if let attachment = attributes[.attachment] as? NSTextAttachment {
+                guard let latex = attachment.image?.accessibilityDescription,
+                      !latex.isEmpty else {
+                    return
+                }
+                result += mathDelimiters ? "$\(latex)$" : "Equation: \(latex)"
+                return
+            }
+            let text = (attributed.string as NSString).substring(with: runRange)
+            result += text.replacingOccurrences(of: "\u{FFFC}", with: "")
         }
         return result
     }
@@ -413,7 +489,11 @@ enum AiAttributedRenderer {
         paragraph.paragraphSpacingBefore = 4
         let result = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
         result.addAttributes(
-            [.paragraphStyle: paragraph, .foregroundColor: color],
+            [
+                .paragraphStyle: paragraph,
+                .foregroundColor: color,
+                .vellumDecorativeRule: true,
+            ],
             range: NSRange(location: 0, length: result.length)
         )
         return result


### PR DESCRIPTION
## Summary
- add a production regression corpus for headings, emphasis, rules, nested lists, math, code, tables, streaming boundaries, and malformed input
- keep SwiftUI and AppKit/TextKit renderers semantically and geometrically consistent
- recover readable output from incomplete model Markdown and preserve escaped literals
- scale math/rule attachments to the actual message width and improve list accessibility

## Verification
- targeted Markdown/UI corpus: 44/44 passed
- full macOS suite: 276/276 passed
- exact isolated bundle build succeeded
- computer-use verified usable default and narrow AI panel chrome; production parser/renderers cover the corpus directly

## Audit
Implements Issue #57 with corpus-driven rendering rather than a one-off parser patch.