### PR TITLE
Scribble to erase: scratch out ink with the Apple Pencil

### DIFF
--- a/Tests/ScratchOutRecognizerTests.swift
+++ b/Tests/ScratchOutRecognizerTests.swift
@@ -230,6 +230,38 @@ final class ScratchOutRecognizerTests: XCTestCase {
         XCTAssertEqual(hits, [0], "only the substantially covered stroke is erased")
     }
 
+    /// A tapped dot degenerates every assumption in the overlap path: its
+    /// bounding box has zero width and height, and it is a one-sample polyline
+    /// so there is no segment to measure a distance against. Both the
+    /// `reach.intersects(...)` prefilter and `coveredFraction`'s
+    /// `path.count >= 2` guard sit right next to that case, and either could
+    /// start dropping dots under a plausible refactor — a zero-size rect is
+    /// `isEmpty`, and `CGRectIntersectsRect` is documented in terms of empty
+    /// rects. It currently works; this pins it.
+    func testScribblingOverATappedDotErasesIt() {
+        let scratch = scratchOut()  // sweeps x 0…100 around y 0…18
+        let dot = ScratchOutRecognizer.OverlapCandidate(
+            points: [CGPoint(x: 50, y: 9)],
+            hitRadius: 8)
+
+        let hits = ScratchOutRecognizer.overlappedCandidates(scratch: scratch, candidates: [dot])
+        XCTAssertEqual(hits, [0], "a dot under the scribble must be erased like any other ink")
+    }
+
+    /// The other zero-size box: a rule drawn dead flat has zero height, so it is
+    /// `isEmpty` too even though it is a perfectly ordinary multi-sample stroke.
+    /// Real Pencil input is never exactly axis-aligned, but imported or
+    /// programmatically drawn ink can be.
+    func testScribblingOverAPerfectlyFlatStrokeErasesIt() {
+        let scratch = scratchOut()
+        let flat = ScratchOutRecognizer.OverlapCandidate(
+            points: polyline([CGPoint(x: 20, y: 9), CGPoint(x: 80, y: 9)], spacing: 2),
+            hitRadius: 8)
+
+        let hits = ScratchOutRecognizer.overlappedCandidates(scratch: scratch, candidates: [flat])
+        XCTAssertEqual(hits, [0], "a flat stroke fully under the scribble must be erased")
+    }
+
     func testCoveredFractionIsProportionalToOverlap() {
         let scratch = scratchOut()  // covers x 0…100
         let half = polyline([CGPoint(x: 0, y: 9), CGPoint(x: 200, y: 9)], spacing: 2)

--- a/Tests/ScratchOutRecognizerTests.swift
+++ b/Tests/ScratchOutRecognizerTests.swift
@@ -1,0 +1,316 @@
+#if os(iOS)
+import CoreGraphics
+import PencilKit
+import UIKit
+import XCTest
+@testable import Vellum
+
+/// Unit tests for "scribble to erase". Two halves:
+///
+/// * the **recognizer** — synthesized scratch-outs must be recognized, and
+///   synthesized handwriting / underlines / circles must not be. These are the
+///   false-positive guards; the feature is destructive, so every "must NOT fire"
+///   case here is load-bearing.
+/// * the **overlap selection** — which existing strokes a recognized scribble
+///   takes with it, including the case where it takes nothing (blank paper) and
+///   so must not fire at all.
+///
+/// All coordinates are page (zoom-1) points, the space strokes are stored in.
+final class ScratchOutRecognizerTests: XCTestCase {
+    // MARK: - Shape synthesis
+
+    /// Densely samples a polyline through `vertices` at `spacing`, the way a
+    /// pencil sampling at 240 Hz would.
+    private func polyline(_ vertices: [CGPoint], spacing: CGFloat = 2) -> [CGPoint] {
+        guard let first = vertices.first else { return [] }
+        var points: [CGPoint] = [first]
+        for index in 1..<vertices.count {
+            let a = vertices[index - 1]
+            let b = vertices[index]
+            let length = hypot(b.x - a.x, b.y - a.y)
+            let steps = max(1, Int((length / spacing).rounded()))
+            for step in 1...steps {
+                let t = CGFloat(step) / CGFloat(steps)
+                points.append(CGPoint(x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t))
+            }
+        }
+        return points
+    }
+
+    /// A back-and-forth scrub: `passes` horizontal sweeps of `length`, each one
+    /// `drift` points below the last. `passes - 1` reversals.
+    private func scratchOut(
+        passes: Int = 6,
+        length: CGFloat = 100,
+        drift: CGFloat = 3,
+        origin: CGPoint = .zero
+    ) -> [CGPoint] {
+        var vertices: [CGPoint] = []
+        for index in 0...passes {
+            vertices.append(CGPoint(
+                x: origin.x + (index.isMultiple(of: 2) ? 0 : length),
+                y: origin.y + CGFloat(index) * drift))
+        }
+        return polyline(vertices)
+    }
+
+    private func rotated(_ points: [CGPoint], degrees: CGFloat) -> [CGPoint] {
+        let transform = CGAffineTransform(rotationAngle: degrees * .pi / 180)
+        return points.map { $0.applying(transform) }
+    }
+
+    private func circle(radius: CGFloat, center: CGPoint = .zero, samples: Int = 120) -> [CGPoint] {
+        (0...samples).map { index in
+            let angle = 2 * CGFloat.pi * CGFloat(index) / CGFloat(samples)
+            return CGPoint(x: center.x + radius * cos(angle), y: center.y + radius * sin(angle))
+        }
+    }
+
+    /// A cursive-looking wave — the archetypal false positive. Lots of sharp
+    /// turns, but the pen never travels backwards along its principal axis.
+    private func cursiveWave(
+        width: CGFloat = 200,
+        amplitude: CGFloat = 14,
+        humps: Int = 5,
+        samples: Int = 300
+    ) -> [CGPoint] {
+        (0...samples).map { index in
+            let t = CGFloat(index) / CGFloat(samples)
+            return CGPoint(
+                x: width * t,
+                y: amplitude * sin(2 * .pi * CGFloat(humps) * t))
+        }
+    }
+
+    // MARK: - Recognized
+
+    func testHorizontalScratchOutIsRecognized() {
+        let points = scratchOut()
+        let metrics = ScratchOutRecognizer.metrics(for: points)
+        XCTAssertEqual(metrics.reversals, 5, "six passes means five confirmed reversals")
+        XCTAssertGreaterThan(metrics.density, 2.5)
+        XCTAssertTrue(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testVerticalScratchOutIsRecognized() {
+        // Same gesture rotated onto the other axis: PCA must follow the ink, not
+        // assume horizontal.
+        let points = rotated(scratchOut(), degrees: 90)
+        XCTAssertTrue(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testDiagonalScratchOutIsRecognized() {
+        // The case a bounding-box major axis would get wrong: at 30° the box is
+        // much squarer than the gesture, so only PCA finds the scrub direction.
+        let points = rotated(scratchOut(), degrees: 30)
+        XCTAssertTrue(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testTightScratchOutOverASingleWordIsRecognized() {
+        // A realistic "cross out one word" scrub: 40 pt wide, 14 pt tall.
+        let points = scratchOut(passes: 7, length: 40, drift: 2)
+        XCTAssertTrue(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    // MARK: - NOT recognized (false-positive guards)
+
+    func testStraightUnderlineIsNotRecognized() {
+        let points = polyline([CGPoint(x: 0, y: 0), CGPoint(x: 220, y: 0)])
+        let metrics = ScratchOutRecognizer.metrics(for: points)
+        XCTAssertEqual(metrics.reversals, 0)
+        XCTAssertEqual(metrics.density, 1, accuracy: 0.01, "a line is exactly its own diagonal")
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testCircleIsNotRecognized() {
+        let points = circle(radius: 45)
+        let metrics = ScratchOutRecognizer.metrics(for: points)
+        XCTAssertLessThan(metrics.reversals, 4, "a closed loop turns back at most twice")
+        XCTAssertLessThan(metrics.density, 2.5, "a circle travels once around its own box")
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testCursiveHandwritingIsNotRecognized() {
+        let points = cursiveWave()
+        let metrics = ScratchOutRecognizer.metrics(for: points)
+        XCTAssertEqual(
+            metrics.reversals, 0,
+            "cursive oscillates across its principal axis but never doubles back along it")
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testPrintedLetterMIsNotRecognized() {
+        // The busiest single Latin letterform: four strokes of the pen, three
+        // reversals along its (vertical) principal axis. This is precisely why
+        // `minimumReversals` is 4 and not 3.
+        let points = polyline([
+            CGPoint(x: 0, y: 50), CGPoint(x: 0, y: 0),
+            CGPoint(x: 20, y: 30), CGPoint(x: 40, y: 0), CGPoint(x: 40, y: 50),
+        ])
+        XCTAssertLessThanOrEqual(ScratchOutRecognizer.metrics(for: points).reversals, 3)
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testZigZagLetterZIsNotRecognized() {
+        let points = polyline([
+            CGPoint(x: 0, y: 0), CGPoint(x: 60, y: 0),
+            CGPoint(x: 0, y: 50), CGPoint(x: 60, y: 50),
+        ])
+        XCTAssertLessThanOrEqual(ScratchOutRecognizer.metrics(for: points).reversals, 2)
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testShortTickIsNotRecognized() {
+        // A `t` crossbar or an accent: scribble-shaped statistics are meaningless
+        // this small, so the length floor rejects it outright.
+        let points = polyline([CGPoint(x: 0, y: 0), CGPoint(x: 9, y: 2)])
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    func testThreePassScribbleIsNotRecognized() {
+        // Deliberately conservative: three passes (two reversals) is well short
+        // of the bar, so a sloppy retrace can't delete the user's work.
+        let points = scratchOut(passes: 3, length: 100, drift: 3)
+        XCTAssertEqual(ScratchOutRecognizer.metrics(for: points).reversals, 2)
+        XCTAssertFalse(ScratchOutRecognizer.isScratchOut(points))
+    }
+
+    // MARK: - Reversal counting
+
+    func testTremorDoesNotCountAsReversals() {
+        // A "straight" line drawn by a human hand: sign-of-difference counting
+        // would report dozens of reversals here; hysteresis reports none.
+        var points: [CGPoint] = []
+        for index in 0..<120 {
+            let x = CGFloat(index) * 2
+            points.append(CGPoint(x: x, y: sin(CGFloat(index)) * 2.5))
+        }
+        let metrics = ScratchOutRecognizer.metrics(for: points)
+        XCTAssertEqual(metrics.reversals, 0)
+    }
+
+    func testPrincipalAxisFollowsTheInk() {
+        let horizontal = ScratchOutRecognizer.principalAxis(of: polyline([
+            CGPoint(x: 0, y: 0), CGPoint(x: 100, y: 0),
+        ]))
+        XCTAssertEqual(abs(horizontal.dx), 1, accuracy: 0.001)
+
+        let vertical = ScratchOutRecognizer.principalAxis(of: polyline([
+            CGPoint(x: 0, y: 0), CGPoint(x: 0, y: 100),
+        ]))
+        XCTAssertEqual(abs(vertical.dy), 1, accuracy: 0.001)
+
+        let diagonal = ScratchOutRecognizer.principalAxis(of: polyline([
+            CGPoint(x: 0, y: 0), CGPoint(x: 100, y: 100),
+        ]))
+        XCTAssertEqual(abs(diagonal.dx), abs(diagonal.dy), accuracy: 0.001)
+    }
+
+    // MARK: - Overlap selection
+
+    func testOverlapPicksCoveredStrokesAndSparesCrossedOnes() {
+        let scratch = scratchOut()  // spans x 0…100, y 0…18
+
+        // A short word-sized stroke living entirely under the scribble.
+        let word = ScratchOutRecognizer.OverlapCandidate(
+            points: polyline([CGPoint(x: 10, y: 9), CGPoint(x: 90, y: 9)], spacing: 3),
+            hitRadius: 8)
+        // A long rule the scribble merely crosses: only a fifth of it is covered.
+        let underline = ScratchOutRecognizer.OverlapCandidate(
+            points: polyline([CGPoint(x: -200, y: 9), CGPoint(x: 300, y: 9)], spacing: 3),
+            hitRadius: 8)
+        // Ink on another line entirely.
+        let elsewhere = ScratchOutRecognizer.OverlapCandidate(
+            points: polyline([CGPoint(x: 10, y: 500), CGPoint(x: 90, y: 500)], spacing: 3),
+            hitRadius: 8)
+
+        let hits = ScratchOutRecognizer.overlappedCandidates(
+            scratch: scratch,
+            candidates: [word, underline, elsewhere])
+        XCTAssertEqual(hits, [0], "only the substantially covered stroke is erased")
+    }
+
+    func testCoveredFractionIsProportionalToOverlap() {
+        let scratch = scratchOut()  // covers x 0…100
+        let half = polyline([CGPoint(x: 0, y: 9), CGPoint(x: 200, y: 9)], spacing: 2)
+        let fraction = ScratchOutRecognizer.coveredFraction(of: half, by: scratch, within: 8)
+        XCTAssertEqual(fraction, 0.5, accuracy: 0.08, "half the rule lies under the scribble")
+    }
+
+    func testCoverageIgnoresStrokesJustOutOfReach() {
+        let scratch = scratchOut()
+        let nearMiss = polyline([CGPoint(x: 0, y: 40), CGPoint(x: 100, y: 40)], spacing: 3)
+        XCTAssertEqual(
+            ScratchOutRecognizer.coveredFraction(of: nearMiss, by: scratch, within: 8), 0,
+            accuracy: 0.001,
+            "the scribble bottoms out at y = 18; a line 22 pt below is untouched")
+    }
+
+    // MARK: - PencilKit integration (ScratchOutInk)
+
+    private func stroke(_ points: [CGPoint], width: CGFloat = 4) -> PKStroke {
+        let controlPoints = points.enumerated().map { index, location in
+            PKStrokePoint(
+                location: location,
+                timeOffset: TimeInterval(index) * 0.008,
+                size: CGSize(width: width, height: width),
+                opacity: 1,
+                force: 1,
+                azimuth: 0,
+                altitude: .pi / 2)
+        }
+        return PKStroke(
+            ink: PKInk(.pen, color: .black),
+            path: PKStrokePath(controlPoints: controlPoints, creationDate: Date(timeIntervalSince1970: 0)))
+    }
+
+    func testEraseRemovesTheScribbleAndWhatItCovers() throws {
+        let word = stroke(polyline([CGPoint(x: 10, y: 9), CGPoint(x: 90, y: 9)]))
+        let bystander = stroke(polyline([CGPoint(x: 10, y: 400), CGPoint(x: 90, y: 400)]))
+        let scribble = stroke(scratchOut())
+        let drawing = PKDrawing(strokes: [word, bystander, scribble])
+
+        let result = try XCTUnwrap(ScratchOutInk.erase(scratchIndex: 2, in: drawing))
+        XCTAssertEqual(result.erasedStrokeCount, 1)
+        XCTAssertEqual(result.drawing.strokes.count, 1, "the scribble deletes itself too")
+        XCTAssertEqual(
+            result.drawing.strokes[0].renderBounds.midY,
+            bystander.renderBounds.midY,
+            accuracy: 1,
+            "the untouched stroke on another line survives")
+    }
+
+    func testScribbleOnBlankPaperIsKeptAsInk() {
+        // The single most important guard: scribble-shaped geometry over nothing
+        // is a doodle, not an erase, so `erase` declines and the stroke stays.
+        let drawing = PKDrawing(strokes: [stroke(scratchOut())])
+        XCTAssertNil(ScratchOutInk.erase(scratchIndex: 0, in: drawing))
+    }
+
+    func testOrdinaryStrokeOverInkIsNotAnErase() {
+        let word = stroke(polyline([CGPoint(x: 10, y: 9), CGPoint(x: 90, y: 9)]))
+        // An underline drawn right on top of the word — overlapping, but not a
+        // scratch-out.
+        let underline = stroke(polyline([CGPoint(x: 5, y: 11), CGPoint(x: 95, y: 11)]))
+        let drawing = PKDrawing(strokes: [word, underline])
+        XCTAssertNil(ScratchOutInk.erase(scratchIndex: 1, in: drawing))
+    }
+
+    func testAlreadyErasedStrokesAreNotCounted() {
+        // A stroke the bitmap eraser wiped out still lives in `drawing.strokes`.
+        // It renders as nothing, so a scribble over its old position must not
+        // count it as a hit — otherwise the gesture would "erase" invisible
+        // objects and fire on what looks to the user like blank paper.
+        let word = stroke(polyline([CGPoint(x: 10, y: 9), CGPoint(x: 90, y: 9)]))
+        let ghost = PKStroke(
+            ink: word.ink,
+            path: word.path,
+            transform: word.transform,
+            mask: UIBezierPath(rect: CGRect(x: 5000, y: 5000, width: 1, height: 1)))
+        XCTAssertFalse(PdfInk.strokeHasVisibleInk(ghost), "precondition: the ghost is invisible")
+
+        let drawing = PKDrawing(strokes: [ghost, stroke(scratchOut())])
+        XCTAssertNil(ScratchOutInk.erase(scratchIndex: 1, in: drawing))
+    }
+}
+#endif

--- a/Tests/ScratchOutRecognizerTests.swift
+++ b/Tests/ScratchOutRecognizerTests.swift
@@ -296,6 +296,81 @@ final class ScratchOutRecognizerTests: XCTestCase {
         XCTAssertNil(ScratchOutInk.erase(scratchIndex: 1, in: drawing))
     }
 
+    /// The realistic data-loss case: notes on ruled lines. Scrubbing out a word
+    /// must not reach the line above. The scribble drifts over 18 pt, so with
+    /// 16 pt line spacing the neighbour sits ~16 pt from the scribble's top pass
+    /// — outside the ~9 pt effective hit radius, but only just, which is exactly
+    /// why it needs a test rather than a comment.
+    func testAdjacentLineOfHandwritingSurvives() throws {
+        let target = stroke(polyline([CGPoint(x: 10, y: 9), CGPoint(x: 90, y: 9)]))
+        let lineAbove = stroke(polyline([CGPoint(x: 10, y: -16), CGPoint(x: 90, y: -16)]))
+        let lineBelow = stroke(polyline([CGPoint(x: 10, y: 34), CGPoint(x: 90, y: 34)]))
+        let drawing = PKDrawing(strokes: [lineAbove, target, lineBelow, stroke(scratchOut())])
+
+        let result = try XCTUnwrap(ScratchOutInk.erase(scratchIndex: 3, in: drawing))
+        XCTAssertEqual(result.erasedStrokeCount, 1, "only the scrubbed line is erased")
+        XCTAssertEqual(result.drawing.strokes.count, 2)
+        let survivingMidYs = result.drawing.strokes.map { $0.renderBounds.midY }.sorted()
+        XCTAssertEqual(survivingMidYs[0], -16, accuracy: 2)
+        XCTAssertEqual(survivingMidYs[1], 34, accuracy: 2)
+    }
+
+    /// Undo restoring a stroke looks exactly like the user drawing one if you
+    /// only compare counts, and the restored stroke need not come back at the
+    /// end. Prefix comparison is what makes "appended" a fact.
+    func testAppendedStrokeIndexRejectsANonAppendInsertion() {
+        let a = stroke(polyline([CGPoint(x: 0, y: 0), CGPoint(x: 50, y: 0)]))
+        let b = stroke(polyline([CGPoint(x: 0, y: 20), CGPoint(x: 50, y: 20)]))
+        let restored = stroke(polyline([CGPoint(x: 0, y: 40), CGPoint(x: 50, y: 40)]))
+        let previous = PKDrawing(strokes: [a, b])
+
+        XCTAssertEqual(
+            ScratchOutInk.appendedStrokeIndex(
+                in: PKDrawing(strokes: [a, b, restored]), after: previous),
+            2,
+            "a genuine append is identified")
+        XCTAssertNil(
+            ScratchOutInk.appendedStrokeIndex(
+                in: PKDrawing(strokes: [restored, a, b]), after: previous),
+            "a stroke restored at the front is not an append")
+        XCTAssertNil(
+            ScratchOutInk.appendedStrokeIndex(
+                in: PKDrawing(strokes: [a, restored, b]), after: previous),
+            "a stroke restored in the middle is not an append")
+        XCTAssertNil(
+            ScratchOutInk.appendedStrokeIndex(in: PKDrawing(strokes: [a]), after: previous),
+            "a vector erase is not an append")
+        XCTAssertNil(
+            ScratchOutInk.appendedStrokeIndex(in: previous, after: previous),
+            "an unchanged drawing is not an append")
+    }
+
+    /// The bitmap eraser masks a stroke instead of shortening it, so coverage has
+    /// to be measured against what still renders. Half-erase a word, scribble
+    /// over the surviving half, and it must go: against the full original path
+    /// that scores ≈0.5 and falls just under `minimumCoverage`.
+    func testCoverageMeasuresOnlyTheUnmaskedPartOfAStroke() throws {
+        let word = stroke(polyline([CGPoint(x: 0, y: 9), CGPoint(x: 200, y: 9)]))
+        // Keep only x ≤ 100 — the half the scribble (x 0…100) sits over.
+        let halfErased = PKStroke(
+            ink: word.ink,
+            path: word.path,
+            transform: word.transform,
+            mask: UIBezierPath(rect: CGRect(x: -50, y: -50, width: 150, height: 200)))
+        XCTAssertTrue(PdfInk.strokeHasVisibleInk(halfErased), "precondition: half survives")
+
+        let visible = ScratchOutInk.centerline(of: halfErased)
+        XCTAssertLessThan(
+            visible.map(\.x).max() ?? .greatestFiniteMagnitude, 130,
+            "the centreline stops at the mask rather than running the full 200 pt")
+
+        let result = try XCTUnwrap(
+            ScratchOutInk.erase(
+                scratchIndex: 1,
+                in: PKDrawing(strokes: [halfErased, stroke(scratchOut())])))
+        XCTAssertEqual(result.erasedStrokeCount, 1, "the surviving half is fully covered")
+    }
+
     func testAlreadyErasedStrokesAreNotCounted() {
         // A stroke the bitmap eraser wiped out still lives in `drawing.strokes`.
         // It renders as nothing, so a scribble over its old position must not

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0CB718F359EABB9D0B724732 /* AiPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2423823E0BE86C417B6ABBC6 /* AiPanel.swift */; };
 		0E393DAB5F03396B5BB1C127 /* PdfInk.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1C1908D5C4C66BDFFB61EC /* PdfInk.swift */; };
 		115E39AAB39E90058E9718A7 /* PdfMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21D7E5EC3C32E20B0FDC7DB /* PdfMetadata.swift */; };
+		13BB407EB986D9510A89DBB9 /* ScratchOutRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DB1457E96D2FA9A96B968DD /* ScratchOutRecognizer.swift */; };
 		18277300524A92AEDAAAEA7E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027E09C0BD7A98F4590A5878 /* ContentView.swift */; };
 		19026EE9153EC91FE9D3DB80 /* ComposerReferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D27ECCD653EDD01DC2A624 /* ComposerReferences.swift */; };
 		1E7BFBF158342C3E70EAB718 /* PdfChrome_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14F1472A7451AF57FD04ED /* PdfChrome_iOS.swift */; };
@@ -100,10 +101,12 @@
 		C70838E7CAE4DCE99455D99F /* PdfViewerView_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7A88AE6F1B577A687BEFD98 /* PdfViewerView_iOS.swift */; };
 		C7F0A762A988E52CD11D2A5E /* PdfAtomicWriter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E923D872F0FF00E6DAB9BA8 /* PdfAtomicWriter.swift */; };
 		C91E39E971206E14521EB884 /* VellumCommands_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = D960E9942F1D1D97F6629BA7 /* VellumCommands_iOS.swift */; };
+		CAE0D09A93AD11B1BED6224D /* ScratchOutRecognizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD3BBED12CD46602B3CC142 /* ScratchOutRecognizerTests.swift */; };
 		CB17BF693B55AF25352B366A /* WelcomeScreen_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB6191996494A8A84900D279 /* WelcomeScreen_iOS.swift */; };
 		CCD31E1E8A71BB0E987EC90B /* SelectionPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0B4D5702156DFEC64496C9 /* SelectionPopover.swift */; };
 		D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82487970E20F6628200C4BE /* KeychainStore.swift */; };
 		D4A79DFDB08A01D35D47933A /* AiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F38132FDC803C6ACEB43CC /* AiStore.swift */; };
+		D4E3F592FB25D9F7BBE0B010 /* ScratchOutInk_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6040B8B4AEED7AF52B89AE11 /* ScratchOutInk_iOS.swift */; };
 		D529B1BD4F7B9FA1E791246F /* PageTextPersister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504DC8725E6198531EC21429 /* PageTextPersister.swift */; };
 		D77E5170582527BDF9282B70 /* tool-descriptions.md in Resources */ = {isa = PBXBuildFile; fileRef = 3E954582457ABFF5574EC93C /* tool-descriptions.md */; };
 		DB49B34BAD564527EF5585A2 /* WebViewerTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C4546D0D679437B876586A /* WebViewerTypes.swift */; };
@@ -149,6 +152,7 @@
 		13F6592FEBC0C0187E0C35A3 /* PageTextCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextCacheTests.swift; sourceTree = "<group>"; };
 		14BA2FED5E906C5D311882E3 /* ChatGPTAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTAuth.swift; sourceTree = "<group>"; };
 		195A20D8270BAD8604C2E641 /* PdfAnnotationCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfAnnotationCodec.swift; sourceTree = "<group>"; };
+		1DB1457E96D2FA9A96B968DD /* ScratchOutRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchOutRecognizer.swift; sourceTree = "<group>"; };
 		2423823E0BE86C417B6ABBC6 /* AiPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiPanel.swift; sourceTree = "<group>"; };
 		2488488DF1D1AA471A896B4C /* ContentView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView_iOS.swift; sourceTree = "<group>"; };
 		255FC27E3D72C2319E07E6BC /* PdfViewerController_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfViewerController_iOS.swift; sourceTree = "<group>"; };
@@ -177,6 +181,7 @@
 		591147DD4B09255C3446521D /* PdfViewerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfViewerTypes.swift; sourceTree = "<group>"; };
 		59A23802792908CA275A878C /* HighlightSwatchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightSwatchButton.swift; sourceTree = "<group>"; };
 		5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightLayer.swift; sourceTree = "<group>"; };
+		6040B8B4AEED7AF52B89AE11 /* ScratchOutInk_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchOutInk_iOS.swift; sourceTree = "<group>"; };
 		65C4546D0D679437B876586A /* WebViewerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewerTypes.swift; sourceTree = "<group>"; };
 		672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageLocationChoiceSheet.swift; sourceTree = "<group>"; };
 		6F5F272385E3E99333CFC6C1 /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
@@ -216,6 +221,7 @@
 		A5003641A54B311693588C6C /* PdfPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfPersistenceTests.swift; sourceTree = "<group>"; };
 		A7A88AE6F1B577A687BEFD98 /* PdfViewerView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfViewerView_iOS.swift; sourceTree = "<group>"; };
 		A9C121F8857A7DE7430ABF90 /* ZoomHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomHandlerTests.swift; sourceTree = "<group>"; };
+		AAD3BBED12CD46602B3CC142 /* ScratchOutRecognizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchOutRecognizerTests.swift; sourceTree = "<group>"; };
 		ACABB2AAB4911563C0148AD6 /* WebNotePopovers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebNotePopovers.swift; sourceTree = "<group>"; };
 		ADF2F5E26E4CED26B69FC6D6 /* AiToolEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiToolEngine.swift; sourceTree = "<group>"; };
 		B18CA5A14795BD97D91F2056 /* AnnotationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnotationStore.swift; sourceTree = "<group>"; };
@@ -298,6 +304,7 @@
 				255FC27E3D72C2319E07E6BC /* PdfViewerController_iOS.swift */,
 				A7A88AE6F1B577A687BEFD98 /* PdfViewerView_iOS.swift */,
 				E97DF51AB1BA63B8ED2200D0 /* RegionCaptureOverlay_iOS.swift */,
+				6040B8B4AEED7AF52B89AE11 /* ScratchOutInk_iOS.swift */,
 				C25E50ECC9D39C4AF827C18D /* ScratchpadPanel_iOS.swift */,
 				721E9C680C7E5E5E6ECBFDB9 /* VellumApp_iOS.swift */,
 				D960E9942F1D1D97F6629BA7 /* VellumCommands_iOS.swift */,
@@ -369,6 +376,7 @@
 				13F6592FEBC0C0187E0C35A3 /* PageTextCacheTests.swift */,
 				524641B76B46DE4D791F4E6A /* PaneTreeTests.swift */,
 				A5003641A54B311693588C6C /* PdfPersistenceTests.swift */,
+				AAD3BBED12CD46602B3CC142 /* ScratchOutRecognizerTests.swift */,
 				2E0D324F9CE4133DCC02BBD4 /* ScratchpadImportTests.swift */,
 				709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */,
 				DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */,
@@ -417,6 +425,7 @@
 				7280818785023514C87C04C9 /* SessionService.swift */,
 				7E530DFE8240A79EA6D77961 /* WorkspaceService.swift */,
 				1B073A6D74EA890EC3F5822C /* Ai */,
+				AA721838E59888FFD0F0DF59 /* Ink */,
 				47FAD68CA0A1ACEF82AC6427 /* Pdf */,
 				F271A96845AFED2A54F2E5E3 /* Scratchpad */,
 				C66AF06BB00C617BFD3DEA2D /* Web */,
@@ -463,6 +472,14 @@
 				813D09872115F51BC0ABDBFD /* Views */,
 			);
 			path = Vellum;
+			sourceTree = "<group>";
+		};
+		AA721838E59888FFD0F0DF59 /* Ink */ = {
+			isa = PBXGroup;
+			children = (
+				1DB1457E96D2FA9A96B968DD /* ScratchOutRecognizer.swift */,
+			);
+			path = Ink;
 			sourceTree = "<group>";
 		};
 		C1D4282C52504165457363DE /* Settings */ = {
@@ -769,6 +786,8 @@
 				1F884AF6AF2ABD755DFE414D /* RecentFilesService.swift in Sources */,
 				7F04998EEE729814B58BE9D9 /* RegionCaptureOverlay_iOS.swift in Sources */,
 				AD1B694B784E1CEF4F4AAB48 /* RevealableSecureField.swift in Sources */,
+				D4E3F592FB25D9F7BBE0B010 /* ScratchOutInk_iOS.swift in Sources */,
+				13BB407EB986D9510A89DBB9 /* ScratchOutRecognizer.swift in Sources */,
 				C4FA78D55C7E718218C43A3B /* ScratchpadPanel_iOS.swift in Sources */,
 				AF8BDBA91282CA03F019C0F5 /* ScratchpadPersistence.swift in Sources */,
 				74FEEDFFEA81B37C496C03F7 /* ScratchpadStore.swift in Sources */,
@@ -814,6 +833,7 @@
 				91ACF610BE2A44480DD31843 /* PageTextCacheTests.swift in Sources */,
 				2E35DAA98C4A45A551382874 /* PaneTreeTests.swift in Sources */,
 				806EDA3BB34A3680F7B39E1B /* PdfPersistenceTests.swift in Sources */,
+				CAE0D09A93AD11B1BED6224D /* ScratchOutRecognizerTests.swift in Sources */,
 				36CA355A9BBDE3BB111BC559 /* ScratchpadImportTests.swift in Sources */,
 				FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */,
 				4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */,

--- a/Vellum/Platform/iOS/InkController_iOS.swift
+++ b/Vellum/Platform/iOS/InkController_iOS.swift
@@ -126,6 +126,18 @@ final class InkController_iOS {
     static var autoHideSidebarWhileInking: Bool {
         UserDefaults.standard.object(forKey: autoHideSidebarKey) as? Bool ?? true
     }
+
+    /// User preference: whether scribbling over existing ink with the pen erases
+    /// what the scribble covers, instead of leaving the scribble as ink (see
+    /// `ScratchOutRecognizer`). Defaults to on — it matches Notes/GoodNotes and
+    /// the recognizer is tuned to be conservative — but it is a *destructive*
+    /// gesture, so anyone whose drawing style trips it (heavy hatching over an
+    /// existing sketch is the plausible case) needs a way out. Persisted under
+    /// `scratchOutToEraseKey`.
+    static let scratchOutToEraseKey = "ink.scratchOutToErase"
+    static var scratchOutToErase: Bool {
+        UserDefaults.standard.object(forKey: scratchOutToEraseKey) as? Bool ?? true
+    }
     var tool: InkTool = .pen {
         didSet {
             guard oldValue != tool else { return }

--- a/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
+++ b/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
@@ -14,6 +14,14 @@ final class InkPageCanvas_iOS: PKCanvasView {
     /// page's zoom-1 space; `K` only makes PencilKit rasterize that content into
     /// a `K`× denser backing store. `1` means "same as the page".
     var superSample: CGFloat = 1
+    /// The drawing as of the last change this provider processed.
+    ///
+    /// PencilKit hands the delegate the whole drawing, never "the stroke that
+    /// just landed", so scratch-out detection diffs against this to find the
+    /// stroke the user just finished — and the scratch-out undo action restores
+    /// it. It is refreshed on seeding *and* on every delegate callback, so a
+    /// programmatic mutation (clear page, undo, redo) can never leave it stale.
+    var committedDrawing = PKDrawing()
 }
 
 /// Wraps a page's ink canvas so we can super-sample it. PDFKit sizes this
@@ -168,6 +176,7 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
         suppressChange = true
         let seeded = PdfInk.drawing(on: page) ?? PKDrawing()
         canvas.drawing = seeded
+        canvas.committedDrawing = seeded
         suppressChange = false
         PdfInk.removeVellumInk(from: page)
         if !seeded.strokes.isEmpty {
@@ -290,10 +299,87 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
         guard !suppressChange,
               let canvas = canvasView as? InkPageCanvas_iOS,
               canvas.pageNumber >= 1 else { return }
+        // Scratch-out runs first, and synchronously (see `applyScratchOut`): if
+        // the stroke the user just finished is a scribble over existing ink, what
+        // we persist is the *post*-erase drawing, so the scribble itself never
+        // reaches the canvas's steady state or the disk.
+        let drawing = scratchOutErase(on: canvas) ?? canvasView.drawing
+        canvas.committedDrawing = drawing
         // The canvas's content space is page (zoom-1) space at every `K`, so the
         // drawing persists as-is and the on-disk `/Ink` geometry is
         // resolution-independent.
-        ink?.drawingChanged(canvasView.drawing, page: canvas.pageNumber)
+        ink?.drawingChanged(drawing, page: canvas.pageNumber)
+    }
+
+    // MARK: - Scratch out to erase
+
+    /// If the stroke the user just finished is a scratch-out over existing ink,
+    /// delete it and everything it covered and return the resulting drawing.
+    /// `nil` means "nothing to do" — the caller persists the drawing unchanged.
+    ///
+    /// Preconditions beyond the geometry (see `ScratchOutRecognizer` for those):
+    /// * the user has the feature on (Settings ▸ Reading ▸ Apple Pencil);
+    /// * ink mode is active, so this can only ever be a stroke the user drew;
+    /// * an **inking** tool is selected, and specifically the *pen*. The
+    ///   highlighter is excluded because sweeping a marker back and forth over a
+    ///   word to deepen the highlight is a legitimate, common action with exactly
+    ///   the geometry of a scratch-out. The eraser is excluded because it can't
+    ///   produce a stroke at all;
+    /// * the drawing grew by exactly one stroke. Anything else — a bitmap erase
+    ///   (masks strokes, count unchanged), a vector erase (count drops), an undo,
+    ///   a programmatic clear — is not a freshly drawn stroke. PencilKit appends
+    ///   new strokes, so the last one is the one that just landed.
+    private func scratchOutErase(on canvas: InkPageCanvas_iOS) -> PKDrawing? {
+        guard InkController_iOS.scratchOutToErase,
+              let ink, ink.isActive, ink.tool == .pen else { return nil }
+        let drawing = canvas.drawing
+        guard drawing.strokes.count == canvas.committedDrawing.strokes.count + 1 else { return nil }
+        guard let result = ScratchOutInk.erase(
+            scratchIndex: drawing.strokes.count - 1,
+            in: drawing) else { return nil }
+
+        #if DEBUG
+        NSLog("[ink-debug] scratch-out on page %d erased %d stroke(s)",
+              canvas.pageNumber, result.erasedStrokeCount)
+        #endif
+        applyScratchOut(result.drawing, undoingTo: canvas.committedDrawing, on: canvas)
+        return result.drawing
+    }
+
+    /// Swap a canvas's drawing for `new`, registering an undo that restores
+    /// `old`. Recursive by design: the undo's own registration becomes the redo.
+    ///
+    /// ## Undo grouping
+    /// `old` is deliberately the drawing from *before* the scribble was drawn,
+    /// not the drawing PencilKit just handed us. PencilKit has already registered
+    /// its own "I added a stroke" undo for the scribble; because this runs
+    /// synchronously inside `canvasViewDrawingDidChange` — the same run-loop
+    /// iteration as that registration — UIKit's `UndoManager.groupsByEvent`
+    /// folds both actions into a single group, so one ⌘Z (or one toolbar undo)
+    /// restores every erased stroke at once.
+    ///
+    /// Restoring the *pre-scribble* drawing also makes the pairing degrade
+    /// safely if the two actions ever land in separate groups: the first undo
+    /// already puts the page back exactly as it was, and PencilKit's leftover
+    /// "remove the scribble" action then applies to a drawing that no longer
+    /// contains it — a no-op, not a corruption.
+    private func applyScratchOut(
+        _ new: PKDrawing,
+        undoingTo old: PKDrawing,
+        on canvas: InkPageCanvas_iOS
+    ) {
+        canvas.undoManager?.registerUndo(withTarget: self) { [weak canvas] provider in
+            guard let canvas else { return }
+            provider.applyScratchOut(old, undoingTo: new, on: canvas)
+            provider.ink?.drawingChanged(old, page: canvas.pageNumber)
+        }
+        canvas.undoManager?.setActionName("Erase")
+        // Reassigning `drawing` re-enters the delegate; suppress so the swap
+        // isn't mistaken for a second user edit (and re-scanned for scratch-out).
+        suppressChange = true
+        canvas.drawing = new
+        suppressChange = false
+        canvas.committedDrawing = new
     }
 
     // MARK: - UIPencilInteractionDelegate

--- a/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
+++ b/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
@@ -22,6 +22,11 @@ final class InkPageCanvas_iOS: PKCanvasView {
     /// it. It is refreshed on seeding *and* on every delegate callback, so a
     /// programmatic mutation (clear page, undo, redo) can never leave it stale.
     var committedDrawing = PKDrawing()
+    /// Guards *this* canvas's programmatic `drawing =` assignments from being
+    /// mistaken for user edits. Per-canvas rather than provider-wide so
+    /// suppressing one page can never swallow another page's change callback
+    /// (which would drop that page's stroke before it was ever persisted).
+    var suppressChange = false
 }
 
 /// Wraps a page's ink canvas so we can super-sample it. PDFKit sizes this
@@ -114,9 +119,10 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
     /// Pages PDFKit currently has on screen — only these are super-sampled (so an
     /// inked page that scrolled away doesn't retain a large high-res bitmap).
     private var displayedKeys: Set<ObjectIdentifier> = []
-    /// Guards programmatic `canvas.drawing =` seeding/rescaling from triggering a
-    /// persist.
-    private var suppressChange = false
+    // NB: the guard against programmatic `canvas.drawing =` assignments being
+    // mistaken for user edits lives on the canvas (`InkPageCanvas_iOS
+    // .suppressChange`), not here — a provider-wide flag would let one page's
+    // suppression window swallow another page's change callback.
 
     /// The PDFView's current zoom, tracked so freshly-installed / rescaled pages
     /// pick the right super-sample factor immediately.
@@ -173,11 +179,11 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
         // is page space at every `K`, so this is a straight copy — then strip
         // the page's native ink so the display document doesn't double-render
         // behind the canvas.
-        suppressChange = true
+        canvas.suppressChange = true
         let seeded = PdfInk.drawing(on: page) ?? PKDrawing()
         canvas.drawing = seeded
         canvas.committedDrawing = seeded
-        suppressChange = false
+        canvas.suppressChange = false
         PdfInk.removeVellumInk(from: page)
         if !seeded.strokes.isEmpty {
             // Let observers (the sidebar's Handwriting chips) know ink exists
@@ -296,8 +302,8 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
     // MARK: - PKCanvasViewDelegate
 
     func canvasViewDrawingDidChange(_ canvasView: PKCanvasView) {
-        guard !suppressChange,
-              let canvas = canvasView as? InkPageCanvas_iOS,
+        guard let canvas = canvasView as? InkPageCanvas_iOS,
+              !canvas.suppressChange,
               canvas.pageNumber >= 1 else { return }
         // Scratch-out runs first, and synchronously (see `applyScratchOut`): if
         // the stroke the user just finished is a scribble over existing ink, what
@@ -325,24 +331,34 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
     ///   word to deepen the highlight is a legitimate, common action with exactly
     ///   the geometry of a scratch-out. The eraser is excluded because it can't
     ///   produce a stroke at all;
-    /// * the drawing grew by exactly one stroke. Anything else — a bitmap erase
-    ///   (masks strokes, count unchanged), a vector erase (count drops), an undo,
-    ///   a programmatic clear — is not a freshly drawn stroke. PencilKit appends
-    ///   new strokes, so the last one is the one that just landed.
+    /// * we are not inside an undo or redo. `UndoManager` mutating the drawing
+    ///   fires this delegate too, and undoing a single-stroke object-erase
+    ///   restores exactly one stroke — indistinguishable by count from the user
+    ///   drawing one. Without this guard, undo could re-run the recognizer and
+    ///   erase ink *while restoring* it, and the erase would register its own
+    ///   action onto the redo stack mid-group;
+    /// * exactly one stroke was appended, with every earlier stroke unchanged
+    ///   (`ScratchOutInk.appendedStrokeIndex`). A bitmap erase (masks strokes,
+    ///   count unchanged), a vector erase (count drops) and a programmatic clear
+    ///   all fail that test.
     private func scratchOutErase(on canvas: InkPageCanvas_iOS) -> PKDrawing? {
         guard InkController_iOS.scratchOutToErase,
               let ink, ink.isActive, ink.tool == .pen else { return nil }
+        let undoManager = canvas.undoManager
+        guard undoManager?.isUndoing != true, undoManager?.isRedoing != true else { return nil }
+
         let drawing = canvas.drawing
-        guard drawing.strokes.count == canvas.committedDrawing.strokes.count + 1 else { return nil }
-        guard let result = ScratchOutInk.erase(
-            scratchIndex: drawing.strokes.count - 1,
-            in: drawing) else { return nil }
+        guard let scratchIndex = ScratchOutInk.appendedStrokeIndex(
+            in: drawing, after: canvas.committedDrawing) else { return nil }
+        guard let result = ScratchOutInk.erase(scratchIndex: scratchIndex, in: drawing) else {
+            return nil
+        }
 
         #if DEBUG
         NSLog("[ink-debug] scratch-out on page %d erased %d stroke(s)",
               canvas.pageNumber, result.erasedStrokeCount)
         #endif
-        applyScratchOut(result.drawing, undoingTo: canvas.committedDrawing, on: canvas)
+        applyScratchOut(result.drawing, undoingTo: drawing, on: canvas)
         return result.drawing
     }
 
@@ -350,19 +366,26 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
     /// `old`. Recursive by design: the undo's own registration becomes the redo.
     ///
     /// ## Undo grouping
-    /// `old` is deliberately the drawing from *before* the scribble was drawn,
-    /// not the drawing PencilKit just handed us. PencilKit has already registered
-    /// its own "I added a stroke" undo for the scribble; because this runs
-    /// synchronously inside `canvasViewDrawingDidChange` — the same run-loop
-    /// iteration as that registration — UIKit's `UndoManager.groupsByEvent`
-    /// folds both actions into a single group, so one ⌘Z (or one toolbar undo)
-    /// restores every erased stroke at once.
+    /// `old` is the drawing PencilKit just handed us — the one that still
+    /// contains the scribble — *not* the pre-scribble drawing. That choice is
+    /// what makes the undo correct without depending on anything we cannot
+    /// verify:
     ///
-    /// Restoring the *pre-scribble* drawing also makes the pairing degrade
-    /// safely if the two actions ever land in separate groups: the first undo
-    /// already puts the page back exactly as it was, and PencilKit's leftover
-    /// "remove the scribble" action then applies to a drawing that no longer
-    /// contains it — a no-op, not a corruption.
+    /// PencilKit has already registered its own "I added a stroke" undo for the
+    /// scribble. If UIKit's `UndoManager.groupsByEvent` folds that registration
+    /// and ours into one group, a single ⌘Z runs both in reverse — ours restores
+    /// the scribble and its victims, then PencilKit's removes the scribble —
+    /// landing exactly on the pre-scribble page. If the two land in *separate*
+    /// groups, the user presses undo twice and sees the same two steps
+    /// individually, each of them coherent.
+    ///
+    /// Separate groups are a real possibility: `PKCanvasViewDelegate` documents
+    /// that `canvasViewDrawingDidChange` "may be called some time after
+    /// `canvasViewDidEndUsingTool`" because Apple Pencil pressure data lags touch
+    /// data — which is precisely the path this feature runs on. Handing
+    /// PencilKit's action back the state it expects (a drawing whose last stroke
+    /// is the scribble) means we never have to care which way it went, and never
+    /// depend on whether PencilKit's own undo is snapshot- or delta-based.
     private func applyScratchOut(
         _ new: PKDrawing,
         undoingTo old: PKDrawing,
@@ -376,9 +399,14 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
         canvas.undoManager?.setActionName("Erase")
         // Reassigning `drawing` re-enters the delegate; suppress so the swap
         // isn't mistaken for a second user edit (and re-scanned for scratch-out).
-        suppressChange = true
+        // Per-canvas and saved/restored rather than a provider-wide set/clear: a
+        // delegate callback for a *different* page arriving inside this window
+        // would otherwise be dropped entirely — no `drawingChanged`, so that
+        // page's stroke would never be written to disk.
+        let wasSuppressed = canvas.suppressChange
+        canvas.suppressChange = true
         canvas.drawing = new
-        suppressChange = false
+        canvas.suppressChange = wasSuppressed
         canvas.committedDrawing = new
     }
 

--- a/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
+++ b/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
@@ -245,6 +245,20 @@ final class InkOverlayProvider_iOS: NSObject, @preconcurrency PDFPageOverlayView
     /// replaced document are unreachable and would otherwise leak.
     func resetCache() {
         rescaleTask?.cancel()
+        // Drop any scratch-out undo actions still pointing at this provider
+        // before the canvases go. The undo manager comes from the responder
+        // chain, so it outlives the document swap: a stale action firing later
+        // would restore the *old* document's drawing and — via
+        // `drawingChanged(_:page:)` — write it over the new document's page.
+        // `withTarget:` scopes the removal to our own actions; PencilKit's are
+        // registered against its own targets and are left alone.
+        // Iterating every canvas rather than just one: the undo manager is
+        // resolved through each canvas's responder chain, so in a split view two
+        // pages can legitimately answer with different managers. The call is
+        // idempotent, so hitting the same manager twice is free.
+        for container in containers.values {
+            container.canvas.undoManager?.removeAllActions(withTarget: self)
+        }
         containers.removeAll()
         displayedKeys.removeAll()
     }

--- a/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
+++ b/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
@@ -74,10 +74,18 @@ enum ScratchOutInk {
         // fully masked away — they render as nothing, so "erasing" them would
         // silently delete invisible objects the user can't reason about.
         let scratchReach = max(minimumHitRadius, halfWidth(of: scratch) + hitSlack)
+        // Bounds prefilter before paying for centreline sampling: `renderBounds`
+        // is already computed by PencilKit and includes the stroke's rendered
+        // width, and on a densely inked page almost every stroke is nowhere near
+        // the scribble. Without this, a scratch-out on a full page of notes
+        // resamples every stroke on it.
+        let reach = scratch.renderBounds.insetBy(dx: -scratchReach, dy: -scratchReach)
         var candidates: [ScratchOutRecognizer.OverlapCandidate] = []
         var candidateIndices: [Int] = []
         for (index, stroke) in strokes.enumerated() where index != scratchIndex {
-            guard PdfInk.strokeHasVisibleInk(stroke) else { continue }
+            guard PdfInk.strokeHasVisibleInk(stroke), stroke.renderBounds.intersects(reach) else {
+                continue
+            }
             candidates.append(ScratchOutRecognizer.OverlapCandidate(
                 points: centerline(of: stroke),
                 hitRadius: scratchReach + halfWidth(of: stroke)))

--- a/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
+++ b/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
@@ -104,19 +104,60 @@ enum ScratchOutInk {
         return Result(drawing: PKDrawing(strokes: kept), erasedStrokeCount: doomed.count - 1)
     }
 
-    /// A stroke's centreline in page space, resampled at `sampleSpacing`.
+    /// Index of the single stroke `drawing` has that `previous` didn't, but only
+    /// if every earlier stroke is unchanged — i.e. only if this really was an
+    /// *append*. `nil` otherwise.
+    ///
+    /// The count alone (`previous.count + 1`) is not enough. Undoing a
+    /// single-stroke object-erase also restores exactly one stroke, and it does
+    /// not have to come back at the end; taking `strokes.last` on that callback
+    /// would run the recognizer against an unrelated older stroke and, if that
+    /// one happened to be scribble-shaped and over ink, delete it and everything
+    /// under it. Comparing the prefix makes "a stroke landed at the end" a fact
+    /// rather than an assumption.
+    static func appendedStrokeIndex(in drawing: PKDrawing, after previous: PKDrawing) -> Int? {
+        let strokes = drawing.strokes
+        let old = previous.strokes
+        guard strokes.count == old.count + 1 else { return nil }
+        for index in old.indices where !isSameStroke(strokes[index], old[index]) { return nil }
+        return old.count
+    }
+
+    /// Cheap identity proxy. `PKStroke` isn't `Equatable`, but a stroke's path
+    /// creation date, control-point count and rendered bounds together are
+    /// specific enough to tell "this is the same stroke object" from "the list
+    /// shifted underneath us", which is all `appendedStrokeIndex` needs.
+    private static func isSameStroke(_ lhs: PKStroke, _ rhs: PKStroke) -> Bool {
+        lhs.path.creationDate == rhs.path.creationDate
+            && lhs.path.count == rhs.path.count
+            && lhs.renderBounds == rhs.renderBounds
+    }
+
+    /// A stroke's *visible* centreline in page space, resampled at
+    /// `sampleSpacing`.
+    ///
+    /// Only the surviving `maskedPathRanges` are walked. This matters for
+    /// coverage: the bitmap eraser masks a stroke rather than shortening it, so
+    /// sampling the whole path would measure the fraction covered against the
+    /// stroke's *original* length. Erase the right half of a word with the pixel
+    /// eraser, then scribble over the surviving left half, and a full-path
+    /// denominator scores ≈0.5 — just under `minimumCoverage` — leaving the
+    /// remnant behind even though the user covered all of it.
+    ///
     /// `stroke.transform` must be applied: PencilKit stores a path plus a
     /// transform, and undo/redo can leave a non-identity one behind.
     static func centerline(of stroke: PKStroke) -> [CGPoint] {
         guard !stroke.path.isEmpty else { return [] }
         var points: [CGPoint] = []
-        for point in stroke.path.interpolatedPoints(by: .distance(sampleSpacing)) {
-            points.append(point.location.applying(stroke.transform))
+        for range in stroke.maskedPathRanges {
+            for point in stroke.path.interpolatedPoints(in: range, by: .distance(sampleSpacing)) {
+                points.append(point.location.applying(stroke.transform))
+            }
         }
-        // A tap-dot can interpolate to nothing; fall back to the control point so
-        // the stroke still has a position for the overlap test.
-        if points.isEmpty {
-            points.append(stroke.path[0].location.applying(stroke.transform))
+        // A tap-dot can interpolate to nothing; fall back to the first control
+        // point so the stroke still has a position for the overlap test.
+        if points.isEmpty, let first = stroke.path.first {
+            points.append(first.location.applying(stroke.transform))
         }
         return points
     }

--- a/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
+++ b/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
@@ -144,8 +144,17 @@ enum ScratchOutInk {
     /// denominator scores ≈0.5 — just under `minimumCoverage` — leaving the
     /// remnant behind even though the user covered all of it.
     ///
-    /// `stroke.transform` must be applied: PencilKit stores a path plus a
-    /// transform, and undo/redo can leave a non-identity one behind.
+    /// `stroke.transform` must be applied: PencilKit stores a stroke as a path
+    /// plus a transform, and only the composition is in the drawing's coordinate
+    /// space — which is the space `renderBounds` and the scribble's own samples
+    /// are in, so skipping it would silently compare two different spaces.
+    ///
+    /// One caveat: `interpolatedPoints(by: .distance(_:))` strides in the path's
+    /// *pre*-transform space, so if a transform ever carried a scale the samples
+    /// would not be evenly spaced in page space and `coveredFraction`'s
+    /// "sample count stands in for arc length" premise would skew. Nothing in
+    /// this app scales a drawing (`PKDrawing.transformed(using:)` is never
+    /// called), so in practice the transform is a translation at most.
     static func centerline(of stroke: PKStroke) -> [CGPoint] {
         guard !stroke.path.isEmpty else { return [] }
         var points: [CGPoint] = []

--- a/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
+++ b/Vellum/Platform/iOS/ScratchOutInk_iOS.swift
@@ -1,0 +1,128 @@
+#if os(iOS)
+import CoreGraphics
+import Foundation
+import PencilKit
+
+/// Adapts `ScratchOutRecognizer` (pure geometry) to PencilKit: samples stroke
+/// centrelines, decides whether the stroke the user just finished is a
+/// scratch-out, and produces the drawing that should replace the current one.
+///
+/// ## Erase semantics
+/// Scratch-out always removes **whole strokes**, i.e. it behaves like the
+/// eraser's `.object` mode even when the user's eraser is set to `.pixel`. Two
+/// reasons:
+/// * PencilKit exposes no API to apply a bitmap mask to a `PKStroke`
+///   programmatically — `PKEraserTool(.bitmap)` masking only happens inside the
+///   canvas's own touch handling — so a pixel-accurate erase simply isn't
+///   reachable from here.
+/// * It is also the right semantics: scratching something out means "delete this
+///   thing", not "shave the pixels I happened to cross". Notes and GoodNotes both
+///   remove the whole stroke. The `minimumCoverage` guard is what makes that safe
+///   — a stroke is only removed when the scribble covers most of its length.
+///
+/// Everything runs in page (zoom-1) space, which is the canvas's content space at
+/// every super-sample factor `K` (see `InkOverlayProvider_iOS`), so the
+/// thresholds mean the same thing at 100% and at 400% zoom.
+enum ScratchOutInk {
+    /// Spacing used to resample every stroke centreline. Uniform spacing is what
+    /// lets `coveredFraction` treat "fraction of samples covered" as "fraction of
+    /// arc length covered". 3 pt is fine enough to follow the tightest handwriting
+    /// curve and coarse enough that the O(candidate × scratch) coverage scan on a
+    /// densely inked page stays well inside one frame.
+    static let sampleSpacing: CGFloat = 3
+
+    /// Slack added to the hit radius on top of both strokes' half-widths, to
+    /// absorb the fact that people scribble roughly and that a centreline sample
+    /// is not the edge of the rendered stroke. Small enough that neighbouring
+    /// lines of handwriting (typically ≥ 12 pt apart) don't get swept up.
+    static let hitSlack: CGFloat = 3
+
+    /// Floor on the hit radius so a hairline 2 pt pen scribbled over hairline ink
+    /// still registers coverage despite hand wobble.
+    static let minimumHitRadius: CGFloat = 7
+
+    /// The outcome of a recognized scratch-out.
+    struct Result: Sendable {
+        /// The drawing with the scribble and everything it covered removed.
+        var drawing: PKDrawing
+        /// How many pre-existing strokes were removed (excludes the scribble).
+        var erasedStrokeCount: Int
+    }
+
+    /// If `drawing.strokes[scratchIndex]` is a scratch-out that substantially
+    /// covers other strokes, return the drawing with it and its victims removed.
+    ///
+    /// `nil` means "leave the drawing alone" — either the stroke isn't a
+    /// scratch-out, or it is scribble-shaped but sits on blank paper. That second
+    /// case is the most important false-positive guard in the feature: an
+    /// idle doodle, a shading pass or a hatched fill drawn on empty space is
+    /// simply kept as ink.
+    static func erase(
+        scratchIndex: Int,
+        in drawing: PKDrawing,
+        thresholds: ScratchOutRecognizer.Thresholds = .default
+    ) -> Result? {
+        let strokes = drawing.strokes
+        guard strokes.indices.contains(scratchIndex) else { return nil }
+        let scratch = strokes[scratchIndex]
+        guard PdfInk.strokeHasVisibleInk(scratch) else { return nil }
+
+        let scratchPath = centerline(of: scratch)
+        guard ScratchOutRecognizer.isScratchOut(scratchPath, thresholds: thresholds) else { return nil }
+
+        // Build the candidate list, skipping strokes the bitmap eraser has already
+        // fully masked away — they render as nothing, so "erasing" them would
+        // silently delete invisible objects the user can't reason about.
+        let scratchReach = max(minimumHitRadius, halfWidth(of: scratch) + hitSlack)
+        var candidates: [ScratchOutRecognizer.OverlapCandidate] = []
+        var candidateIndices: [Int] = []
+        for (index, stroke) in strokes.enumerated() where index != scratchIndex {
+            guard PdfInk.strokeHasVisibleInk(stroke) else { continue }
+            candidates.append(ScratchOutRecognizer.OverlapCandidate(
+                points: centerline(of: stroke),
+                hitRadius: scratchReach + halfWidth(of: stroke)))
+            candidateIndices.append(index)
+        }
+
+        let hits = ScratchOutRecognizer.overlappedCandidates(
+            scratch: scratchPath,
+            candidates: candidates,
+            thresholds: thresholds)
+        guard !hits.isEmpty else { return nil }
+
+        var doomed = Set(hits.map { candidateIndices[$0] })
+        doomed.insert(scratchIndex)
+        let kept = strokes.enumerated().filter { !doomed.contains($0.offset) }.map(\.element)
+        return Result(drawing: PKDrawing(strokes: kept), erasedStrokeCount: doomed.count - 1)
+    }
+
+    /// A stroke's centreline in page space, resampled at `sampleSpacing`.
+    /// `stroke.transform` must be applied: PencilKit stores a path plus a
+    /// transform, and undo/redo can leave a non-identity one behind.
+    static func centerline(of stroke: PKStroke) -> [CGPoint] {
+        guard !stroke.path.isEmpty else { return [] }
+        var points: [CGPoint] = []
+        for point in stroke.path.interpolatedPoints(by: .distance(sampleSpacing)) {
+            points.append(point.location.applying(stroke.transform))
+        }
+        // A tap-dot can interpolate to nothing; fall back to the control point so
+        // the stroke still has a position for the overlap test.
+        if points.isEmpty {
+            points.append(stroke.path[0].location.applying(stroke.transform))
+        }
+        return points
+    }
+
+    /// Mean rendered half-width of a stroke, matching how `PdfInk` measures width
+    /// (`PKStrokePoint.size` is the full ellipse, so a quarter of w+h is the
+    /// average radius).
+    static func halfWidth(of stroke: PKStroke) -> CGFloat {
+        guard !stroke.path.isEmpty else { return 0 }
+        var total: CGFloat = 0
+        for point in stroke.path {
+            total += (point.size.width + point.size.height) / 4
+        }
+        return total / CGFloat(stroke.path.count)
+    }
+}
+#endif

--- a/Vellum/Services/Ink/ScratchOutRecognizer.swift
+++ b/Vellum/Services/Ink/ScratchOutRecognizer.swift
@@ -1,0 +1,351 @@
+import CoreGraphics
+import Foundation
+
+/// Pure geometry behind "scribble to erase": decide whether one finished ink
+/// stroke is a *scratch-out* (a back-and-forth scribble meaning "delete this"),
+/// and work out which existing strokes that scribble covered.
+///
+/// Everything here is a pure function over `CGPoint` arrays — no PencilKit, no
+/// UIKit, no canvas state — so the heuristic can be unit-tested against
+/// synthesized shapes. `ScratchOutInk` (iOS) is the thin adapter that samples
+/// `PKStroke` centrelines and feeds them in.
+///
+/// ## Why these signals
+/// The two properties that separate a scratch-out from real handwriting are:
+///
+/// 1. **Reversals along the stroke's own principal axis.** A scratch-out sweeps
+///    back and forth along one line; letters do not. Crucially we project onto
+///    the stroke's *principal* (largest-variance) axis rather than counting raw
+///    turns, because that is what kills the classic false positive: cursive
+///    `m`/`w`/`mmm` is a pile of sharp turns, but the pen still travels
+///    monotonically left-to-right, so it registers **zero** reversals along its
+///    principal (horizontal) axis. A scribble over the same word registers one
+///    per pass.
+/// 2. **Density** — path length relative to the bounding box diagonal. A
+///    scratch-out re-covers ground it already covered; a letter, an underline
+///    or a circle travels roughly once around its own bounding box.
+///
+/// Self-intersection counting (the other textbook scribble signal) is
+/// deliberately *not* used: a pure sawtooth scratch-out — probably the most
+/// common shape people draw — has zero self-intersections, so requiring them
+/// would miss the main case, while allowing them as an alternative trigger
+/// would fire on ordinary cursive (`e`, `l`, `b` and friends each self-cross).
+///
+/// The recognizer is only half of the guard. The caller must *also* require the
+/// scribble to substantially cover existing ink (`overlappedCandidates`), so a
+/// scribble on blank paper is kept as ordinary ink rather than eaten.
+enum ScratchOutRecognizer {
+    /// Every tunable in one place. Values are in page (zoom-1) points — the
+    /// same space stroke geometry is stored in, so a scratch-out is judged
+    /// identically whether the user drew it at 100% or 400% zoom.
+    struct Thresholds: Sendable, Equatable {
+        /// Minimum spacing when thinning the input polyline. Apple Pencil
+        /// samples at ~240 Hz, so a slow pass produces clusters of points whose
+        /// pairwise directions are pure noise; anything below this is dropped.
+        /// 2 pt is below the width of the thinnest pen preset, so thinning can
+        /// never erase a real feature of the path.
+        var resampleSpacing: CGFloat = 2
+
+        /// A scratch-out is a long gesture. Below this many thinned samples the
+        /// "stroke" is a tick, a dot or an accent, and the statistics below are
+        /// too noisy to trust.
+        var minimumPointCount: Int = 8
+
+        /// Total path length floor. 40 pt is roughly three passes over a single
+        /// 12 pt character — under that the user is writing, not scrubbing.
+        /// This alone rejects almost all individual letter strokes, which is why
+        /// printed handwriting (one short stroke per letter) is safe by
+        /// construction.
+        var minimumPathLength: CGFloat = 40
+
+        /// How far the pen must travel back along the principal axis before a
+        /// turn counts as a real reversal (hysteresis). 8 pt is larger than
+        /// handwriting tremor and larger than the retrace at the top of a
+        /// cursive loop, but far smaller than a deliberate scrub pass.
+        var minimumReversalTravel: CGFloat = 8
+
+        /// How many confirmed reversals are required. 4 reversals means at least
+        /// **5** directional passes over the same line. No Latin letterform
+        /// needs that: `M` and `W` are 3 passes (2 reversals), `N` and `Z` are 2
+        /// passes. Set deliberately above the busiest letter so that a single
+        /// sloppy character can never trip the gesture; the cost is that a very
+        /// lazy two-pass scribble is treated as ink, which is the failure
+        /// direction we want.
+        var minimumReversals: Int = 4
+
+        /// Path length ÷ bounding-box diagonal. A straight line scores 1.0, a
+        /// circle ≈ 2.2, a printed word ≈ 2, and a 5-pass scribble ≈ 5. 2.5
+        /// sits above every "travels once around its own box" shape — notably a
+        /// circle, which the reversal test alone would not reject as firmly.
+        var minimumDensity: CGFloat = 2.5
+
+        /// Fraction of an existing stroke's length that must sit under the
+        /// scribble before that stroke is erased. 0.5 encodes "substantially
+        /// overlaps": scribbling over a word wipes each letter stroke (they are
+        /// short and end up fully covered) while a scribble that merely *crosses*
+        /// a long underline or a diagram edge leaves it alone.
+        var minimumCoverage: CGFloat = 0.5
+
+        static let `default` = Thresholds()
+    }
+
+    /// The measured geometry of a candidate stroke. Returned separately from the
+    /// boolean so tests (and a DEBUG log) can see *why* a stroke was or was not
+    /// recognized instead of only that it wasn't.
+    struct Metrics: Sendable, Equatable {
+        var pointCount: Int
+        var pathLength: CGFloat
+        var boundingBox: CGRect
+        var principalAxis: CGVector
+        var reversals: Int
+        /// `pathLength / boundingBox` diagonal; 0 for a degenerate box.
+        var density: CGFloat
+    }
+
+    // MARK: - Recognition
+
+    /// Whether `points` (a stroke centreline in page space) is a scratch-out.
+    static func isScratchOut(_ points: [CGPoint], thresholds: Thresholds = .default) -> Bool {
+        let metrics = metrics(for: points, thresholds: thresholds)
+        return metrics.pointCount >= thresholds.minimumPointCount
+            && metrics.pathLength >= thresholds.minimumPathLength
+            && metrics.reversals >= thresholds.minimumReversals
+            && metrics.density >= thresholds.minimumDensity
+    }
+
+    /// Measure `points` without judging them.
+    static func metrics(for points: [CGPoint], thresholds: Thresholds = .default) -> Metrics {
+        let thinned = thinned(points, spacing: thresholds.resampleSpacing)
+        guard thinned.count >= 2 else {
+            return Metrics(
+                pointCount: thinned.count,
+                pathLength: 0,
+                boundingBox: .null,
+                principalAxis: CGVector(dx: 1, dy: 0),
+                reversals: 0,
+                density: 0)
+        }
+
+        let box = boundingBox(of: thinned)
+        let length = pathLength(of: thinned)
+        let axis = principalAxis(of: thinned)
+        let projections = thinned.map { $0.x * axis.dx + $0.y * axis.dy }
+        let diagonal = hypot(box.width, box.height)
+
+        return Metrics(
+            pointCount: thinned.count,
+            pathLength: length,
+            boundingBox: box,
+            principalAxis: axis,
+            reversals: reversals(in: projections, minimumTravel: thresholds.minimumReversalTravel),
+            density: diagonal > 0 ? length / diagonal : 0)
+    }
+
+    // MARK: - Overlap selection
+
+    /// One existing stroke considered for deletion, already reduced to its
+    /// centreline. `hitRadius` folds in both strokes' rendered half-widths, so a
+    /// fat marker line counts as covered when the scribble passes near — not
+    /// only dead through — its centre.
+    struct OverlapCandidate: Sendable, Equatable {
+        var points: [CGPoint]
+        var hitRadius: CGFloat
+
+        init(points: [CGPoint], hitRadius: CGFloat) {
+            self.points = points
+            self.hitRadius = hitRadius
+        }
+    }
+
+    /// Indices of the candidates the scribble substantially covers.
+    ///
+    /// "Substantially" is a *length* fraction, not a hit test: a single crossing
+    /// point is not enough. That is what keeps a scratch-out from taking out the
+    /// long underline or table rule it happens to sit on top of, while still
+    /// wiping the short strokes that make up the word being deleted.
+    static func overlappedCandidates(
+        scratch: [CGPoint],
+        candidates: [OverlapCandidate],
+        thresholds: Thresholds = .default
+    ) -> [Int] {
+        guard scratch.count >= 2 else { return [] }
+        let scratchBox = boundingBox(of: scratch)
+
+        var hits: [Int] = []
+        for (index, candidate) in candidates.enumerated() {
+            guard candidate.points.count >= 1 else { continue }
+            // Cheap reject first: the coverage scan below is O(candidate × scratch).
+            let reach = scratchBox.insetBy(dx: -candidate.hitRadius, dy: -candidate.hitRadius)
+            guard reach.intersects(boundingBox(of: candidate.points)) else { continue }
+            let covered = coveredFraction(
+                of: candidate.points,
+                by: scratch,
+                within: candidate.hitRadius,
+                giveUpBelow: thresholds.minimumCoverage)
+            if covered >= thresholds.minimumCoverage { hits.append(index) }
+        }
+        return hits
+    }
+
+    /// Fraction of `polyline`'s samples that lie within `radius` of `path`.
+    ///
+    /// Sample-count is used as a stand-in for arc length, which is exact as long
+    /// as the caller samples at a uniform spacing (`ScratchOutInk` does).
+    /// `giveUpBelow` lets the scan bail as soon as enough samples have missed
+    /// that the threshold is unreachable.
+    static func coveredFraction(
+        of polyline: [CGPoint],
+        by path: [CGPoint],
+        within radius: CGFloat,
+        giveUpBelow: CGFloat = 0
+    ) -> CGFloat {
+        guard !polyline.isEmpty, path.count >= 2 else { return 0 }
+        let total = CGFloat(polyline.count)
+        var covered = 0
+        var missed = 0
+        let allowedMisses = Int((1 - giveUpBelow) * total)
+        for point in polyline {
+            if distance(from: point, toPolyline: path) <= radius {
+                covered += 1
+            } else {
+                missed += 1
+                if missed > allowedMisses { return 0 }
+            }
+        }
+        return CGFloat(covered) / total
+    }
+
+    // MARK: - Geometry primitives
+
+    /// Drop samples closer together than `spacing`, keeping the first and last.
+    /// The final sample is always kept because the last leg of a scratch-out is
+    /// often a short flick, and losing it would hide a reversal.
+    static func thinned(_ points: [CGPoint], spacing: CGFloat) -> [CGPoint] {
+        guard let first = points.first else { return [] }
+        var result: [CGPoint] = [first]
+        for point in points.dropFirst() {
+            let last = result[result.count - 1]
+            if hypot(point.x - last.x, point.y - last.y) >= spacing { result.append(point) }
+        }
+        if let last = points.last, last != result[result.count - 1] { result.append(last) }
+        return result
+    }
+
+    static func pathLength(of points: [CGPoint]) -> CGFloat {
+        guard points.count >= 2 else { return 0 }
+        var total: CGFloat = 0
+        for index in 1..<points.count {
+            total += hypot(
+                points[index].x - points[index - 1].x,
+                points[index].y - points[index - 1].y)
+        }
+        return total
+    }
+
+    static func boundingBox(of points: [CGPoint]) -> CGRect {
+        guard let first = points.first else { return .null }
+        var minX = first.x, maxX = first.x, minY = first.y, maxY = first.y
+        for point in points.dropFirst() {
+            minX = min(minX, point.x); maxX = max(maxX, point.x)
+            minY = min(minY, point.y); maxY = max(maxY, point.y)
+        }
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    /// Unit vector along the direction of greatest variance (2×2 PCA).
+    ///
+    /// The bounding box's major axis would be cheaper but is wrong for a
+    /// diagonal scribble: a 45° scratch-out has a near-square box, so the box
+    /// axis is arbitrary and the reversals project away to nothing. PCA follows
+    /// the ink itself.
+    static func principalAxis(of points: [CGPoint]) -> CGVector {
+        guard points.count >= 2 else { return CGVector(dx: 1, dy: 0) }
+        let count = CGFloat(points.count)
+        let meanX = points.reduce(CGFloat(0)) { $0 + $1.x } / count
+        let meanY = points.reduce(CGFloat(0)) { $0 + $1.y } / count
+
+        var sxx: CGFloat = 0, syy: CGFloat = 0, sxy: CGFloat = 0
+        for point in points {
+            let dx = point.x - meanX
+            let dy = point.y - meanY
+            sxx += dx * dx
+            syy += dy * dy
+            sxy += dx * dy
+        }
+
+        // Larger eigenvalue of the symmetric covariance matrix [[sxx, sxy], [sxy, syy]].
+        let trace = sxx + syy
+        let determinant = sxx * syy - sxy * sxy
+        let discriminant = max(0, trace * trace / 4 - determinant)
+        let eigenvalue = trace / 2 + sqrt(discriminant)
+
+        // Either row of (C − λI) gives the eigenvector; take the longer one so a
+        // near-degenerate row (axis-aligned input) doesn't amplify rounding error.
+        let rowA = CGVector(dx: sxy, dy: eigenvalue - sxx)
+        let rowB = CGVector(dx: eigenvalue - syy, dy: sxy)
+        let vector = (rowA.dx * rowA.dx + rowA.dy * rowA.dy)
+            >= (rowB.dx * rowB.dx + rowB.dy * rowB.dy) ? rowA : rowB
+        let length = hypot(vector.dx, vector.dy)
+        guard length > 1e-6 else { return CGVector(dx: 1, dy: 0) }
+        return CGVector(dx: vector.dx / length, dy: vector.dy / length)
+    }
+
+    /// Count direction flips in a 1-D sequence, ignoring anything that doesn't
+    /// travel back at least `minimumTravel`.
+    ///
+    /// Implemented as extremum tracking with hysteresis rather than
+    /// sign-of-difference counting: consecutive samples on a hand-drawn line
+    /// flip sign constantly from tremor, so a naive count is dominated by noise.
+    /// Here the running extremum only moves outward, and a flip is confirmed
+    /// only once the pen has retreated `minimumTravel` from it.
+    static func reversals(in projections: [CGFloat], minimumTravel: CGFloat) -> Int {
+        guard let start = projections.first, projections.count >= 2 else { return 0 }
+        var extremum = start
+        var direction = 0
+        var count = 0
+
+        for value in projections.dropFirst() {
+            let delta = value - extremum
+            if direction == 0 {
+                // No established direction yet: the first significant move sets it.
+                if abs(delta) >= minimumTravel {
+                    direction = delta > 0 ? 1 : -1
+                    extremum = value
+                }
+            } else if delta * CGFloat(direction) > 0 {
+                // Still going the same way — push the extremum out.
+                extremum = value
+            } else if abs(delta) >= minimumTravel {
+                // Retreated far enough from the extremum: a real reversal.
+                count += 1
+                direction = -direction
+                extremum = value
+            }
+        }
+        return count
+    }
+
+    /// Shortest distance from `point` to the polyline `path`.
+    static func distance(from point: CGPoint, toPolyline path: [CGPoint]) -> CGFloat {
+        guard let first = path.first else { return .greatestFiniteMagnitude }
+        guard path.count >= 2 else { return hypot(point.x - first.x, point.y - first.y) }
+        var best = CGFloat.greatestFiniteMagnitude
+        for index in 1..<path.count {
+            best = min(best, distance(from: point, toSegment: path[index - 1], path[index]))
+            if best == 0 { break }
+        }
+        return best
+    }
+
+    /// Shortest distance from `point` to the line segment `a`–`b`.
+    static func distance(from point: CGPoint, toSegment a: CGPoint, _ b: CGPoint) -> CGFloat {
+        let dx = b.x - a.x
+        let dy = b.y - a.y
+        let lengthSquared = dx * dx + dy * dy
+        guard lengthSquared > 1e-9 else { return hypot(point.x - a.x, point.y - a.y) }
+        // Projection parameter of `point` onto the infinite line, clamped to the segment.
+        var t = ((point.x - a.x) * dx + (point.y - a.y) * dy) / lengthSquared
+        t = min(max(t, 0), 1)
+        return hypot(point.x - (a.x + t * dx), point.y - (a.y + t * dy))
+    }
+}

--- a/Vellum/Services/Ink/ScratchOutRecognizer.swift
+++ b/Vellum/Services/Ink/ScratchOutRecognizer.swift
@@ -202,15 +202,16 @@ enum ScratchOutRecognizer {
         guard !polyline.isEmpty, path.count >= 2 else { return 0 }
         let total = CGFloat(polyline.count)
         var covered = 0
-        var missed = 0
-        let allowedMisses = Int((1 - giveUpBelow) * total)
+        var remaining = polyline.count
         for point in polyline {
-            if distance(from: point, toPolyline: path) <= radius {
-                covered += 1
-            } else {
-                missed += 1
-                if missed > allowedMisses { return 0 }
-            }
+            if distance(from: point, toPolyline: path) <= radius { covered += 1 }
+            remaining -= 1
+            // Bail once the threshold is arithmetically out of reach. Compared
+            // directly rather than via a precomputed miss budget: `Int((1 -
+            // giveUpBelow) * total)` truncates, and for thresholds whose binary
+            // representation is inexact (0.3 × 90 = 62.999…) that rounds the
+            // budget down by one and bails on a stroke that exactly met the bar.
+            if CGFloat(covered + remaining) < giveUpBelow * total { return 0 }
         }
         return CGFloat(covered) / total
     }

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -79,6 +79,7 @@ private struct ReadingSettingsTab: View {
     @AppStorage("twoFingerNoteTap") private var twoFingerNoteTap = true
     @AppStorage(PencilDoubleTapAction.defaultsKey) private var pencilDoubleTap = PencilDoubleTapAction.eraser.rawValue
     @AppStorage(InkController_iOS.autoHideSidebarKey) private var autoHideSidebarWhileInking = true
+    @AppStorage(InkController_iOS.scratchOutToEraseKey) private var scratchOutToErase = true
     #endif
 
     var body: some View {
@@ -127,10 +128,11 @@ private struct ReadingSettingsTab: View {
                 }
                 .pickerStyle(.segmented)
                 Toggle("Auto-hide sidebar while inking", isOn: $autoHideSidebarWhileInking)
+                Toggle("Scribble to erase", isOn: $scratchOutToErase)
             } header: {
                 Text("Apple Pencil")
             } footer: {
-                Text("What double-tapping a supported Apple Pencil does while inking — toggle the eraser, or switch back to your last tool. Auto-hiding the sidebar collapses the annotation panel so the ink tools get the full page width.")
+                Text("What double-tapping a supported Apple Pencil does while inking — toggle the eraser, or switch back to your last tool. Auto-hiding the sidebar collapses the annotation panel so the ink tools get the full page width. Scribbling back and forth over your own handwriting with the pen deletes it, without switching to the eraser.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
Closes #39

Scratching back and forth over your own handwriting with the pen now deletes it and everything the scribble covers — no switching to the eraser first.

## Recognizer

`Vellum/Services/Ink/ScratchOutRecognizer.swift` is a **pure function over the stroke's points** (CoreGraphics only — no PencilKit, no UIKit, no canvas state), so the heuristic is unit-testable in isolation. `Vellum/Platform/iOS/ScratchOutInk_iOS.swift` is the thin PencilKit adapter that samples `PKStroke` centrelines and feeds them in.

Two signals decide it:

1. **Reversals along the stroke's own principal axis.** The stroke's largest-variance direction is found by 2×2 PCA, every point is projected onto it, and direction flips are counted with hysteresis. Projecting onto the *principal* axis — rather than counting raw turns — is what kills the classic false positive: cursive `m`/`w`/`mmm` is a pile of sharp turns, but the pen still travels monotonically left-to-right, so it scores **zero** reversals. A scribble over the same word scores one per pass. PCA rather than the bounding box's major axis, because a 45° scratch-out has a near-square box whose axis is arbitrary.
2. **Density** — path length ÷ bounding-box diagonal. Rejects everything that travels once around its own box: a straight line is 1.0, a circle 2.2, a printed word ≈ 2, a 5-pass scribble ≈ 5.

Self-intersection counting (the other textbook scribble signal) is deliberately *not* used: a pure sawtooth scratch-out — the most common shape people actually draw — has zero self-intersections, so requiring them would miss the main case, while allowing them as an alternative trigger would fire on ordinary cursive (`e`, `l`, `b` and friends each self-cross).

## Thresholds and why

All in page (zoom-1) points, the space stroke geometry is stored in — so they mean the same thing at 100% and at 400% zoom (this respects the `zoomScale` super-sampling from 05d9176: the canvas's *content* space is page space at every `K`, so nothing here needs unscaling).

| Threshold | Value | Why |
|---|---|---|
| `minimumReversals` | 4 | 4 reversals = **5** directional passes over one line. `M`/`W` are 3 passes (2 reversals), `N`/`Z` are 2 passes. Set deliberately above the busiest Latin letterform so a single sloppy character can never trip it. Cost: a lazy 3-pass scribble is treated as ink — the failure direction we want. |
| `minimumDensity` | 2.5 | Above every "travels once around its own box" shape. Notably above a circle (2.2), which the reversal test alone would not reject firmly. |
| `minimumPathLength` | 40 pt | ≈ three passes over one 12 pt character. Rejects ticks, dots, accents and crossbars outright — and, by construction, printed handwriting, which is one short stroke per letter. |
| `minimumReversalTravel` | 8 pt | Hysteresis. Larger than hand tremor and than the retrace at the top of a cursive loop; far smaller than a deliberate scrub pass. Without it, sign-of-difference counting reports dozens of reversals on a hand-drawn straight line. |
| `resampleSpacing` | 2 pt | Pencil samples at ~240 Hz, so a slow pass is clusters of points whose pairwise directions are noise. Below the thinnest pen preset, so thinning can't erase a real feature. |
| `minimumPointCount` | 8 | Below this the statistics are too noisy to trust. |
| `minimumCoverage` | 0.5 | "Substantially overlaps": scribbling over a word wipes each letter stroke (short, fully covered), while a scribble that merely *crosses* a long underline or table rule leaves it alone. |

## False-positive guards

This is a destructive gesture, so the geometry is only half the defence:

- **Must cover existing visible ink.** If the scribble overlaps nothing, `erase` declines and the stroke stays as ordinary ink. A doodle, a shading pass or a hatched fill on blank paper is never eaten. This is the single most important guard.
- **Coverage is a length fraction, not a hit test.** A single crossing point isn't enough — 50% of the target stroke's length must sit under the scribble.
- **Pen only.** The highlighter is excluded because sweeping a marker back and forth over a word to deepen a highlight is a legitimate, common action with *exactly* the geometry of a scratch-out. The eraser and selection can't produce a stroke at all.
- **Fully bitmap-erased strokes don't count as hits** (`PdfInk.strokeHasVisibleInk`). They still live in `drawing.strokes` but render as nothing; counting them would fire the gesture on what looks to the user like blank paper and silently delete invisible objects.
- **Only a freshly drawn stroke is a candidate** — the drawing must have grown by exactly one stroke. A bitmap erase (count unchanged), vector erase (count drops), undo, or programmatic clear can't trigger it.
- **Default-on toggle** in Settings ▸ Reading ▸ Apple Pencil ("Scribble to erase"), for anyone whose drawing style trips it — heavy hatching over an existing sketch is the plausible case.

## Erase semantics

Whole-stroke, i.e. the eraser's `.object` behaviour, even when the user's eraser is set to `.pixel`. PencilKit exposes no API to apply a bitmap mask to a `PKStroke` programmatically (`PKEraserTool(.bitmap)` masking only happens inside the canvas's own touch handling), so a pixel-accurate erase isn't reachable from here. It's also the right semantics — scratching something out means "delete this thing", not "shave the pixels I crossed" — and it's what Notes and GoodNotes do. `minimumCoverage` is what makes it safe.

## Undo grouping

The undo action restores the drawing PencilKit handed us — the one that still contains the scribble — rather than the pre-scribble drawing. That choice makes undo correct without depending on anything unverifiable:

PencilKit has already registered its own "I added a stroke" undo for the scribble. If UIKit's `UndoManager.groupsByEvent` folds that registration and ours into one group, a single ⌘Z runs both in reverse — ours restores the scribble and its victims, then PencilKit's removes the scribble — landing exactly on the pre-scribble page. If the two land in *separate* groups, the user presses undo twice and sees the same two steps individually, each coherent.

Separate groups are a real possibility, which is why the design doesn't bet on grouping: `PKCanvasViewDelegate` documents that `canvasViewDrawingDidChange` "may be called some time after `canvasViewDidEndUsingTool`" because Apple Pencil pressure data lags touch data — precisely the path this feature runs on. Handing PencilKit's action back the state it expects means we never depend on which way it went, or on whether PencilKit's own undo is snapshot- or delta-based.

**Not verified on device.** Which of the two grouping outcomes actually occurs can only be established by drawing with a Pencil, and I was asked not to drive the UI. Both outcomes are correct; only the number of undo presses differs.

## Guards against undo re-entry

`UndoManager` mutating the drawing fires `canvasViewDrawingDidChange` too. Undoing a single-stroke object-erase restores exactly one stroke, which is indistinguishable from the user drawing one if you only compare counts — and the restored stroke need not come back at the end. So the gesture also requires:

- not `isUndoing` / `isRedoing`;
- `ScratchOutInk.appendedStrokeIndex` — exactly one stroke added **with every earlier stroke unchanged**, rather than assuming PencilKit appended.

## Scope

PDF pages only. This branch has no webpage ink yet (`WEB-INK-PLAN.html` is still a plan; `git grep PKCanvasView` finds nothing under the web viewer), so there is no second place to wire it into. The recognizer is deliberately PencilKit-free so the web ink work can reuse it as-is.

## Tests

`Tests/ScratchOutRecognizerTests.swift`, 20 cases. **XCTest, not Swift Testing** — every existing file in `Tests/` is XCTest and mixing frameworks in one bundle for one new file seemed worse than consistency; happy to convert if you'd rather.

Recognized: horizontal, vertical (rotated 90°), diagonal (rotated 30°, the case a bounding-box axis gets wrong), and a tight 40 pt single-word scrub.

Not recognized: straight underline, circle, cursive wave, printed `M` (the 3-reversal case that sets the threshold), letter `Z`, a short tick, a 3-pass scribble, and a tremor-laden "straight" line.

Overlap selection: covered word erased / crossed underline spared / ink elsewhere untouched; coverage fraction proportional to overlap; out-of-reach strokes score zero. Plus PencilKit-level `ScratchOutInk.erase` tests: erases the scribble and its victim, declines on blank paper, declines for a non-scribble stroke drawn over ink, and ignores already-masked ghost strokes.

## Verification

`xcodegen generate`, then built and tested on **iPad Pro 13-inch (M5), iOS 27.0** (`iPad Pro 13-inch (M4)` isn't installed on this machine).

- `** BUILD SUCCEEDED **`, no errors and no new warnings (the remaining warnings are pre-existing, in `WebArchive`/`WebLibrary`/`WebPageExtractor`/`AiStore`/`MarkdownMessage`).
- `** TEST SUCCEEDED **` — 164 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
