### PR TITLE
Port the macOS keyboard shortcuts to iPadOS

### DIFF
--- a/Tests/KeyboardShortcutsTests.swift
+++ b/Tests/KeyboardShortcutsTests.swift
@@ -1,0 +1,277 @@
+import UIKit
+import XCTest
+@testable import Vellum
+
+// Pins the iPad hardware-keyboard shortcut table (issue #40). The catalog is the
+// single source of truth for both dispatch surfaces — the SwiftUI `Commands`
+// menu and the `UIKeyCommand`s installed on the PDF/Web views — so a golden test
+// over the table is what stops a future edit from silently dropping, re-keying,
+// or double-binding a shortcut that shipped on macOS.
+//
+// The expectations below are transcribed from the macOS menu
+// (`Vellum/App/VellumCommands.swift`) and the macOS key monitor
+// (`Vellum/App/ContentView.swift`), NOT from the iOS implementation — that is
+// the point: the test fails if iPad drifts away from Mac parity.
+
+@MainActor
+final class KeyboardShortcutsTests: XCTestCase {
+
+    /// (action, title, key, modifiers, menu) in menu order.
+    ///
+    /// `menu` is pinned too, not just the key: on iPadOS the menu a shortcut
+    /// lands in *is* its discoverability — it decides where the item shows up in
+    /// the ⌘-hold HUD and the menu bar — so silently moving a row between menus
+    /// is as much a regression as re-keying it.
+    private typealias Row = (
+        action: VellumShortcutAction,
+        title: String,
+        key: VellumShortcutKey,
+        modifiers: VellumKeyModifiers,
+        menu: VellumShortcutMenu
+    )
+
+    private var expected: [Row] {
+        var rows: [Row] = [
+            // File
+            (.newTab, "New Tab", .character("t"), .command, .file),
+            (.openFile, "Open…", .character("o"), .command, .file),
+            (.addWebpage, "Add Webpage…", .character("l"), .command, .file),
+            (.closeTab, "Close Tab", .character("w"), .command, .file),
+            (.printDocument, "Print…", .character("p"), .command, .file),
+            (.save, "Save", .character("s"), .command, .file),
+            // Find
+            (.find, "Find…", .character("f"), .command, .find),
+            (.findNext, "Find Next", .character("g"), .command, .find),
+            (.findPrevious, "Find Previous", .character("g"), [.command, .shift], .find),
+            (.dismiss, "Dismiss", .escape, [], .find),
+            // View
+            (.zoomIn, "Zoom In", .character("+"), .command, .view),
+            (.zoomOut, "Zoom Out", .character("-"), .command, .view),
+            (.actualSize, "Actual Size", .character("0"), .command, .view),
+            (.toggleInspector, "Toggle Inspector", .character("s"), [.command, .option], .view),
+            (.splitRight, "Split Right", .character("\\"), .command, .view),
+            (.splitDown, "Split Down", .character("\\"), [.command, .option], .view),
+            (.mergePanes, "Merge Panes", .character("j"), [.command, .option], .view),
+            (.closePane, "Close Pane", .character("\\"), [.command, .shift], .view),
+            // Navigate
+            (.previousPage, "Previous Page", .upArrow, .command, .navigate),
+            (.nextPage, "Next Page", .downArrow, .command, .navigate),
+            (.firstPage, "First Page", .upArrow, [.command, .option], .navigate),
+            (.lastPage, "Last Page", .downArrow, [.command, .option], .navigate),
+            (.webBack, "Back", .character("["), .command, .navigate),
+            (.webForward, "Forward", .character("]"), .command, .navigate),
+            (.previousTab, "Show Previous Tab", .character("["), [.command, .shift], .navigate),
+            (.nextTab, "Show Next Tab", .character("]"), [.command, .shift], .navigate),
+        ]
+        // ⌘1…⌘9 tab switching.
+        for number in 1...9 {
+            rows.append(
+                (
+                    .showTab(number), "Show Tab \(number)", .character(Character("\(number)")),
+                    .command, .navigate
+                )
+            )
+        }
+        rows += [
+            // Annotations
+            (.bookmarkPage, "Bookmark Page", .character("d"), .command, .annotations),
+            (.toggleNoteMode, "Toggle Note Mode", .character("n"), [], .annotations),
+        ]
+        return rows
+    }
+
+    // MARK: - The table itself
+
+    func testCatalogMatchesTheMacShortcutTableExactly() {
+        let actual = VellumShortcutCatalog.all
+        XCTAssertEqual(
+            actual.count, expected.count,
+            "Shortcut count changed — a macOS shortcut was added or dropped.")
+
+        for (index, row) in expected.enumerated() where index < actual.count {
+            let shortcut = actual[index]
+            XCTAssertEqual(shortcut.action, row.action, "Wrong action at index \(index)")
+            XCTAssertEqual(shortcut.title, row.title, "Wrong title for \(row.action.identifier)")
+            XCTAssertEqual(
+                shortcut.combo.key, row.key, "Wrong key for \(row.action.identifier)")
+            XCTAssertEqual(
+                shortcut.combo.modifiers, row.modifiers,
+                "Wrong modifiers for \(row.action.identifier)")
+            XCTAssertEqual(
+                shortcut.menu, row.menu,
+                "\(row.action.identifier) moved to a different menu — it would appear "
+                    + "somewhere else in the ⌘-hold HUD.")
+        }
+    }
+
+    func testEveryActionIsBoundExactlyOnce() {
+        let identifiers = VellumShortcutCatalog.all.map(\.action.identifier)
+        XCTAssertEqual(
+            Set(identifiers).count, identifiers.count,
+            "Two rows bind the same action; the catalog lookup would drop one.")
+    }
+
+    func testNoChordIsBoundTwice() {
+        // Primary chords AND responder-chain alternates share one keyboard, so
+        // collisions are checked across both.
+        let combos = VellumShortcutCatalog.all.flatMap { [$0.combo] + $0.alternates }
+        XCTAssertEqual(
+            Set(combos).count, combos.count,
+            "The same chord is bound to two actions — dispatch would be ambiguous.")
+    }
+
+    func testEveryShortcutHasAMenuHome() {
+        // Menu placement is the discoverability story on iPadOS: an item with no
+        // menu never shows up in the ⌘-hold HUD or the menu bar.
+        for shortcut in VellumShortcutCatalog.all {
+            XCTAssertFalse(
+                shortcut.title.isEmpty, "\(shortcut.action.identifier) has no title")
+        }
+        let menus = Set(VellumShortcutCatalog.all.map(\.menu))
+        XCTAssertEqual(menus, [.file, .find, .view, .navigate, .annotations])
+    }
+
+    func testIdentifiersRoundTripThroughTheCatalog() {
+        // The UIKeyCommand path can only carry a property list, so it ships the
+        // identifier string and resolves it back on the way out.
+        for shortcut in VellumShortcutCatalog.all {
+            XCTAssertEqual(
+                VellumShortcutCatalog.action(forIdentifier: shortcut.action.identifier),
+                shortcut.action)
+        }
+        XCTAssertNil(VellumShortcutCatalog.action(forIdentifier: "notAShortcut"))
+    }
+
+    // MARK: - What we deliberately do NOT bind
+
+    func testSystemTextEditingChordsAreNotShadowed() {
+        // UIKit implements these on every text surface; shadowing any of them
+        // would break editing inside the find field, the AI composer, and the
+        // scratchpad.
+        let reserved: Set<Character> = ["c", "v", "x", "a", "z"]
+        for shortcut in VellumShortcutCatalog.all {
+            for combo in [shortcut.combo] + shortcut.alternates {
+                guard combo.modifiers == .command,
+                      case .character(let character) = combo.key
+                else { continue }
+                XCTAssertFalse(
+                    reserved.contains(character),
+                    "⌘\(character) is a system text-editing chord and must stay unbound "
+                        + "(claimed by \(shortcut.action.identifier)).")
+            }
+        }
+    }
+
+    func testOnlyNoteModeUsesABareKey() {
+        // A modifier-less chord swallows a literal keystroke, so exactly one is
+        // allowed (bare N, matching macOS) plus Escape, which types nothing.
+        let bare = VellumShortcutCatalog.all.filter { $0.combo.modifiers.isEmpty }
+        XCTAssertEqual(Set(bare.map(\.action)), [.toggleNoteMode, .dismiss])
+    }
+
+    // MARK: - Responder-chain (UIKeyCommand) projection
+
+    func testDocumentSurfaceSetCoversTheChordsPdfKitAndWebKitClaim() {
+        // These are the chords a focused PDFView/WKWebView has its own bindings
+        // for; each must also be installed on Vellum's document surfaces or the
+        // SwiftUI menu copy loses the dispatch race.
+        let expectedActions: Set<VellumShortcutAction> = [
+            .find, .findNext, .findPrevious, .dismiss,
+            .zoomIn, .zoomOut, .actualSize,
+            .previousPage, .nextPage, .firstPage, .lastPage,
+            .webBack, .webForward, .previousTab, .nextTab,
+        ]
+        XCTAssertEqual(
+            Set(VellumShortcutCatalog.documentSurfaceShortcuts.map(\.action)), expectedActions)
+    }
+
+    func testNoteModeIsNeverInstalledOnADocumentSurface() {
+        // Bare N on the web surface would eat the letter "n" typed into a page's
+        // text field.
+        let noteMode = VellumShortcutCatalog[.toggleNoteMode]
+        XCTAssertNotNil(noteMode)
+        XCTAssertFalse(noteMode?.installOnDocumentSurface ?? true)
+    }
+
+    func testKeyCommandsCarryTheirActionAndBeatSystemBehaviour() {
+        let selector = #selector(UIResponder.becomeFirstResponder)  // arbitrary, unused
+        let commands = VellumShortcutCatalog.documentSurfaceKeyCommands(action: selector)
+
+        // One command per primary chord plus one per alternate.
+        let expectedCount = VellumShortcutCatalog.documentSurfaceShortcuts
+            .reduce(0) { $0 + 1 + $1.alternates.count }
+        XCTAssertEqual(commands.count, expectedCount)
+
+        for command in commands {
+            XCTAssertEqual(command.action, selector)
+            guard let identifier = command.propertyList as? String,
+                  let action = VellumShortcutCatalog.action(forIdentifier: identifier),
+                  let shortcut = VellumShortcutCatalog[action]
+            else {
+                return XCTFail("Key command lost its action identifier")
+            }
+            XCTAssertEqual(
+                command.wantsPriorityOverSystemBehavior, shortcut.overridesSystemBehavior,
+                "\(identifier) has the wrong priority against system behaviour.")
+            XCTAssertFalse(command.input?.isEmpty ?? true)
+        }
+    }
+
+    func testEscapeDoesNotOverrideSystemBehaviour() {
+        // A matched UIKeyCommand is consumed unconditionally on iOS, so Escape
+        // can never be as transparent as the macOS NSEvent monitor (which always
+        // lets the event continue). Not claiming priority is the closest
+        // equivalent: the system keeps first claim on Escape for dismissing an
+        // edit-menu callout or a Full Keyboard Access interaction.
+        XCTAssertEqual(VellumShortcutCatalog[.dismiss]?.overridesSystemBehavior, false)
+
+        // Everything else on the responder chain is there precisely to win.
+        for shortcut in VellumShortcutCatalog.documentSurfaceShortcuts where shortcut.action != .dismiss {
+            XCTAssertTrue(
+                shortcut.overridesSystemBehavior,
+                "\(shortcut.action.identifier) would lose to PDFKit/WebKit.")
+        }
+    }
+
+    func testOnlyThePrimaryChordIsAdvertisedInTheDiscoverabilityHud() {
+        // Alternates exist so a chord people actually press works (⌘= for Zoom
+        // In); advertising them would list the same title three times.
+        let commands = VellumShortcutCatalog.documentSurfaceKeyCommands(
+            action: #selector(UIResponder.becomeFirstResponder))
+        let titled = commands.filter { $0.discoverabilityTitle != nil }
+        XCTAssertEqual(titled.count, VellumShortcutCatalog.documentSurfaceShortcuts.count)
+        XCTAssertEqual(
+            Set(titled.compactMap(\.discoverabilityTitle)).count, titled.count,
+            "Two HUD entries share a title — an alternate leaked into the HUD.")
+    }
+
+    func testZoomInAcceptsTheUnshiftedEqualsKeyOverADocument() {
+        // On iPadOS a UIKeyCommand matches the literal input string plus exact
+        // modifier flags, so a lone "+" binding never fires for the key most
+        // people actually press. The alternates cover both spellings.
+        let zoomIn = VellumShortcutCatalog[.zoomIn]
+        XCTAssertNotNil(zoomIn)
+        XCTAssertTrue(zoomIn?.alternates.contains(VellumKeyCombo("=")) ?? false)
+        XCTAssertTrue(
+            zoomIn?.alternates.contains(VellumKeyCombo("+", [.command, .shift])) ?? false)
+    }
+
+    // MARK: - Framework bridging
+
+    func testModifiersMapToUIKitFlags() {
+        XCTAssertEqual(VellumKeyModifiers.command.keyModifierFlags, .command)
+        XCTAssertEqual(VellumKeyModifiers.shift.keyModifierFlags, .shift)
+        // UIKit spells Option "alternate" — an easy mapping to get wrong.
+        XCTAssertEqual(VellumKeyModifiers.option.keyModifierFlags, .alternate)
+        XCTAssertEqual(VellumKeyModifiers.control.keyModifierFlags, .control)
+        XCTAssertEqual(
+            VellumKeyModifiers([.command, .option]).keyModifierFlags, [.command, .alternate])
+    }
+
+    func testNamedKeysMapToUIKitInputStrings() {
+        XCTAssertEqual(VellumShortcutKey.upArrow.keyCommandInput, UIKeyCommand.inputUpArrow)
+        XCTAssertEqual(VellumShortcutKey.downArrow.keyCommandInput, UIKeyCommand.inputDownArrow)
+        XCTAssertEqual(VellumShortcutKey.escape.keyCommandInput, UIKeyCommand.inputEscape)
+        XCTAssertEqual(VellumShortcutKey.character("f").keyCommandInput, "f")
+    }
+}

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1F27BEF7A0CFEDADB3836503 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FE3740EBDBD76FAFDA06C42F /* Assets.xcassets */; };
 		1F884AF6AF2ABD755DFE414D /* RecentFilesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4C07C56943274B9E062A70 /* RecentFilesService.swift */; };
 		1FCCAC565DBDC21D62F833FB /* PdfBookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B81C915E0D9617AFC8B14CF4 /* PdfBookmarks.swift */; };
+		22AF5CEF40F9C905992B2D35 /* ShortcutRouter_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCD3CD51FA59977E52683DB3 /* ShortcutRouter_iOS.swift */; };
 		2439956FEFA7E14A045B9289 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54417DBF142FD33E6B2F6672 /* SettingsView.swift */; };
 		249CCA82E8B519D78426C055 /* PageTextCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5513F929B10D107AED515D1E /* PageTextCache.swift */; };
 		25F3CB0EC3551FC76CD5AFAC /* WebSessionBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC36411CEE83A332FBFA83A0 /* WebSessionBackend.swift */; };
@@ -43,6 +44,7 @@
 		41EDFC3445164FFD63A268C8 /* OpenCodeZenClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F39E1889C3B2C6F221C33BC9 /* OpenCodeZenClient.swift */; };
 		4554D74619804C88BA0BFADD /* GeminiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */; };
 		4B759FBB179307FE097DA861 /* StorageLocationChoiceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */; };
+		4E41F6F15E5C43C22C756AF4 /* KeyboardShortcutsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC849F7BCACD9A70CD3E3430 /* KeyboardShortcutsTests.swift */; };
 		4E8BAA1F3AEC100D4C768AFA /* PaneTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7B863B676278E0E8D3C2EDB /* PaneTree.swift */; };
 		4F0CAF425277CA915B0EEFDB /* WebLibraryStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8C07E2E3B6096D5FBD0510 /* WebLibraryStorageTests.swift */; };
 		4FF972F2B1437D5D46AE6BA4 /* HighlightLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */; };
@@ -105,6 +107,7 @@
 		D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82487970E20F6628200C4BE /* KeychainStore.swift */; };
 		D4A79DFDB08A01D35D47933A /* AiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F38132FDC803C6ACEB43CC /* AiStore.swift */; };
 		D529B1BD4F7B9FA1E791246F /* PageTextPersister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504DC8725E6198531EC21429 /* PageTextPersister.swift */; };
+		D6B79D50C1DBB43C29F0A19E /* KeyboardShortcuts_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4B2A34AE7B5D089B26884 /* KeyboardShortcuts_iOS.swift */; };
 		D77E5170582527BDF9282B70 /* tool-descriptions.md in Resources */ = {isa = PBXBuildFile; fileRef = 3E954582457ABFF5574EC93C /* tool-descriptions.md */; };
 		DB49B34BAD564527EF5585A2 /* WebViewerTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C4546D0D679437B876586A /* WebViewerTypes.swift */; };
 		DC190B489E12CE0D1218C949 /* SwiftMath in Frameworks */ = {isa = PBXBuildFile; productRef = 0F9E9D97558DCF004997C26D /* SwiftMath */; };
@@ -222,6 +225,7 @@
 		B6E95679B108A0702A0657D8 /* PKCE.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PKCE.swift; sourceTree = "<group>"; };
 		B81C915E0D9617AFC8B14CF4 /* PdfBookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfBookmarks.swift; sourceTree = "<group>"; };
 		BC65D72937E15736374B3533 /* WebViewerView_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewerView_iOS.swift; sourceTree = "<group>"; };
+		BCD3CD51FA59977E52683DB3 /* ShortcutRouter_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutRouter_iOS.swift; sourceTree = "<group>"; };
 		BE90299DD7109284EF8AE43D /* OpenAIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIClient.swift; sourceTree = "<group>"; };
 		C00E4B04332A759BD4D59A98 /* PdfTextLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfTextLocator.swift; sourceTree = "<group>"; };
 		C1F083E5C02A66A025F06638 /* WebContentScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentScript.swift; sourceTree = "<group>"; };
@@ -229,6 +233,7 @@
 		C25E50ECC9D39C4AF827C18D /* ScratchpadPanel_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadPanel_iOS.swift; sourceTree = "<group>"; };
 		C44C96AA3D078A0E0EE50B92 /* GeminiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeminiClient.swift; sourceTree = "<group>"; };
 		C4DE459571959DABFA99D4BB /* AiSettingsPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiSettingsPanel.swift; sourceTree = "<group>"; };
+		C6C4B2A34AE7B5D089B26884 /* KeyboardShortcuts_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcuts_iOS.swift; sourceTree = "<group>"; };
 		C75C2F535B12256E191B781C /* PdfKitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfKitView.swift; sourceTree = "<group>"; };
 		C7B863B676278E0E8D3C2EDB /* PaneTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneTree.swift; sourceTree = "<group>"; };
 		C8DCF286D5E58E45AB3FABA8 /* MathRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MathRenderer.swift; sourceTree = "<group>"; };
@@ -252,6 +257,7 @@
 		E97DF51AB1BA63B8ED2200D0 /* RegionCaptureOverlay_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionCaptureOverlay_iOS.swift; sourceTree = "<group>"; };
 		E9A35D0EA31DC7A28CB8FA8A /* ScratchpadStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadStore.swift; sourceTree = "<group>"; };
 		EC36411CEE83A332FBFA83A0 /* WebSessionBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSessionBackend.swift; sourceTree = "<group>"; };
+		EC849F7BCACD9A70CD3E3430 /* KeyboardShortcutsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutsTests.swift; sourceTree = "<group>"; };
 		EEA75D024B6F4DEC807ABD97 /* WebLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebLibrary.swift; sourceTree = "<group>"; };
 		F2630E8BE36D65B9E485FD6F /* Controls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controls.swift; sourceTree = "<group>"; };
 		F39E1889C3B2C6F221C33BC9 /* OpenCodeZenClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeZenClient.swift; sourceTree = "<group>"; };
@@ -291,6 +297,7 @@
 				96A7991568F0B38518672931 /* InkController_iOS.swift */,
 				438D3DD29145D25F74DF89C8 /* InkOverlayProvider_iOS.swift */,
 				7D0AB7EE7306E1C02A815F35 /* InkToolPalette_iOS.swift */,
+				C6C4B2A34AE7B5D089B26884 /* KeyboardShortcuts_iOS.swift */,
 				8764C0B9C595EB79CC9B28F0 /* PaneView_iOS.swift */,
 				CE14F1472A7451AF57FD04ED /* PdfChrome_iOS.swift */,
 				8B1C1908D5C4C66BDFFB61EC /* PdfInk.swift */,
@@ -299,6 +306,7 @@
 				A7A88AE6F1B577A687BEFD98 /* PdfViewerView_iOS.swift */,
 				E97DF51AB1BA63B8ED2200D0 /* RegionCaptureOverlay_iOS.swift */,
 				C25E50ECC9D39C4AF827C18D /* ScratchpadPanel_iOS.swift */,
+				BCD3CD51FA59977E52683DB3 /* ShortcutRouter_iOS.swift */,
 				721E9C680C7E5E5E6ECBFDB9 /* VellumApp_iOS.swift */,
 				D960E9942F1D1D97F6629BA7 /* VellumCommands_iOS.swift */,
 				BC65D72937E15736374B3533 /* WebViewerView_iOS.swift */,
@@ -365,6 +373,7 @@
 			children = (
 				4AA459842CA86BEED9D34C1E /* AiPipelineTests.swift */,
 				887BAD6DD07D5B3101E1873B /* InkPersistenceTests.swift */,
+				EC849F7BCACD9A70CD3E3430 /* KeyboardShortcutsTests.swift */,
 				6F5F272385E3E99333CFC6C1 /* MarkdownParserTests.swift */,
 				13F6592FEBC0C0187E0C35A3 /* PageTextCacheTests.swift */,
 				524641B76B46DE4D791F4E6A /* PaneTreeTests.swift */,
@@ -731,6 +740,7 @@
 				2D9B44E54F3EF77786B0CCBC /* InkController_iOS.swift in Sources */,
 				3E706409E2D0039C0100A7B6 /* InkOverlayProvider_iOS.swift in Sources */,
 				C216FBF992CE583A32436389 /* InkToolPalette_iOS.swift in Sources */,
+				D6B79D50C1DBB43C29F0A19E /* KeyboardShortcuts_iOS.swift in Sources */,
 				D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */,
 				E5F120A320C5FC13A9026B70 /* MarkdownMessage.swift in Sources */,
 				ED7C505CE3E48CE35C600873 /* MathRenderer.swift in Sources */,
@@ -776,6 +786,7 @@
 				CCD31E1E8A71BB0E987EC90B /* SelectionPopover.swift in Sources */,
 				B1EA8A76FD9FE32930829528 /* SessionService.swift in Sources */,
 				2439956FEFA7E14A045B9289 /* SettingsView.swift in Sources */,
+				22AF5CEF40F9C905992B2D35 /* ShortcutRouter_iOS.swift in Sources */,
 				7A22F35E2A3DE9629E53A11D /* StickyNoteOverlay.swift in Sources */,
 				4B759FBB179307FE097DA861 /* StorageLocationChoiceSheet.swift in Sources */,
 				6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */,
@@ -810,6 +821,7 @@
 			files = (
 				C529F97AB901B963D8DB4726 /* AiPipelineTests.swift in Sources */,
 				E76ADFB8CB195942D8A8F759 /* InkPersistenceTests.swift in Sources */,
+				4E41F6F15E5C43C22C756AF4 /* KeyboardShortcutsTests.swift in Sources */,
 				8E2B30ED60C29E54F33081F7 /* MarkdownParserTests.swift in Sources */,
 				91ACF610BE2A44480DD31843 /* PageTextCacheTests.swift in Sources */,
 				2E35DAA98C4A45A551382874 /* PaneTreeTests.swift in Sources */,

--- a/Vellum/Platform/iOS/KeyboardShortcuts_iOS.swift
+++ b/Vellum/Platform/iOS/KeyboardShortcuts_iOS.swift
@@ -1,0 +1,491 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+// The single source of truth for every hardware-keyboard shortcut on iPad
+// (issue #40 — "Allow keyboard shortcuts same as mac on iPadOS").
+//
+// The table is deliberately plain data — no SwiftUI views, no stores, no
+// UIKit responders — for two reasons:
+//
+//  1. It is consumed by TWO dispatch surfaces that must never drift apart:
+//     `VellumCommands_iOS` (the SwiftUI `Commands` menu, which is what
+//     populates the ⌘-hold discoverability HUD and the iPadOS 26 menu bar) and
+//     the `UIKeyCommand`s installed on Vellum's UIKit document surfaces (see
+//     `ShortcutRouter_iOS.swift`). Describing a shortcut once and projecting it
+//     into both surfaces makes a mismatch structurally impossible.
+//  2. Being view-free, it is directly unit-testable — `Tests/KeyboardShortcutsTests.swift`
+//     pins the whole table so a future edit cannot silently drop or re-key a
+//     shortcut that shipped on macOS.
+//
+// Parity reference: `Vellum/App/VellumCommands.swift` (the macOS menu) plus the
+// local NSEvent monitor in `Vellum/App/ContentView.swift`, which on macOS picks
+// up the handful of chords menus cannot express (Escape, bare `N`) and the ones
+// a focused PDFView/WKWebView would otherwise swallow.
+
+// MARK: - Modifiers
+
+/// Framework-neutral modifier set. SwiftUI's `EventModifiers` and UIKit's
+/// `UIKeyModifierFlags` both exist, but neither is usable as *the* table type:
+/// the table has to project into both, and `EventModifiers` carries no
+/// guaranteed `Hashable` conformance to assert against in tests. Owning the
+/// type keeps the catalog independent of either framework's spelling.
+struct VellumKeyModifiers: OptionSet, Hashable, Sendable {
+    let rawValue: Int
+
+    init(rawValue: Int) { self.rawValue = rawValue }
+
+    static let command = VellumKeyModifiers(rawValue: 1 << 0)
+    static let shift = VellumKeyModifiers(rawValue: 1 << 1)
+    static let option = VellumKeyModifiers(rawValue: 1 << 2)
+    static let control = VellumKeyModifiers(rawValue: 1 << 3)
+
+    /// SwiftUI spelling, for `.keyboardShortcut(_:modifiers:)`.
+    var eventModifiers: EventModifiers {
+        var result: EventModifiers = []
+        if contains(.command) { result.insert(.command) }
+        if contains(.shift) { result.insert(.shift) }
+        if contains(.option) { result.insert(.option) }
+        if contains(.control) { result.insert(.control) }
+        return result
+    }
+
+    /// UIKit spelling, for `UIKeyCommand(modifierFlags:)`. Note UIKit calls the
+    /// Option key `.alternate`.
+    var keyModifierFlags: UIKeyModifierFlags {
+        var result: UIKeyModifierFlags = []
+        if contains(.command) { result.insert(.command) }
+        if contains(.shift) { result.insert(.shift) }
+        if contains(.option) { result.insert(.alternate) }
+        if contains(.control) { result.insert(.control) }
+        return result
+    }
+}
+
+// MARK: - Keys
+
+/// The key half of a chord. Only the keys Vellum actually binds are modelled —
+/// an open-ended `Character` case plus the three named keys we use — so an
+/// invalid binding cannot be spelled.
+enum VellumShortcutKey: Hashable, Sendable {
+    case character(Character)
+    case upArrow
+    case downArrow
+    case escape
+
+    /// SwiftUI spelling.
+    var keyEquivalent: KeyEquivalent {
+        switch self {
+        case .character(let character): KeyEquivalent(character)
+        case .upArrow: .upArrow
+        case .downArrow: .downArrow
+        case .escape: .escape
+        }
+    }
+
+    /// UIKit spelling. `UIKeyCommand` takes the *input string* the keyboard
+    /// produces, with the arrow/escape keys spelled as sentinel constants.
+    var keyCommandInput: String {
+        switch self {
+        case .character(let character): String(character)
+        case .upArrow: UIKeyCommand.inputUpArrow
+        case .downArrow: UIKeyCommand.inputDownArrow
+        case .escape: UIKeyCommand.inputEscape
+        }
+    }
+}
+
+/// A key plus its modifiers — one physical chord.
+struct VellumKeyCombo: Hashable, Sendable {
+    let key: VellumShortcutKey
+    let modifiers: VellumKeyModifiers
+
+    init(_ key: VellumShortcutKey, _ modifiers: VellumKeyModifiers) {
+        self.key = key
+        self.modifiers = modifiers
+    }
+
+    /// Convenience for the common `⌘<letter>` shape.
+    init(_ character: Character, _ modifiers: VellumKeyModifiers = .command) {
+        self.init(.character(character), modifiers)
+    }
+}
+
+// MARK: - Actions
+
+/// What a shortcut *does*, independent of which key runs it. This is the token
+/// that travels from a key press to `VellumShortcutRouter`, so tests can assert
+/// "⌘D is still wired to `bookmarkPage`" without touching a store.
+enum VellumShortcutAction: Hashable, Sendable {
+    // File
+    case newTab
+    case openFile
+    case addWebpage
+    case closeTab
+    case printDocument
+    case save
+    // Find
+    case find
+    case findNext
+    case findPrevious
+    case dismiss
+    // View
+    case zoomIn
+    case zoomOut
+    case actualSize
+    case toggleInspector
+    case splitRight
+    case splitDown
+    case mergePanes
+    case closePane
+    // Navigate
+    case previousPage
+    case nextPage
+    case firstPage
+    case lastPage
+    case webBack
+    case webForward
+    case previousTab
+    case nextTab
+    /// 1-based tab index, matching the ⌘1…⌘9 labels.
+    case showTab(Int)
+    // Annotations
+    case bookmarkPage
+    case toggleNoteMode
+
+    /// Stable string identity. `UIKeyCommand` can only round-trip a property
+    /// list, not a Swift enum, so the responder-chain path ships this string in
+    /// `propertyList` and resolves it back through the catalog on the way out.
+    var identifier: String {
+        switch self {
+        case .newTab: "newTab"
+        case .openFile: "openFile"
+        case .addWebpage: "addWebpage"
+        case .closeTab: "closeTab"
+        case .printDocument: "printDocument"
+        case .save: "save"
+        case .find: "find"
+        case .findNext: "findNext"
+        case .findPrevious: "findPrevious"
+        case .dismiss: "dismiss"
+        case .zoomIn: "zoomIn"
+        case .zoomOut: "zoomOut"
+        case .actualSize: "actualSize"
+        case .toggleInspector: "toggleInspector"
+        case .splitRight: "splitRight"
+        case .splitDown: "splitDown"
+        case .mergePanes: "mergePanes"
+        case .closePane: "closePane"
+        case .previousPage: "previousPage"
+        case .nextPage: "nextPage"
+        case .firstPage: "firstPage"
+        case .lastPage: "lastPage"
+        case .webBack: "webBack"
+        case .webForward: "webForward"
+        case .previousTab: "previousTab"
+        case .nextTab: "nextTab"
+        case .showTab(let index): "showTab.\(index)"
+        case .bookmarkPage: "bookmarkPage"
+        case .toggleNoteMode: "toggleNoteMode"
+        }
+    }
+}
+
+// MARK: - Menu placement
+
+/// Which menu a shortcut is surfaced in. On iPadOS these become the sections of
+/// the ⌘-hold HUD and (on iPadOS 26) the real menu bar, so placement is the
+/// discoverability story — a shortcut with no menu home is a shortcut nobody
+/// finds.
+enum VellumShortcutMenu: Hashable, Sendable {
+    /// The standard File group (New Tab / Open / Close Tab / Print / Save).
+    case file
+    /// Appended after the standard text-editing group, like the Mac's Edit ▸ Find.
+    case find
+    /// Appended after the standard sidebar group: zoom, inspector, split panes.
+    case view
+    /// Vellum's own "Navigate" menu: pages, web history, tabs.
+    case navigate
+    /// Vellum's own "Annotations" menu.
+    case annotations
+}
+
+// MARK: - Shortcut
+
+/// One row of the shortcut table.
+struct VellumShortcut: Hashable, Sendable, Identifiable {
+    /// What running this shortcut does.
+    let action: VellumShortcutAction
+    /// Menu title, reused as the `UIKeyCommand` title so the ⌘-hold HUD and the
+    /// menu bar read identically.
+    let title: String
+    /// The chord shown in the menu.
+    let combo: VellumKeyCombo
+    /// Where the menu item lives.
+    let menu: VellumShortcutMenu
+    /// Extra chords that run the same action but are intentionally NOT shown in
+    /// the menu (a menu item can only display one key equivalent, and a second
+    /// item with the same title reads as a duplicate). Alternates are installed
+    /// on the responder chain only — see `installOnDocumentSurface`.
+    let alternates: [VellumKeyCombo]
+    /// Whether this shortcut is ALSO installed as a `UIKeyCommand` on Vellum's
+    /// UIKit document surfaces (`VellumPDFView`, `VellumWebView`).
+    ///
+    /// SwiftUI `.keyboardShortcut` menu commands sit at the very end of the
+    /// responder chain, so a UIKit view that is first responder gets the key
+    /// event first and can consume it — PDFKit and WebKit both ship their own
+    /// key commands for finding, scrolling, zooming and history. macOS solves
+    /// this with a local `NSEvent` monitor (`ContentView.handleKeyDown`); iPadOS
+    /// has no equivalent hook, so instead we hang the same chord off the Vellum
+    /// view that *owns* the surface. Being nearer the first responder, ours wins,
+    /// and because UIKit stops at the first responder that handles the chord the
+    /// menu copy does not also fire.
+    ///
+    /// Only set for chords a document surface plausibly claims. Shortcuts that
+    /// nothing in PDFKit/WebKit competes for (⌘T, ⌘W, split management, ⌘1…⌘9)
+    /// stay menu-only, which keeps the per-keystroke `keyCommands` array small
+    /// and avoids shadowing anything unnecessarily.
+    ///
+    /// ⌘O / ⌘L / ⌘P are a judgement call worth spelling out: the macOS monitor
+    /// DOES intercept them, because AppKit's PDFView and WKWebView implement
+    /// `performKeyEquivalent` broadly enough to eat them. Their UIKit
+    /// counterparts publish key commands rather than a catch-all hook, and
+    /// neither publishes one for open / locate / print (UIKit's own ⌘P exists
+    /// only for document-based apps, which Vellum is not — it is a plain
+    /// `WindowGroup`). So they are left menu-only; if a future iOS release adds
+    /// such a binding, the fix is one flag on these rows.
+    let installOnDocumentSurface: Bool
+    /// Whether the responder-chain copy sets `wantsPriorityOverSystemBehavior`,
+    /// i.e. asks UIKit to prefer Vellum's binding over the system's own for the
+    /// same chord.
+    ///
+    /// True for everything Vellum genuinely needs to win (⌘F must open Vellum's
+    /// cross-format find bar, not WebKit's; ⌘↑ must page, not scroll-to-top).
+    ///
+    /// False for Escape, deliberately. A matched `UIKeyCommand` is consumed
+    /// unconditionally on iOS, so Escape can never be as transparent here as it
+    /// is on macOS — the AppKit monitor returns `false` for Escape and lets the
+    /// event continue no matter what. Leaving the priority flag off is the
+    /// closest achievable equivalent: the system keeps first claim on Escape for
+    /// things like dismissing an edit-menu callout or a Full Keyboard Access
+    /// interaction, and Vellum only sees it when nothing else wanted it.
+    let overridesSystemBehavior: Bool
+
+    var id: String { action.identifier }
+
+    init(
+        _ action: VellumShortcutAction,
+        _ title: String,
+        _ combo: VellumKeyCombo,
+        menu: VellumShortcutMenu,
+        alternates: [VellumKeyCombo] = [],
+        installOnDocumentSurface: Bool = false,
+        overridesSystemBehavior: Bool = true
+    ) {
+        self.action = action
+        self.title = title
+        self.combo = combo
+        self.menu = menu
+        self.alternates = alternates
+        self.installOnDocumentSurface = installOnDocumentSurface
+        self.overridesSystemBehavior = overridesSystemBehavior
+    }
+}
+
+// MARK: - The table
+
+enum VellumShortcutCatalog {
+    /// Every shortcut, in menu order.
+    ///
+    /// Deliberately NOT ported from macOS:
+    ///  • Sidebar text sizing (⌘+ / ⌘− while the pointer hovers the open side
+    ///    panel). It is pointer-contextual — it only fires because AppKit can
+    ///    ask "is the mouse over the sidebar right now" — and it doubles up the
+    ///    document-zoom chord. On a touch-first iPad there is no dependable
+    ///    hover state to disambiguate with, so ⌘+/⌘− mean document zoom only.
+    ///  • Window management (New Window, Minimise, Cycle Windows). Those are
+    ///    AppKit's standard menus rather than Vellum's own; iPadOS manages
+    ///    windows through Stage Manager / the system multitasking UI.
+    ///  • ⌘C / ⌘V / ⌘X / ⌘A / ⌘Z inside text. UIKit already implements these on
+    ///    every text surface; shadowing them would break editing.
+    static let all: [VellumShortcut] = file + find + view + navigate + annotations
+
+    // MARK: File
+
+    private static let file: [VellumShortcut] = [
+        VellumShortcut(.newTab, "New Tab", VellumKeyCombo("t"), menu: .file),
+        // ⌘O is safe to claim: `VellumCommands_iOS` installs this via
+        // `CommandGroup(replacing: .importExport)`, which removes the system's
+        // import/export group (and any key equivalent it carried) outright, so
+        // there is exactly one owner of the chord.
+        VellumShortcut(.openFile, "Open…", VellumKeyCombo("o"), menu: .file),
+        VellumShortcut(.addWebpage, "Add Webpage…", VellumKeyCombo("l"), menu: .file),
+        VellumShortcut(.closeTab, "Close Tab", VellumKeyCombo("w"), menu: .file),
+        VellumShortcut(.printDocument, "Print…", VellumKeyCombo("p"), menu: .file),
+        VellumShortcut(.save, "Save", VellumKeyCombo("s"), menu: .file),
+    ]
+
+    // MARK: Find
+
+    private static let find: [VellumShortcut] = [
+        // The find trio has to reach the document surfaces: WKWebView ships a
+        // ⌘F find interaction and both WebKit and UITextView bind ⌘G / ⌘⇧G to
+        // "find next/previous" in their own search UI, none of which knows about
+        // Vellum's cross-format FindBar.
+        VellumShortcut(.find, "Find…", VellumKeyCombo("f"), menu: .find, installOnDocumentSurface: true),
+        VellumShortcut(
+            .findNext, "Find Next", VellumKeyCombo("g"), menu: .find, installOnDocumentSurface: true),
+        VellumShortcut(
+            .findPrevious, "Find Previous", VellumKeyCombo("g", [.command, .shift]), menu: .find,
+            installOnDocumentSurface: true),
+        // Escape mirrors the macOS key monitor: close the find bar if it is up,
+        // otherwise drop the annotation selection and leave note mode. It needs
+        // BOTH surfaces — the menu copy is what fires while the find field holds
+        // first responder (the field is a sibling of the document view, so the
+        // document view's key commands are not in its responder chain).
+        VellumShortcut(
+            .dismiss, "Dismiss", VellumKeyCombo(.escape, []), menu: .find,
+            installOnDocumentSurface: true, overridesSystemBehavior: false),
+    ]
+
+    // MARK: View
+
+    private static let view: [VellumShortcut] = [
+        // ⌘+ is the Mac's Zoom In and stays the menu chord for parity. On iPadOS
+        // a `UIKeyCommand` matches the literal input string plus exact modifier
+        // flags, so "+" only ever matches when Shift is also reported; ⌘= (the
+        // unshifted key most people actually press) and ⌘⇧+ are registered as
+        // responder-chain alternates so every spelling of "zoom in" works over a
+        // document.
+        VellumShortcut(
+            .zoomIn, "Zoom In", VellumKeyCombo("+"), menu: .view,
+            alternates: [VellumKeyCombo("="), VellumKeyCombo("+", [.command, .shift])],
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .zoomOut, "Zoom Out", VellumKeyCombo("-"), menu: .view, installOnDocumentSurface: true),
+        VellumShortcut(
+            .actualSize, "Actual Size", VellumKeyCombo("0"), menu: .view,
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .toggleInspector, "Toggle Inspector", VellumKeyCombo("s", [.command, .option]),
+            menu: .view),
+        // Split chords mirror macOS: they avoid the arrow keys, which ⌘⌥↑/↓
+        // already use for First/Last Page. ⌘\ matches VS Code's "Split Editor".
+        VellumShortcut(.splitRight, "Split Right", VellumKeyCombo("\\"), menu: .view),
+        VellumShortcut(
+            .splitDown, "Split Down", VellumKeyCombo("\\", [.command, .option]), menu: .view),
+        VellumShortcut(
+            .mergePanes, "Merge Panes", VellumKeyCombo("j", [.command, .option]), menu: .view),
+        VellumShortcut(
+            .closePane, "Close Pane", VellumKeyCombo("\\", [.command, .shift]), menu: .view),
+    ]
+
+    // MARK: Navigate
+
+    private static let navigate: [VellumShortcut] = [
+        // Every chord in this group is one a document surface competes for:
+        // PDFView and WKWebView are scroll views, and UIKit binds ⌘↑/⌘↓ to
+        // scroll-to-top/bottom, while WKWebView binds ⌘[ / ⌘] to its own
+        // back/forward (which bypasses Vellum's session rebinding).
+        VellumShortcut(
+            .previousPage, "Previous Page", VellumKeyCombo(.upArrow, .command), menu: .navigate,
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .nextPage, "Next Page", VellumKeyCombo(.downArrow, .command), menu: .navigate,
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .firstPage, "First Page", VellumKeyCombo(.upArrow, [.command, .option]), menu: .navigate,
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .lastPage, "Last Page", VellumKeyCombo(.downArrow, [.command, .option]), menu: .navigate,
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .webBack, "Back", VellumKeyCombo("["), menu: .navigate, installOnDocumentSurface: true),
+        VellumShortcut(
+            .webForward, "Forward", VellumKeyCombo("]"), menu: .navigate,
+            installOnDocumentSurface: true),
+        VellumShortcut(
+            .previousTab, "Show Previous Tab", VellumKeyCombo("[", [.command, .shift]),
+            menu: .navigate, installOnDocumentSurface: true),
+        VellumShortcut(
+            .nextTab, "Show Next Tab", VellumKeyCombo("]", [.command, .shift]), menu: .navigate,
+            installOnDocumentSurface: true),
+    ] + tabSwitching
+
+    /// ⌘1…⌘9. Titles are static ("Show Tab 3") rather than the Mac's live
+    /// document titles: iPadOS builds its menu once per `Commands` evaluation
+    /// and a stale title is worse than a positional one.
+    private static let tabSwitching: [VellumShortcut] = (1...9).map { number in
+        VellumShortcut(
+            .showTab(number), "Show Tab \(number)",
+            VellumKeyCombo(Character("\(number)")), menu: .navigate)
+    }
+
+    // MARK: Annotations
+
+    private static let annotations: [VellumShortcut] = [
+        VellumShortcut(.bookmarkPage, "Bookmark Page", VellumKeyCombo("d"), menu: .annotations),
+        // Bare `N` carries no modifier, so it is menu-only on purpose: installing
+        // it on the web surface would swallow the letter "n" whenever the user
+        // types into a page's text field. The router additionally suppresses it
+        // while any text input holds first responder.
+        VellumShortcut(
+            .toggleNoteMode, "Toggle Note Mode", VellumKeyCombo(.character("n"), []),
+            menu: .annotations),
+    ]
+
+    // MARK: - Lookup
+
+    private static let byAction: [VellumShortcutAction: VellumShortcut] =
+        Dictionary(uniqueKeysWithValues: all.map { ($0.action, $0) })
+
+    private static let byIdentifier: [String: VellumShortcutAction] =
+        Dictionary(uniqueKeysWithValues: all.map { ($0.action.identifier, $0.action) })
+
+    /// The shortcut bound to `action`, or nil if the table does not carry one.
+    static subscript(action: VellumShortcutAction) -> VellumShortcut? { byAction[action] }
+
+    /// Shortcuts belonging to one menu, in table order.
+    static func shortcuts(in menu: VellumShortcutMenu) -> [VellumShortcut] {
+        all.filter { $0.menu == menu }
+    }
+
+    /// Resolves the string identity a `UIKeyCommand` carried back to its action.
+    static func action(forIdentifier identifier: String) -> VellumShortcutAction? {
+        byIdentifier[identifier]
+    }
+
+    /// The shortcuts duplicated onto Vellum's UIKit document surfaces.
+    static var documentSurfaceShortcuts: [VellumShortcut] {
+        all.filter(\.installOnDocumentSurface)
+    }
+
+    /// Builds the `UIKeyCommand`s for the document surfaces. `action` is the
+    /// selector on the hosting view; each command carries its shortcut's string
+    /// identity in `propertyList` so one selector can serve the whole table.
+    static func documentSurfaceKeyCommands(action selector: Selector) -> [UIKeyCommand] {
+        documentSurfaceShortcuts.flatMap { shortcut in
+            ([shortcut.combo] + shortcut.alternates).enumerated().map { index, combo in
+                let isPrimary = index == 0
+                let command = UIKeyCommand(
+                    title: shortcut.title,
+                    action: selector,
+                    input: combo.key.keyCommandInput,
+                    modifierFlags: combo.modifiers.keyModifierFlags,
+                    propertyList: shortcut.action.identifier)
+                // Only the primary chord is advertised in the ⌘-hold HUD.
+                // Alternates exist to make a chord people actually press work
+                // (⌘= for Zoom In); listing them too would show the same title
+                // three times, which is noise rather than discoverability.
+                if isPrimary {
+                    command.discoverabilityTitle = shortcut.title
+                }
+                // The whole point of these duplicates: beat PDFKit's/WebKit's
+                // own bindings for the same chord instead of losing the race.
+                command.wantsPriorityOverSystemBehavior = shortcut.overridesSystemBehavior
+                return command
+            }
+        }
+    }
+}
+#endif  // os(iOS)

--- a/Vellum/Platform/iOS/KeyboardShortcuts_iOS.swift
+++ b/Vellum/Platform/iOS/KeyboardShortcuts_iOS.swift
@@ -463,6 +463,15 @@ enum VellumShortcutCatalog {
     /// Builds the `UIKeyCommand`s for the document surfaces. `action` is the
     /// selector on the hosting view; each command carries its shortcut's string
     /// identity in `propertyList` so one selector can serve the whole table.
+    ///
+    /// `@MainActor` because every UIKit member it touches is — `UIKeyCommand`'s
+    /// initializer, `discoverabilityTitle` and `wantsPriorityOverSystemBehavior`
+    /// are all main-actor isolated, so building the commands from a nonisolated
+    /// context warns today and is an error under a stricter concurrency setting.
+    /// Costs the callers nothing: both are already on the main actor (the
+    /// `VellumShortcutResponder` extension via the `@MainActor` protocol, and the
+    /// `@MainActor` test case).
+    @MainActor
     static func documentSurfaceKeyCommands(action selector: Selector) -> [UIKeyCommand] {
         documentSurfaceShortcuts.flatMap { shortcut in
             ([shortcut.combo] + shortcut.alternates).enumerated().map { index, combo in

--- a/Vellum/Platform/iOS/PdfKitView_iOS.swift
+++ b/Vellum/Platform/iOS/PdfKitView_iOS.swift
@@ -8,9 +8,31 @@ import UIKit
 // selection tracking feeding PdfViewerControlleriOS. Touch selection is native
 // (long-press handles); note placement + dismissal happen in the SwiftUI overlay.
 
-/// PDFView subclass — a hook for the Pencil ink canvas (Phase 4) and a spot to
-/// trim the selection edit menu so the custom Liquid Glass popover leads.
-final class VellumPDFView: PDFView {
+/// PDFView subclass — a hook for the Pencil ink canvas (Phase 4), a spot to
+/// trim the selection edit menu so the custom Liquid Glass popover leads, and
+/// the carrier for Vellum's hardware-keyboard commands over a PDF.
+final class VellumPDFView: PDFView, VellumShortcutResponder {
+    var onShortcut: VellumShortcutHandler?
+
+    /// Built once: `keyCommands` is queried on every key press while this view
+    /// is in the responder chain, and the array is constant for the lifetime of
+    /// the view (the catalog is static and the selector never changes).
+    private lazy var vellumCommands: [UIKeyCommand] =
+        vellumKeyCommands(action: #selector(vellumPerformShortcut(_:)))
+
+    /// Vellum's chords are listed first so they take precedence over anything
+    /// PDFKit contributes for the same combination (scroll-to-top on ⌘↑, its own
+    /// find plumbing on ⌘F), and `super`'s are preserved so nothing else PDFKit
+    /// offers is lost. See `VellumShortcutResponder` for why the duplication
+    /// with the SwiftUI menu is necessary at all.
+    override var keyCommands: [UIKeyCommand]? {
+        vellumCommands + (super.keyCommands ?? [])
+    }
+
+    @objc private func vellumPerformShortcut(_ sender: UIKeyCommand) {
+        vellumPerform(sender)
+    }
+
     override func buildMenu(with builder: UIMenuBuilder) {
         // Suppress the system callout entirely — it fights the Liquid Glass
         // selection popover for the same anchor (the popover carries copy /
@@ -31,6 +53,7 @@ struct PdfKitView_iOS: UIViewRepresentable {
     let ink: InkController_iOS
 
     @Environment(AppStore.self) private var app
+    @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.palette) private var palette
 
     func makeCoordinator() -> Coordinator { Coordinator(controller: controller, ink: ink) }
@@ -52,6 +75,12 @@ struct PdfKitView_iOS: UIViewRepresentable {
         // the virtualized per-page canvases), so barrel double-taps are delivered
         // reliably regardless of scroll position / which page canvas is live.
         view.addInteraction(UIPencilInteraction(delegate: ink.inkProvider))
+        // Hardware-keyboard commands for when PDFKit holds first responder. The
+        // WorkspaceStore is created once for the app's lifetime, so capturing it
+        // here (rather than re-assigning on every update) cannot go stale.
+        view.onShortcut = { [workspace] action in
+            VellumShortcutRouter.perform(action, workspace: workspace)
+        }
         view.document = document
         view.scaleFactor = CGFloat(min(AppStore.maxZoom, max(AppStore.minZoom, app.zoom)))
         controller.pdfView = view

--- a/Vellum/Platform/iOS/ShortcutRouter_iOS.swift
+++ b/Vellum/Platform/iOS/ShortcutRouter_iOS.swift
@@ -1,0 +1,297 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+// The execution half of the keyboard-shortcut system (issue #40). The table in
+// `KeyboardShortcuts_iOS.swift` says *what* the chords are; this file is the one
+// place that says what they *do*, plus the plumbing that lets a UIKit document
+// surface run them.
+//
+// Both dispatch surfaces funnel through `VellumShortcutRouter.perform`:
+//   • `VellumCommands_iOS` — the SwiftUI menu, i.e. the ⌘-hold HUD / menu bar.
+//   • `VellumShortcutResponder` — `UIKeyCommand`s on `VellumPDFView` /
+//     `VellumWebView`, for when PDFKit or WebKit holds first responder.
+// One implementation means the two can never disagree about what ⌘G does.
+
+/// Callback shape a document surface uses to hand a decoded shortcut back to
+/// SwiftUI. `@MainActor` because everything it touches (the stores, the router)
+/// is main-actor isolated, and UIKit delivers key commands on the main thread
+/// anyway — spelling it out lets the compiler check it instead of us.
+typealias VellumShortcutHandler = @MainActor (VellumShortcutAction) -> Void
+
+// MARK: - Router
+
+@MainActor
+enum VellumShortcutRouter {
+    /// Runs `action` against the workspace's focused pane.
+    ///
+    /// Unlike macOS — which routes through `@FocusedValue` and gets menu
+    /// validation (and therefore `.disabled` state) for free — the iPad app is a
+    /// single window whose menu is rebuilt only when SwiftUI re-evaluates
+    /// `Commands`. Relying on `.disabled` would leave stale menu state, so every
+    /// precondition is re-checked *here*, at invocation time, and an
+    /// inapplicable shortcut is a silent no-op rather than a wrong action.
+    ///
+    /// Note the target is always `workspace.focusedPane`, even when the chord
+    /// arrived from a document surface's `UIKeyCommand`. Pane focus is driven by
+    /// the tap catcher (`PaneFocusCatcher_iOS`), not by UIKit first-responder
+    /// status, so in a split it is conceivable for a pane to take first
+    /// responder without having taken pane focus (a long-press text selection,
+    /// say). Routing to the focused pane regardless is the deliberate choice:
+    /// it matches what the toolbar, inspector and find bar all act on, so the
+    /// keyboard never disagrees with the rest of the chrome.
+    static func perform(_ action: VellumShortcutAction, workspace: WorkspaceStore) {
+        let pane = workspace.focusedPane
+        let app = pane.app
+
+        switch action {
+        // MARK: File
+        case .newTab:
+            app.newStartTab()
+
+        case .openFile:
+            // The document picker is presented by the shell (`ContentView_iOS`),
+            // which owns the presentation state; panes and `Commands` structs
+            // cannot drive it directly, so both go through this notification.
+            NotificationCenter.default.post(name: .vellumOpenFile, object: nil)
+
+        case .addWebpage:
+            NotificationCenter.default.post(name: .vellumAddWebpage, object: nil)
+
+        case .closeTab:
+            // Works on a lone document-less start tab too, matching macOS.
+            guard !app.tabs.isEmpty else { return }
+            Task { await app.closeFile() }
+
+        case .printDocument:
+            guard app.document != nil else { return }
+            app.printDocument()
+
+        case .save:
+            // Save writes annotations back into the PDF; web tabs persist via
+            // export, not Save, so the command is PDF-only.
+            guard app.document?.kind == .pdf, let sessionId = app.activeTabId else { return }
+            Task { try? await app.sessions.saveFile(sessionId: sessionId) }
+
+        // MARK: Find
+        case .find:
+            guard app.document != nil else { return }
+            app.showFind()
+
+        case .findNext:
+            guard app.findVisible else { return }
+            app.findNext()
+
+        case .findPrevious:
+            guard app.findVisible else { return }
+            app.findPrev()
+
+        case .dismiss:
+            // Order matters and mirrors the macOS key monitor: closing the find
+            // bar comes first and is NOT gated on the text-input check, because
+            // the find field is itself a text input holding first responder —
+            // gating it would make Escape unable to close the very bar it opened.
+            if app.findVisible {
+                app.hideFind()
+                return
+            }
+            guard !VellumKeyboardFocus.isTextInputFirstResponder else { return }
+            pane.annotations.selectAnnotation(nil)
+            app.setMode(.view)
+
+        // MARK: View
+        case .zoomIn:
+            guard app.document != nil else { return }
+            app.zoomIn()
+
+        case .zoomOut:
+            guard app.document != nil else { return }
+            app.zoomOut()
+
+        case .actualSize:
+            guard app.document != nil else { return }
+            app.resetZoom()
+
+        case .toggleInspector:
+            // The inspector only exists alongside a document, but its open state
+            // is window-global so it survives focus changes.
+            guard app.document != nil else { return }
+            workspace.sidebarOpen.toggle()
+
+        case .splitRight:
+            workspace.splitFocused(.horizontal)
+
+        case .splitDown:
+            workspace.splitFocused(.vertical)
+
+        case .mergePanes:
+            guard workspace.isSplit else { return }
+            workspace.mergeAll()
+
+        case .closePane:
+            guard workspace.isSplit else { return }
+            workspace.closePane(workspace.focusedPaneId)
+
+        // MARK: Navigate
+        case .previousPage:
+            goToPage(app, delta: -1)
+
+        case .nextPage:
+            goToPage(app, delta: 1)
+
+        case .firstPage:
+            guard isPdf(app) else { return }
+            app.goToPage(1)
+
+        case .lastPage:
+            guard isPdf(app) else { return }
+            app.goToPage(app.numPages)
+
+        case .webBack:
+            webHistory(app, delta: -1)
+
+        case .webForward:
+            webHistory(app, delta: 1)
+
+        case .previousTab:
+            guard app.tabs.count >= 2 else { return }
+            app.cycleTab(-1)
+
+        case .nextTab:
+            guard app.tabs.count >= 2 else { return }
+            app.cycleTab(1)
+
+        case .showTab(let number):
+            // The table is 1-based (⌘1 is the first tab); `tabs` is 0-based.
+            let index = number - 1
+            guard app.tabs.indices.contains(index) else { return }
+            app.activateTab(app.tabs[index].id)
+
+        // MARK: Annotations
+        case .bookmarkPage:
+            guard app.document != nil else { return }
+            let annotations = pane.annotations
+            Task { await annotations.toggleBookmark() }
+
+        case .toggleNoteMode:
+            // Bare `N` with no modifier: it must never steal a keystroke that
+            // belongs to a text field, the scratchpad's CodeMirror editor, or
+            // the AI composer. This is the iOS analogue of the macOS
+            // `ContentView.isTextInputFirstResponder` responder walk.
+            guard app.document != nil, !VellumKeyboardFocus.isTextInputFirstResponder else { return }
+            app.setMode(app.mode == .note ? .view : .note)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func isPdf(_ app: AppStore) -> Bool { app.document?.kind == .pdf }
+
+    private static func goToPage(_ app: AppStore, delta: Int) {
+        guard isPdf(app) else { return }
+        app.goToPage(app.currentPage + delta)
+    }
+
+    private static func webHistory(_ app: AppStore, delta: Int) {
+        // The web viewer owns its WKWebView's history so it can rebind the
+        // session; the shortcut only asks it to move.
+        //
+        // Inherited quirk, not a regression: this notification is pane-blind, so
+        // in a split with two web tabs both move. macOS behaves identically (the
+        // toolbar buttons post the same broadcast) — fixing it means making the
+        // notification pane-scoped on both platforms, which is out of scope here.
+        guard app.document?.kind == .web else { return }
+        NotificationCenter.default.post(
+            name: .vellumWebHistory, object: nil, userInfo: ["delta": delta])
+    }
+}
+
+// MARK: - Keyboard focus
+
+/// First-responder questions the shortcut system needs to answer before firing
+/// a chord that a text surface might legitimately want.
+@MainActor
+enum VellumKeyboardFocus {
+    /// True when the user is typing somewhere: a UIKit text control, anything
+    /// conforming to `UITextInput`, or the scratchpad's WebView-hosted editor.
+    ///
+    /// Mirrors the macOS `ContentView.isTextInputFirstResponder`. The scratchpad
+    /// needs the ancestry walk because CodeMirror edits inside a WKWebView, so
+    /// the first responder is a private WebKit content view rather than a
+    /// `UITextView` — hence the marker subclass `ScratchpadWebView`.
+    static var isTextInputFirstResponder: Bool {
+        guard let responder = UIResponder.vellumCurrentFirstResponder else { return false }
+        if responder is UITextField || responder is UITextView || responder is UISearchBar {
+            return true
+        }
+        guard let view = responder as? UIView else {
+            // Non-view responders can still be text inputs (e.g. a custom
+            // `UIKeyInput`), so fall back to the protocol test.
+            return responder is any UITextInput
+        }
+        var ancestor: UIView? = view
+        while let current = ancestor {
+            if current is ScratchpadWebView { return true }
+            ancestor = current.superview
+        }
+        return view is any UITextInput
+    }
+}
+
+/// Resolves the current first responder without holding a reference to it, by
+/// bouncing a captured selector through the responder chain — the standard UIKit
+/// idiom, since `UIWindow` exposes no `firstResponder` property.
+extension UIResponder {
+    @MainActor private static weak var _vellumFirstResponder: UIResponder?
+
+    @MainActor
+    static var vellumCurrentFirstResponder: UIResponder? {
+        _vellumFirstResponder = nil
+        UIApplication.shared.sendAction(
+            #selector(UIResponder._vellumCaptureFirstResponder(_:)), to: nil, from: nil, for: nil)
+        return _vellumFirstResponder
+    }
+
+    @MainActor
+    @objc private func _vellumCaptureFirstResponder(_ sender: Any?) {
+        UIResponder._vellumFirstResponder = self
+    }
+}
+
+// MARK: - Document-surface responder
+
+/// Adopted by the Vellum-owned views that wrap a UIKit document surface
+/// (`VellumPDFView` around PDFKit, `VellumWebView` around WebKit).
+///
+/// Why this exists at all: SwiftUI's `.keyboardShortcut` commands live at the
+/// end of the responder chain, so whenever PDFKit or WebKit is first responder
+/// it sees the key press first and can consume chords it has its own bindings
+/// for (⌘F, ⌘G, ⌘↑/⌘↓ scrolling, ⌘[ / ⌘] history). macOS neutralises that with
+/// a local `NSEvent` monitor; iPadOS offers no such pre-dispatch hook, so we put
+/// the competing chords on the nearest Vellum-owned ancestor of the first
+/// responder instead. UIKit stops at the first responder that handles a chord,
+/// so this wins the race *and* keeps the menu copy from double-firing.
+@MainActor
+protocol VellumShortcutResponder: UIView {
+    /// Set by the `UIViewRepresentable` that vends the view; forwards to
+    /// `VellumShortcutRouter.perform`.
+    var onShortcut: VellumShortcutHandler? { get set }
+}
+
+extension VellumShortcutResponder {
+    /// The catalog's document-surface commands, bound to `selector`. Conformers
+    /// pass their own `#selector(...)` because an `@objc` entry point cannot be
+    /// synthesised in a protocol extension.
+    func vellumKeyCommands(action selector: Selector) -> [UIKeyCommand] {
+        VellumShortcutCatalog.documentSurfaceKeyCommands(action: selector)
+    }
+
+    /// Decodes the shortcut a `UIKeyCommand` carried and forwards it.
+    func vellumPerform(_ command: UIKeyCommand) {
+        guard let identifier = command.propertyList as? String,
+              let action = VellumShortcutCatalog.action(forIdentifier: identifier)
+        else { return }
+        onShortcut?(action)
+    }
+}
+#endif  // os(iOS)

--- a/Vellum/Platform/iOS/VellumCommands_iOS.swift
+++ b/Vellum/Platform/iOS/VellumCommands_iOS.swift
@@ -5,277 +5,136 @@ import UIKit
 /// Hardware-keyboard shortcuts for the iPad app, mirroring the macOS
 /// `VellumCommands` menu surface (see `App/VellumCommands.swift`). When a Magic
 /// Keyboard or any Bluetooth keyboard is attached, these appear in the ⌘-hold
-/// discoverability HUD and fire the same actions as the Mac app.
+/// discoverability HUD — and, on iPadOS 26, in the real menu bar — and fire the
+/// same actions as the Mac app.
+///
+/// This type is only the *presentation* of the shortcut system (issue #40):
+///   • the chords themselves live in `KeyboardShortcuts_iOS.swift`, as a plain
+///     data table so they can be unit-tested and shared;
+///   • the behaviour lives in `VellumShortcutRouter`, which the UIKit
+///     document-surface key commands also call.
+/// Every item below is therefore a two-liner: title and chord straight out of
+/// the catalog, action straight into the router. Adding a shortcut means adding
+/// a row to the table and one `item(_:)` call here — the two cannot drift.
 ///
 /// Unlike macOS — which routes through `@FocusedValue` for free menu validation
-/// — the iPad app is a single window, so we capture the WorkspaceStore directly,
-/// resolve the focused pane's stores at invocation time, and guard inside each
-/// action. That keeps every guard fresh (no reliance on `Commands` re-evaluation
-/// to update `.disabled` state), so a shortcut never silently no-ops because a
-/// menu item was left stale — and every document command targets the pane the
-/// user is actually working in.
+/// — the iPad app is a single window, so we capture the WorkspaceStore directly
+/// and the router re-checks every precondition at invocation time. That keeps
+/// each guard fresh (no reliance on `Commands` re-evaluation to refresh
+/// `.disabled` state), so a shortcut never fires the wrong thing because a menu
+/// item was left stale — and every document command targets the pane the user
+/// is actually working in.
 struct VellumCommands_iOS: Commands {
     let workspace: WorkspaceStore
-
-    private var appStore: AppStore { workspace.focusedPane.app }
-    private var annotationStore: AnnotationStore { workspace.focusedPane.annotations }
 
     var body: some Commands {
         // MARK: File
         CommandGroup(replacing: .newItem) {
-            Button("New Tab") { appStore.newStartTab() }
-                .keyboardShortcut("t", modifiers: .command)
+            item(.newTab)
         }
 
-        // Replace UIKit's document-import command so ⌘O has exactly one owner
-        // and routes through Vellum's pane-aware importer.
+        // Replacing (not adding to) the standard import/export group means the
+        // system's own document-import item — and any key equivalent it carries
+        // — goes away, leaving Vellum's pane-aware importer as the sole owner of
+        // ⌘O.
         CommandGroup(replacing: .importExport) {
-            Button("Open…") {
-                NotificationCenter.default.post(name: .vellumOpenFile, object: nil)
-            }
-            // UIKit owns the standard hardware ⌘O key command on iPad. Adding
-            // a SwiftUI duplicate produces undefined dispatch; keep this menu
-            // action while leaving the standard key equivalent to UIKit.
-
-            Button("Add Webpage…") {
-                NotificationCenter.default.post(name: .vellumAddWebpage, object: nil)
-            }
-            .keyboardShortcut("l", modifiers: .command)
+            item(.openFile)
+            item(.addWebpage)
         }
 
         CommandGroup(after: .newItem) {
-            Button("Close Tab") {
-                guard !appStore.tabs.isEmpty else { return }
-                Task { await appStore.closeFile() }
-            }
-            .keyboardShortcut("w", modifiers: .command)
+            item(.closeTab)
         }
 
         CommandGroup(replacing: .printItem) {
-            Button("Print…") {
-                guard appStore.document != nil else { return }
-                appStore.printDocument()
-            }
-            .keyboardShortcut("p", modifiers: .command)
-        }
-
-        // MARK: Find
-        // UIKit already owns the responder-chain ⌘A/⌘F/⌘G commands on iPad.
-        // These menu actions expose Vellum's document-aware find UI without
-        // registering duplicate key equivalents with undefined dispatch.
-        CommandGroup(after: .textEditing) {
-            Button("Find…") {
-                guard appStore.document != nil else { return }
-                appStore.showFind()
-            }
-
-            Button("Find Next") {
-                guard appStore.findVisible else { return }
-                appStore.findNext()
-            }
-
-            Button("Find Previous") {
-                guard appStore.findVisible else { return }
-                appStore.findPrev()
-            }
+            item(.printDocument)
         }
 
         CommandGroup(replacing: .saveItem) {
-            Button("Save") {
-                // Save writes annotations back into the PDF; web tabs persist via
-                // export, not Save, so the command is PDF-only.
-                guard appStore.document?.kind == .pdf,
-                      let sessionId = appStore.activeTabId else { return }
-                Task { try? await appStore.sessions.saveFile(sessionId: sessionId) }
-            }
-            .keyboardShortcut("s", modifiers: .command)
+            item(.save)
         }
 
-        // MARK: View
+        // MARK: Edit → Find
+        // Appended after the standard text-editing group, where the Mac's
+        // Edit ▸ Find lives. ⌘C/⌘V/⌘X/⌘A are deliberately absent: UIKit already
+        // implements those on every text surface and shadowing them would break
+        // editing.
+        CommandGroup(after: .textEditing) {
+            item(.find)
+            item(.findNext)
+            item(.findPrevious)
+            item(.dismiss)
+        }
+
+        // MARK: View (zoom + inspector live alongside the built-in sidebar group)
         CommandGroup(after: .sidebar) {
-            Button("Zoom In") {
-                guard appStore.document != nil else { return }
-                appStore.zoomIn()
-            }
-            .keyboardShortcut("+", modifiers: .command)
-
-            // ⌘= as an unshifted alias for Zoom In: on hardware keyboards the
-            // "+" glyph needs Shift, so ⌘= is the ergonomic combo most reach for.
-            Button("Zoom In") {
-                guard appStore.document != nil else { return }
-                appStore.zoomIn()
-            }
-            .keyboardShortcut("=", modifiers: .command)
-
-            Button("Zoom Out") {
-                guard appStore.document != nil else { return }
-                appStore.zoomOut()
-            }
-            .keyboardShortcut("-", modifiers: .command)
-
-            Button("Actual Size") {
-                guard appStore.document != nil else { return }
-                appStore.resetZoom()
-            }
-            .keyboardShortcut("0", modifiers: .command)
+            item(.zoomIn)
+            item(.zoomOut)
+            item(.actualSize)
 
             Divider()
 
-            Button("Toggle Inspector") {
-                guard appStore.document != nil else { return }
-                workspace.sidebarOpen.toggle()
-            }
-            .keyboardShortcut("s", modifiers: [.command, .option])
+            item(.toggleInspector)
 
             Divider()
 
-            // Split shortcuts mirror macOS: they avoid the arrow keys, which
-            // ⌘⌥↑/↓ already use for First/Last Page. ⌘\ matches VS Code.
-            Button("Split Right") { workspace.splitFocused(.horizontal) }
-                .keyboardShortcut("\\", modifiers: .command)
-
-            Button("Split Down") { workspace.splitFocused(.vertical) }
-                .keyboardShortcut("\\", modifiers: [.command, .option])
-
-            Button("Merge Panes") {
-                guard workspace.isSplit else { return }
-                workspace.mergeAll()
-            }
-            .keyboardShortcut("j", modifiers: [.command, .option])
-
-            Button("Close Pane") {
-                guard workspace.isSplit else { return }
-                workspace.closePane(workspace.focusedPaneId)
-            }
-            .keyboardShortcut("\\", modifiers: [.command, .shift])
+            item(.splitRight)
+            item(.splitDown)
+            item(.mergePanes)
+            item(.closePane)
         }
 
         // MARK: Navigate
         CommandMenu("Navigate") {
-            Button("Previous Page") { goToPage(-1) }
-                .keyboardShortcut(.upArrow, modifiers: .command)
-
-            Button("Next Page") { goToPage(1) }
-                .keyboardShortcut(.downArrow, modifiers: .command)
-
-            Button("First Page") {
-                guard isPdf else { return }
-                appStore.goToPage(1)
-            }
-            .keyboardShortcut(.upArrow, modifiers: [.command, .option])
-
-            Button("Last Page") {
-                guard isPdf else { return }
-                appStore.goToPage(appStore.numPages)
-            }
-            .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+            item(.previousPage)
+            item(.nextPage)
+            item(.firstPage)
+            item(.lastPage)
 
             Divider()
 
             // Web in-page history.
-            Button("Back") { webHistory(-1) }
-                .keyboardShortcut("[", modifiers: .command)
-
-            Button("Forward") { webHistory(1) }
-                .keyboardShortcut("]", modifiers: .command)
+            item(.webBack)
+            item(.webForward)
 
             Divider()
 
-            // Tab cycling, wrapping at the ends across any mix of tabs.
-            Button("Show Previous Tab") {
-                guard appStore.tabs.count >= 2 else { return }
-                appStore.cycleTab(-1)
-            }
-            .keyboardShortcut("[", modifiers: [.command, .shift])
-
-            Button("Show Next Tab") {
-                guard appStore.tabs.count >= 2 else { return }
-                appStore.cycleTab(1)
-            }
-            .keyboardShortcut("]", modifiers: [.command, .shift])
+            // Tab cycling, wrapping at the ends across any mix of
+            // PDF / web / start tabs.
+            item(.previousTab)
+            item(.nextTab)
 
             Divider()
 
             // Tab switching ⌘1…⌘9.
             ForEach(1...9, id: \.self) { number in
-                Button("Show Tab \(number)") { activateTab(index: number - 1) }
-                    .keyboardShortcut(
-                        KeyEquivalent(Character("\(number)")), modifiers: .command)
+                item(.showTab(number))
             }
         }
 
         // MARK: Annotations
         CommandMenu("Annotations") {
-            Button("Bookmark Page") {
-                guard appStore.document != nil else { return }
-                Task { await annotationStore.toggleBookmark() }
-            }
-            .keyboardShortcut("d", modifiers: .command)
-
-            Button("Toggle Note Mode") {
-                // Bare `N` has no modifier, so it can collide with typing in the
-                // scratchpad editor's WebView. Suppress it while that editor
-                // holds keyboard focus (iOS analogue of macOS
-                // `ContentView.isTextInputFirstResponder`'s responder walk).
-                guard appStore.document != nil, !scratchpadEditorFocused else { return }
-                appStore.setMode(appStore.mode == .note ? .view : .note)
-            }
-            .keyboardShortcut("n", modifiers: [])
+            item(.bookmarkPage)
+            item(.toggleNoteMode)
         }
     }
 
-    // MARK: - Derived state / actions
-
-    private var isPdf: Bool {
-        guard let doc = appStore.document else { return false }
-        return doc.kind == .pdf
-    }
-
-    /// True when keyboard focus is inside the scratchpad editor's WKWebView.
-    /// Editing happens in a private WebKit content view (no `UITextField` to
-    /// detect directly), so we walk the first responder's view ancestry for the
-    /// marker `ScratchpadWebView`.
-    private var scratchpadEditorFocused: Bool {
-        guard let responder = UIResponder.vellumCurrentFirstResponder as? UIView else { return false }
-        var view: UIView? = responder
-        while let current = view {
-            if current is ScratchpadWebView { return true }
-            view = current.superview
+    /// One menu item, fully described by the catalog.
+    ///
+    /// Titles are static rather than state-dependent ("Bookmark Page", not
+    /// "Remove Bookmark"): iPadOS builds the menu from a single `Commands`
+    /// evaluation and does not re-validate items the way AppKit does before each
+    /// menu tracking session, so a live title would read as stale more often
+    /// than it read as correct.
+    @ViewBuilder
+    private func item(_ action: VellumShortcutAction) -> some View {
+        if let shortcut = VellumShortcutCatalog[action] {
+            Button(shortcut.title) {
+                VellumShortcutRouter.perform(action, workspace: workspace)
+            }
+            .keyboardShortcut(
+                shortcut.combo.key.keyEquivalent, modifiers: shortcut.combo.modifiers.eventModifiers)
         }
-        return false
-    }
-
-    private func goToPage(_ delta: Int) {
-        guard isPdf else { return }
-        appStore.goToPage(appStore.currentPage + delta)
-    }
-
-    private func webHistory(_ delta: Int) {
-        guard appStore.document?.kind == .web else { return }
-        NotificationCenter.default.post(
-            name: .vellumWebHistory, object: nil, userInfo: ["delta": delta])
-    }
-
-    private func activateTab(index: Int) {
-        guard appStore.tabs.indices.contains(index) else { return }
-        appStore.activateTab(appStore.tabs[index].id)
-    }
-}
-
-/// Resolves the current first responder without a reference to it, by bouncing a
-/// captured selector through the responder chain — the standard UIKit idiom.
-extension UIResponder {
-    private weak static var _vellumFirstResponder: UIResponder?
-
-    static var vellumCurrentFirstResponder: UIResponder? {
-        _vellumFirstResponder = nil
-        UIApplication.shared.sendAction(
-            #selector(UIResponder._vellumCaptureFirstResponder(_:)), to: nil, from: nil, for: nil)
-        return _vellumFirstResponder
-    }
-
-    @objc private func _vellumCaptureFirstResponder(_ sender: Any?) {
-        UIResponder._vellumFirstResponder = self
     }
 }
 #endif  // os(iOS)

--- a/Vellum/Platform/iOS/WebViewerView_iOS.swift
+++ b/Vellum/Platform/iOS/WebViewerView_iOS.swift
@@ -236,16 +236,52 @@ private struct WebDocumentIdentity_iOS: Hashable {
     var url: String?
 }
 
+/// WKWebView subclass that carries Vellum's hardware-keyboard commands.
+///
+/// WebKit is first responder for essentially the whole time a web tab is open,
+/// and it ships its own bindings for several chords Vellum also uses (⌘F find,
+/// ⌘[ / ⌘] history, ⌘↑ / ⌘↓ scroll-to-end). Its bindings bypass Vellum's
+/// cross-format find bar and its session rebinding, so the Vellum commands are
+/// hung here — nearer the first responder than the SwiftUI menu — to win the
+/// dispatch race. See `VellumShortcutResponder` for the full rationale.
+final class VellumWebView: WKWebView, VellumShortcutResponder {
+    var onShortcut: VellumShortcutHandler?
+
+    /// Built once: `keyCommands` is consulted on every key press, and the array
+    /// is constant for the life of the view.
+    private lazy var vellumCommands: [UIKeyCommand] =
+        vellumKeyCommands(action: #selector(vellumPerformShortcut(_:)))
+
+    /// Vellum's chords first so they beat WebKit's own, `super`'s preserved so
+    /// everything else WebKit offers (text editing, selection) still works.
+    override var keyCommands: [UIKeyCommand]? {
+        vellumCommands + (super.keyCommands ?? [])
+    }
+
+    @objc private func vellumPerformShortcut(_ sender: UIKeyCommand) {
+        vellumPerform(sender)
+    }
+}
+
 /// Hosts the controller's WKWebView. UIKit counterpart of the macOS
 /// NSViewRepresentable — no AppKit involved.
 private struct WebViewRepresentable_iOS: UIViewRepresentable {
     let controller: WebViewerController_iOS
 
-    func makeUIView(context: Context) -> WKWebView {
-        controller.webView
+    @Environment(WorkspaceStore.self) private var workspace
+
+    func makeUIView(context: Context) -> VellumWebView {
+        let webView = controller.webView
+        // Hardware-keyboard commands for when WebKit holds first responder. The
+        // WorkspaceStore lives for the whole app session, so capturing it once
+        // cannot go stale.
+        webView.onShortcut = { [workspace] action in
+            VellumShortcutRouter.perform(action, workspace: workspace)
+        }
+        return webView
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {}
+    func updateUIView(_ uiView: VellumWebView, context: Context) {}
 }
 
 // MARK: - Controller (the WebViewer bridge logic, iOS)
@@ -306,8 +342,8 @@ final class WebViewerController_iOS: NSObject {
     @ObservationIgnored private var pendingLocates: [String: (LocatedText?) -> Void] = [:]
     @ObservationIgnored private var pendingCaptures: [String: (CapturedWebPosition?) -> Void] = [:]
 
-    @ObservationIgnored private lazy var _webView: WKWebView = makeWebView()
-    var webView: WKWebView { _webView }
+    @ObservationIgnored private lazy var _webView: VellumWebView = makeWebView()
+    var webView: VellumWebView { _webView }
 
     /// Isolated content world for the bridge: the content script and the
     /// "vellum" message handler live here, out of reach of page scripts (a
@@ -317,7 +353,7 @@ final class WebViewerController_iOS: NSObject {
     /// unchanged.
     private static let bridgeWorld = WKContentWorld.world(name: "VellumBridge")
 
-    private func makeWebView() -> WKWebView {
+    private func makeWebView() -> VellumWebView {
         let configuration = WKWebViewConfiguration()
         let schemeHandler = VellumWebSchemeHandler()
         configuration.setURLSchemeHandler(
@@ -337,7 +373,7 @@ final class WebViewerController_iOS: NSObject {
             injectionTime: .atDocumentEnd,
             forMainFrameOnly: true,
             in: Self.bridgeWorld))
-        let webView = WKWebView(frame: .zero, configuration: configuration)
+        let webView = VellumWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = self
         webView.uiDelegate = self
         // Native edge-swipe back/forward bypasses the session-rebind path


### PR DESCRIPTION
Closes #40

Ports the macOS keyboard-shortcut surface to iPadOS, and restructures it so the two dispatch surfaces iPadOS needs can't drift apart.

## Why this is more than "add `.keyboardShortcut`"

`ipad-app` already had a `VellumCommands_iOS` with most of the ⌘-chords. Two problems it left open:

1. **Missing shortcuts.** ⌘O, ⌘F, ⌘G, ⌘⇧G and Escape shipped on the Mac but had no key equivalent on iPad — the previous port left them as menu items with no chord, on the assumption UIKit already owned them.
2. **Dispatch races.** SwiftUI `.keyboardShortcut` commands sit at the *end* of the responder chain, so while PDFKit or WebKit is first responder they see the key first and can eat it — both ship their own bindings for ⌘F, ⌘G, ⌘↑/⌘↓, ⌘[ / ⌘]. macOS neutralises this with a local `NSEvent` monitor (`ContentView.handleKeyDown`); iPadOS has no equivalent pre-dispatch hook.

So the chords a document surface competes for are *also* installed as `UIKeyCommand`s on the Vellum-owned views wrapping those surfaces (`VellumPDFView`, the new `VellumWebView`), with `wantsPriorityOverSystemBehavior = true`. Being nearer the first responder they win, and because UIKit stops at the first responder that handles a chord the menu copy doesn't double-fire.

## Shape

| File | Role |
|---|---|
| `Vellum/Platform/iOS/KeyboardShortcuts_iOS.swift` | **New.** The shortcut table as plain data — no views, no stores. Projects into SwiftUI (`KeyEquivalent`/`EventModifiers`) and UIKit (`UIKeyCommand`). |
| `Vellum/Platform/iOS/ShortcutRouter_iOS.swift` | **New.** The one implementation of what each shortcut *does*, plus the `VellumShortcutResponder` protocol and the first-responder helpers. |
| `Vellum/Platform/iOS/VellumCommands_iOS.swift` | Rewritten: every menu item is now title + chord straight from the table, action straight into the router. |
| `Vellum/Platform/iOS/PdfKitView_iOS.swift` | `VellumPDFView` carries the document-surface key commands. |
| `Vellum/Platform/iOS/WebViewerView_iOS.swift` | New `VellumWebView: WKWebView` does the same for web tabs. |
| `Tests/KeyboardShortcutsTests.swift` | **New.** Golden test over the whole table. |

Keeping the table as pure data is what makes it testable: the test transcribes the expectations from the *macOS* sources, so it fails if iPad drifts from Mac parity.

## Shortcut table

"+ responder chain" = also installed as a `UIKeyCommand` on the PDF/Web views, because PDFKit/WebKit claim that chord.

| macOS | Command | iPad |
|---|---|---|
| ⌘T | New Tab | ported |
| ⌘O | Open… | **ported (was missing a chord)** — installed via `CommandGroup(replacing: .importExport)`, which removes the system import group so there is exactly one owner |
| ⌘L | Add Webpage… | ported |
| ⌘W | Close Tab | ported |
| ⌘P | Print… | ported |
| ⌘S | Save | ported (PDF-only, as on Mac — web tabs persist via export) |
| ⌘F | Find… | **ported (was missing a chord)** + responder chain |
| ⌘G | Find Next | **ported (was missing a chord)** + responder chain |
| ⌘⇧G | Find Previous | **ported (was missing a chord)** + responder chain |
| Esc | Close find bar, else clear annotation selection + leave note mode | **ported (was missing)** + responder chain. Needs *both* surfaces: the menu copy is what fires while the find field holds first responder |
| ⌘+ | Zoom In | ported + responder chain. ⌘= and ⌘⇧+ are responder-chain **alternates**: a `UIKeyCommand` matches the literal input string plus exact modifier flags, so a lone `+` binding never fires for the key people actually press |
| ⌘− | Zoom Out | ported + responder chain |
| ⌘0 | Actual Size | ported + responder chain |
| ⌘⌥S | Toggle Inspector | ported |
| ⌘\ | Split Right | ported |
| ⌘⌥\ | Split Down | ported |
| ⌘⌥J | Merge Panes | ported |
| ⌘⇧\ | Close Pane | ported |
| ⌘↑ | Previous Page | ported + responder chain (UIKit binds ⌘↑ to scroll-to-top) |
| ⌘↓ | Next Page | ported + responder chain |
| ⌘⌥↑ | First Page | ported + responder chain |
| ⌘⌥↓ | Last Page | ported + responder chain |
| ⌘[ | Back (web) | ported + responder chain (WKWebView's own back bypasses Vellum's session rebinding) |
| ⌘] | Forward (web) | ported + responder chain |
| ⌘⇧[ | Show Previous Tab | ported + responder chain |
| ⌘⇧] | Show Next Tab | ported + responder chain |
| ⌘1…⌘9 | Show Tab N | ported |
| ⌘D | Bookmark Page | ported |
| N (bare) | Toggle Note Mode | ported, menu-only on purpose — installing a modifier-less chord on the web surface would swallow the letter "n" typed into a page's text field. Suppressed while any text input holds first responder |

### Deliberately skipped

| macOS | Why not on iPad |
|---|---|
| ⌘+ / ⌘− **sidebar text sizing** (only while the pointer hovers the open side panel) | Pointer-contextual: it only works because AppKit can ask "is the mouse over the sidebar right now", and it doubles up the document-zoom chord. Touch-first iPad has no dependable hover state to disambiguate with, so ⌘+/⌘− mean document zoom only |
| Window management (New Window, Minimise, Cycle Windows) | AppKit's standard menus rather than Vellum's own; iPadOS manages windows through Stage Manager / system multitasking |
| ⌘C / ⌘V / ⌘X / ⌘A / ⌘Z in text | UIKit already implements these on every text surface — shadowing them would break editing. A test asserts the catalog never claims them |

## Discoverability

Every shortcut has a menu home (`file` / `find` / `view` / `navigate` / `annotations`), which is what populates the ⌘-hold HUD and the iPadOS 26 menu bar. The `UIKeyCommand` duplicates carry the same string as both `title` and `discoverabilityTitle`, so the HUD reads identically whichever surface is first responder. A test asserts no shortcut is left without a title or a menu.

## Also fixed along the way

- The duplicate `"Zoom In"` menu item (⌘+ and ⌘= were two separate buttons with the same title) is gone — the alias is now a responder-chain alternate instead of a second menu row.
- The bare-`N` guard previously only checked the scratchpad WebView. It now covers any `UITextField` / `UITextView` / `UISearchBar` / `UITextInput` first responder, so it no longer steals a keystroke from the find field or the AI composer.

## Known limitations / deliberate choices

- **Escape can't be fully transparent.** On macOS the `NSEvent` monitor returns `false` for Escape, so AppKit always gets it afterwards. On iOS a matched `UIKeyCommand` is consumed unconditionally — there is no "handle and continue". The closest equivalent is to leave `wantsPriorityOverSystemBehavior` **off** for Escape alone, so the system keeps first claim (edit-menu callout dismissal, Full Keyboard Access) and Vellum only sees it when nothing else wanted it. A test pins this.
- **Shortcuts target the focused pane, not the first-responder pane.** Pane focus is driven by the tap catcher, not UIKit first-responder status, so in a split it is conceivable for a pane to take first responder without taking pane focus (a long-press text selection, say). Routing to the focused pane regardless is deliberate — it matches what the toolbar, inspector and find bar act on, so the keyboard never disagrees with the rest of the chrome. Not verified on hardware.
- **⌘[ / ⌘] are pane-blind.** `.vellumWebHistory` is a global broadcast, so in a split with two web tabs both move. Inherited from macOS (the toolbar buttons post the same notification), not a regression from this PR.
- **⌘O / ⌘L / ⌘P are menu-only** even though the macOS monitor intercepts them. AppKit's PDFView/WKWebView eat them via a broad `performKeyEquivalent`; their UIKit counterparts publish discrete key commands instead and none covers open / locate / print (UIKit's own ⌘P exists only for document-based apps, and Vellum is a plain `WindowGroup`). If a future iOS release adds one, the fix is a single flag on those rows.

### Verification scope

Everything here was verified by compilation and headless unit tests only — no UI was driven and no simulator was interacted with. Confirming which chords a focused `PDFView`/`WKWebView` *actually* swallows at runtime, and the split-pane first-responder edge case above, needs a hardware keyboard on a real iPad; those two points are reasoned from the UIKit API surface and the macOS behaviour, and are **unverified**. The design keeps that cheap to correct: each is a single boolean on a table row.

## Testing

`Tests/KeyboardShortcutsTests.swift` uses XCTest to match the other twelve files in `Tests/` (the repo has no Swift Testing usage yet). It asserts:

- the full ordered table — action, title, key and modifiers for all 37 rows — transcribed from the macOS sources;
- every action bound exactly once, and no chord bound twice (primaries *and* alternates);
- identifiers round-trip through the catalog (the `UIKeyCommand` `propertyList` path depends on this);
- no system text-editing chord is shadowed, and bare keys are limited to N and Escape;
- the responder-chain set covers exactly the chords PDFKit/WebKit claim, and every generated `UIKeyCommand` carries its action and `wantsPriorityOverSystemBehavior`;
- the SwiftUI ↔ UIKit modifier/key bridging (notably that Option maps to UIKit's `.alternate`).

Built and tested against `platform=iOS Simulator,name=iPad Pro 13-inch (M5),OS=26.5` — the M4 iPad Pro simulator isn't installed on this machine. No new warnings.
