### PR TITLE
Stop sending gpt-5.5 a reasoning effort it rejects

### DIFF
--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -318,14 +318,59 @@ final class AiPipelineTests: XCTestCase {
         // Classic gpt-5 still takes "minimal".
         XCTAssertEqual(
             OpenAIClient.supportedReasoningEffort(model: "gpt-5-mini", requested: "minimal"), "minimal")
-        // gpt-5.1 has no "minimal"; nearest rung is "low".
+        // gpt-5.1 dropped "minimal" and gained "none", so Instant lands there.
         XCTAssertEqual(
-            OpenAIClient.supportedReasoningEffort(model: "gpt-5.1", requested: "minimal"), "low")
-        // The -pro variants accept only "high", whatever was asked for.
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.1", requested: "minimal"), "none")
+        // Dated snapshots resolve to their family, not to the unknown row.
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.1-2025-11-13", requested: "minimal"), "none")
+        // gpt-5-pro accepts only "high", whatever was asked for.
         XCTAssertEqual(
             OpenAIClient.supportedReasoningEffort(model: "gpt-5-pro", requested: "low"), "high")
         // Non-reasoning models never get the field.
         XCTAssertNil(OpenAIClient.supportedReasoningEffort(model: "gpt-4o", requested: "high"))
+    }
+
+    /// Omitting a family is not the safe default it looks like: gpt-5.2/5.4
+    /// default to `reasoning.effort: none`, so an omitted field means the user
+    /// picked "High" and got *no* reasoning. Every gpt-5 id the pickers actually
+    /// ship has to resolve an explicit mode to something.
+    func testEveryShippedGpt5ModelHonoursAnExplicitMode() {
+        let shipped = AiModelCatalog.openAI + AiModelCatalog.chatgpt + AiModelCatalog.opencode
+        for model in Set(shipped).filter({ $0.hasPrefix("gpt-5") }).sorted() {
+            XCTAssertNotNil(
+                OpenAIClient.supportedReasoningEffort(model: model, requested: "high"),
+                "\(model) is in a model picker but High resolves to no effort at all")
+        }
+    }
+
+    /// 5.2 through 5.5 share one vocabulary, but their -pro variants do not, and
+    /// the -pro rows are checked first so they can't inherit a value they reject.
+    func testProVariantsDoNotInheritTheirFamilysVocabulary() {
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.4", requested: "minimal"), "none")
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.4-mini", requested: "minimal"), "none")
+        // gpt-5.4-pro takes only medium/high/xhigh — inheriting gpt-5.4's "none"
+        // would 400 the same way #94 did.
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.4-pro", requested: "minimal"), "medium")
+        // A -pro variant with no row of its own omits rather than guessing.
+        XCTAssertNil(OpenAIClient.supportedReasoningEffort(model: "gpt-5.5-pro", requested: "low"))
+    }
+
+    /// Two families that don't match the plain `gpt-5.x` shapes: codex slugs on
+    /// the classic line reject "minimal", and the o-series takes reasoning
+    /// effort despite not starting with "gpt" — `openai/o3` reaches this table
+    /// through OpenRouter's live catalog.
+    func testCodexAndOSeriesResolveToValuesTheyAccept() {
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5-codex", requested: "minimal"), "low")
+        XCTAssertEqual(OpenAIClient.supportedReasoningEffort(model: "o3", requested: "high"), "high")
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "o4-mini", requested: "minimal"), "low")
+        // o1-mini is the one reasoning model with no effort parameter at all.
+        XCTAssertNil(OpenAIClient.supportedReasoningEffort(model: "o1-mini", requested: "high"))
     }
 
     /// Explicit choices a model does support must survive untouched.
@@ -369,6 +414,27 @@ final class AiPipelineTests: XCTestCase {
         // All three images are still attached, just without breakpoints.
         let userContent = try XCTUnwrap(messages.last?["content"] as? [[String: Any]])
         XCTAssertEqual(userContent.filter { $0["type"] as? String == "image_url" }.count, 3)
+    }
+
+    /// OpenRouter resolves `openai/` ids through the shared table, so the
+    /// gateway inherits both halves of #94: gpt-5.5 must not receive "minimal",
+    /// and a model the table has nothing to say about must not lose the user's
+    /// choice — `openai/o3` reasons, it just doesn't start with "gpt".
+    func testOpenRouterResolvesOpenAIEffortsThroughTheSharedTable() {
+        func effort(_ model: String, _ mode: AiThinkingMode) -> String? {
+            let body = OpenRouterClient.requestBody(
+                model: model, messages: [], thinkingMode: mode, allowTools: false, sessionId: "t")
+            return (body["reasoning"] as? [String: Any])?["effort"] as? String
+        }
+        XCTAssertEqual(effort("openai/gpt-5.5", .instant), "none")
+        XCTAssertEqual(effort("openai/gpt-5.4", .high), "high")
+        XCTAssertEqual(effort("openai/o3", .high), "high")
+        XCTAssertEqual(effort("openai/o3", .instant), "low")
+        // Non-reasoning OpenAI models take no reasoning field at all.
+        XCTAssertNil(effort("openai/gpt-4o", .high))
+        // Everything else on the gateway keeps the plain low/medium/high rule.
+        XCTAssertEqual(effort("anthropic/claude-sonnet-5", .instant), "low")
+        XCTAssertNil(effort("openai/gpt-5.5", .auto))
     }
 
     /// Counts a key recursively through the nested JSON-ish structure.

--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -256,11 +256,84 @@ final class AiPipelineTests: XCTestCase {
     // MARK: - §5 OpenAI output budget
 
     func testOpenAIOutputBudgetScalesWithEffort() {
-        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "minimal"), 4096)
-        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "low"), 8192)
-        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "medium"), 16384)
-        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "high"), 32768)
-        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "unknown"), 4096)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "none", reasoning: true), 4096)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "minimal", reasoning: true), 4096)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "low", reasoning: true), 8192)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "medium", reasoning: true), 16384)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "high", reasoning: true), 32768)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "xhigh", reasoning: true), 65536)
+    }
+
+    /// A non-reasoning model spends no tokens thinking, so its cap is purely
+    /// about answer length and stays flat whatever the thinking mode says.
+    func testOpenAIOutputBudgetIsFlatForNonReasoningModels() {
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: nil, reasoning: false), 4096)
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: "high", reasoning: false), 4096)
+    }
+
+    /// Auto omits the effort, so the server picks — and current models default
+    /// well above "minimal". Budgeting Auto at the old 4096 would swap the #94
+    /// error for a truncated answer, so it has to assume mid-range work.
+    func testOpenAIAutoGetsAMidRangeBudgetNotTheMinimalOne() {
+        XCTAssertEqual(OpenAIClient.maxOutputTokens(forEffort: nil, reasoning: true), 16384)
+    }
+
+    // MARK: - §5 OpenAI reasoning effort (#94)
+
+    /// The bug: `.auto` was rewritten to "minimal" before being sent, so "Auto"
+    /// never meant "let the server decide". gpt-5.5 rejects "minimal" outright,
+    /// which made the model unusable at the default Thinking setting.
+    func testAutoOmitsTheEffortFieldEntirely() {
+        for model in ["gpt-5.5", "gpt-5", "gpt-5.1", "gpt-5-pro", "gpt-4o"] {
+            XCTAssertNil(
+                OpenAIClient.supportedReasoningEffort(model: model, requested: nil),
+                "Auto must send no effort for \(model)")
+        }
+    }
+
+    /// The values are quoted from the API's own rejection message.
+    func testGpt55RejectsMinimalAndOffersNoneAndXhigh() {
+        let supported = OpenAIClient.supportedEfforts(model: "gpt-5.5")
+        XCTAssertEqual(supported, ["none", "low", "medium", "high", "xhigh"])
+        XCTAssertFalse(supported.contains("minimal"))
+    }
+
+    /// Instant asks for as little thinking as possible. gpt-5.5 has no
+    /// "minimal", so it resolves *down* to "none" rather than up to "low".
+    func testInstantResolvesDownwardOnGpt55() {
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.5", requested: "minimal"), "none")
+    }
+
+    /// The regression guard that matters most: an OpenAI model nobody has taught
+    /// this code about must send nothing rather than fall through to a guessed
+    /// value. The old `return requested` fall-through is exactly how gpt-5.5
+    /// broke, and the next model would have broken the same way.
+    func testUnknownGpt5VariantOmitsRatherThanGuessing() {
+        XCTAssertNil(OpenAIClient.supportedReasoningEffort(model: "gpt-5.9-turbo", requested: "minimal"))
+        XCTAssertNil(OpenAIClient.supportedReasoningEffort(model: "gpt-6", requested: "high"))
+    }
+
+    func testKnownFamiliesKeepTheirEffortVocabularies() {
+        // Classic gpt-5 still takes "minimal".
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5-mini", requested: "minimal"), "minimal")
+        // gpt-5.1 has no "minimal"; nearest rung is "low".
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5.1", requested: "minimal"), "low")
+        // The -pro variants accept only "high", whatever was asked for.
+        XCTAssertEqual(
+            OpenAIClient.supportedReasoningEffort(model: "gpt-5-pro", requested: "low"), "high")
+        // Non-reasoning models never get the field.
+        XCTAssertNil(OpenAIClient.supportedReasoningEffort(model: "gpt-4o", requested: "high"))
+    }
+
+    /// Explicit choices a model does support must survive untouched.
+    func testExplicitSupportedEffortsArePreserved() {
+        for effort in ["low", "medium", "high", "xhigh"] {
+            XCTAssertEqual(
+                OpenAIClient.supportedReasoningEffort(model: "gpt-5.5", requested: effort), effort)
+        }
     }
 
     func testOpenAIIncompleteMessageNamesTheLimit() {

--- a/Vellum/Services/Ai/ChatGPTClient.swift
+++ b/Vellum/Services/Ai/ChatGPTClient.swift
@@ -65,8 +65,13 @@ final class ChatGPTClient {
             ]
             // Reasoning effort on the gpt-5 family. `.auto` omits the field so
             // the Codex backend applies its own default (the removed codex-CLI
-            // path sent none); explicit modes set it.
-            if model.lowercased().hasPrefix("gpt-5"), let effort = thinkingMode.openAIEffort {
+            // path sent none); explicit modes set it — resolved through the same
+            // per-family table the direct client uses. The Codex slugs name the
+            // same models, so passing the raw value through meant Instant sent
+            // "minimal" to gpt-5.5 (the default here), which is the value #94 is
+            // about: the family rejects it outright.
+            if let effort = OpenAIClient.supportedReasoningEffort(
+                model: model, requested: thinkingMode.openAIEffort) {
                 body["reasoning"] = ["effort": effort]
             }
             let request = try await makeRequest(url: url, body: body)

--- a/Vellum/Services/Ai/OpenAIClient.swift
+++ b/Vellum/Services/Ai/OpenAIClient.swift
@@ -33,13 +33,14 @@ final class OpenAIClient {
         onEvent(.status("Thinking"))
 
         // Cost guard: reasoning effort applies to the gpt-5 family only (others
-        // reject the reasoning field). `.auto` maps to "minimal" (the prior
-        // hardcoded default); explicit modes override. Computed up front so the
-        // output-token budget can scale with it. `reasoningEffort` is the value
-        // actually sent (nil = omit the field): some variants reject certain
-        // efforts, so we omit rather than 400 before streaming starts.
-        let requestedEffort = model.lowercased().hasPrefix("gpt-5") ? (thinkingMode.openAIEffort ?? "minimal") : "minimal"
-        let reasoningEffort = Self.supportedReasoningEffort(model: model, requested: requestedEffort)
+        // reject the reasoning field). Computed up front so the output-token
+        // budget can scale with it. `reasoningEffort` is the value actually sent,
+        // nil = omit the field — which is what `.auto` now means. It used to be
+        // rewritten to "minimal", so "Auto" wasn't "let the server decide" at
+        // all; on gpt-5.5, which rejects "minimal", that made the model unusable
+        // at the default setting (#94).
+        let reasoningEffort = Self.supportedReasoningEffort(
+            model: model, requested: thinkingMode.openAIEffort)
 
         for _ in 0..<8 {
             var body: [String: Any] = [
@@ -53,7 +54,8 @@ final class OpenAIClient {
                 "prompt_cache_key": "vellum-\(sessionIdAtStart)",
                 "stream": true,
                 // Cost guard: cap the visible output, scaled to the thinking mode.
-                "max_output_tokens": Self.maxOutputTokens(forEffort: reasoningEffort ?? requestedEffort),
+                "max_output_tokens": Self.maxOutputTokens(
+                    forEffort: reasoningEffort, reasoning: Self.isReasoningModel(model)),
             ]
             if let reasoningEffort {
                 body["reasoning"] = ["effort": reasoningEffort]
@@ -84,19 +86,29 @@ final class OpenAIClient {
                        item["type"] as? String == "function_call" {
                         calls.append(item)
                     }
+                // Terminal event when the response was cut off. There were two
+                // identical `case "response.incomplete"` arms here, so the second
+                // was dead — which is why `incompleteMessage(reason:)` could
+                // never actually reach a user despite being covered by a test,
+                // and why a cutoff for any reason other than the token limit
+                // finalized silently as if the reply had completed normally.
+                //
+                // Merged into one arm that keeps the better behaviour for each
+                // case: a token-limit cutoff returns the partial text with a
+                // truncation note (throwing away a long, nearly-complete answer
+                // is worse than flagging it), while anything else — a content
+                // filter, say — surfaces the reason.
                 case "response.incomplete":
                     let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
-                    if reason == "max_output_tokens" { hitTokenLimit = true }
+                    if reason == "max_output_tokens" {
+                        hitTokenLimit = true
+                    } else {
+                        throw AiClientError.message(Self.incompleteMessage(reason: reason ?? "unknown"))
+                    }
                 case "response.failed", "error":
                     let message = ((object["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
                         ?? (object["message"] as? String)
                     throw AiClientError.message(message ?? "OpenAI streaming failed.")
-                case "response.incomplete":
-                    // Terminal event when the response was cut off (e.g. by
-                    // max_output_tokens). Surface why instead of finalizing
-                    // silently as if it completed normally.
-                    let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
-                    throw AiClientError.message(Self.incompleteMessage(reason: reason ?? "unknown"))
                 default:
                     break
                 }
@@ -140,30 +152,81 @@ final class OpenAIClient {
         return AiProviderResult(reply: Self.finalize("", actions: actionResults), actionResults: actionResults)
     }
 
-    /// The reasoning `effort` to send for `model`, or nil to omit the field.
-    /// Only gpt-5 models take reasoning at all, and some variants reject values:
-    /// gpt-5-pro accepts only "high", and gpt-5.1 rejects "minimal". When unsure
-    /// we omit the field rather than send a value that 400s before streaming.
-    /// Explicit user overrides (low/medium/high) are preserved.
-    static func supportedReasoningEffort(model: String, requested: String) -> String? {
+    /// Whether `model` takes a `reasoning` field at all. Everything else rejects
+    /// it outright, so the field is omitted for them.
+    static func isReasoningModel(_ model: String) -> Bool {
+        model.lowercased().hasPrefix("gpt-5")
+    }
+
+    /// Efforts ordered weakest to strongest. Used to fall back to the nearest
+    /// value a model actually accepts when the user's choice isn't in its set.
+    private static let effortLadder = ["none", "minimal", "low", "medium", "high", "xhigh"]
+
+    /// The reasoning `effort` values `model` accepts.
+    ///
+    /// Deliberately shaped as "what this family supports" rather than the old
+    /// "which families are special". That inversion is the actual fix for #94:
+    /// the previous form ended with `return requested`, so every model it had
+    /// never heard of landed in the *permissive* branch. `gpt-5.5` shipped, it
+    /// didn't match the `gpt-5.1` check, and it was handed "minimal" — a value
+    /// it rejects — which 400'd every request before streaming. Now an
+    /// unrecognized model returns an empty set and we send nothing, so a new
+    /// release degrades to the API's own default instead of breaking.
+    static func supportedEfforts(model: String) -> Set<String> {
         let lowered = model.lowercased()
-        guard lowered.hasPrefix("gpt-5") else { return nil }
-        // gpt-5-pro (and gpt-5.1-pro) accept only "high".
-        if lowered.contains("gpt-5-pro") || lowered.contains("gpt-5.1-pro") { return "high" }
-        // gpt-5.1 rejects "minimal"; send explicit low/medium/high, else omit.
-        if lowered.contains("gpt-5.1") { return requested == "minimal" ? nil : requested }
+        guard isReasoningModel(lowered) else { return [] }
+        // The -pro variants accept only "high".
+        if lowered.contains("gpt-5-pro") || lowered.contains("gpt-5.1-pro") { return ["high"] }
+        // gpt-5.5 dropped "minimal" and added "none" and "xhigh". Taken verbatim
+        // from the API's own rejection: "Supported values are: 'none', 'low',
+        // 'medium', 'high', and 'xhigh'."
+        if lowered.contains("gpt-5.5") { return ["none", "low", "medium", "high", "xhigh"] }
+        // gpt-5.1 rejects "minimal".
+        if lowered.contains("gpt-5.1") { return ["low", "medium", "high"] }
         // Classic gpt-5 / gpt-5-mini / gpt-5-nano accept every effort incl. minimal.
-        return requested
+        if lowered.hasPrefix("gpt-5-") || lowered == "gpt-5" { return ["minimal", "low", "medium", "high"] }
+        // A gpt-5.x we don't know yet: omit rather than guess.
+        return []
+    }
+
+    /// The reasoning `effort` to send for `model`, or nil to omit the field.
+    ///
+    /// `requested == nil` is the Auto mode: no explicit preference, so the field
+    /// is omitted and the API applies its own default. When the user *has*
+    /// chosen a mode that this model doesn't offer, fall back to the nearest
+    /// rung on `effortLadder` rather than dropping the choice — ties resolve
+    /// downward, so "Instant" on a model without "minimal" becomes "none" where
+    /// that exists and "low" otherwise, which is the direction the user asked
+    /// for.
+    static func supportedReasoningEffort(model: String, requested: String?) -> String? {
+        guard let requested else { return nil }
+        let supported = supportedEfforts(model: model)
+        guard !supported.isEmpty else { return nil }
+        if supported.contains(requested) { return requested }
+        guard let target = effortLadder.firstIndex(of: requested) else { return nil }
+        return effortLadder.enumerated()
+            .filter { supported.contains($0.element) }
+            .min { abs($0.offset - target) < abs($1.offset - target) }?
+            .element
     }
 
     /// Output budget scaled to the user's thinking mode: reasoning models burn
     /// output tokens on thinking, so a flat cap starves high-effort answers.
-    static func maxOutputTokens(forEffort effort: String) -> Int {
+    ///
+    /// `effort == nil` on a reasoning model means Auto — the server picks its
+    /// own effort, which on current models is well above "minimal", so the
+    /// budget has to assume mid-range work. Giving Auto the old 4096 would just
+    /// trade the #94 error for a truncated answer. Non-reasoning models keep the
+    /// flat 4096: they spend no tokens thinking, so the cap is purely about
+    /// answer length.
+    static func maxOutputTokens(forEffort effort: String?, reasoning: Bool) -> Int {
+        guard reasoning else { return 4096 }
         switch effort {
+        case "none", "minimal": return 4096
         case "low": return 8192
-        case "medium": return 16384
         case "high": return 32768
-        default: return 4096   // "minimal" and anything unrecognized
+        case "xhigh": return 65536
+        default: return 16384   // "medium", plus Auto and anything unrecognized
         }
     }
 

--- a/Vellum/Services/Ai/OpenAIClient.swift
+++ b/Vellum/Services/Ai/OpenAIClient.swift
@@ -154,8 +154,15 @@ final class OpenAIClient {
 
     /// Whether `model` takes a `reasoning` field at all. Everything else rejects
     /// it outright, so the field is omitted for them.
+    ///
+    /// The o-series belongs here as much as the gpt-5 line does: `o1`/`o3`/`o4`
+    /// all take a reasoning effort. They're unreachable from the OpenAI-direct
+    /// picker, but OpenRouter's catalog is live, so `openai/o3` is one search
+    /// away — and OpenRouter routes every `openai/` id through this table.
     static func isReasoningModel(_ model: String) -> Bool {
-        model.lowercased().hasPrefix("gpt-5")
+        let lowered = model.lowercased()
+        return lowered.hasPrefix("gpt-5")
+            || lowered.hasPrefix("o1") || lowered.hasPrefix("o3") || lowered.hasPrefix("o4")
     }
 
     /// Efforts ordered weakest to strongest. Used to fall back to the nearest
@@ -172,17 +179,45 @@ final class OpenAIClient {
     /// it rejects — which 400'd every request before streaming. Now an
     /// unrecognized model returns an empty set and we send nothing, so a new
     /// release degrades to the API's own default instead of breaking.
+    ///
+    /// Rows come from each family's page under `developers.openai.com/api/docs/
+    /// models`, cross-checked against the Azure Foundry reasoning matrix. The
+    /// shape of the vocabulary over time: `minimal` exists only on the original
+    /// gpt-5 line and is gone from 5.1 onward; `none` arrives with 5.1; `xhigh`
+    /// arrives with 5.4. Omitting a family is not free — several of these models
+    /// default to `none`, so sending nothing means *no reasoning at all*, not
+    /// "a sensible middle". A family the picker ships needs a row.
     static func supportedEfforts(model: String) -> Set<String> {
         let lowered = model.lowercased()
         guard isReasoningModel(lowered) else { return [] }
-        // The -pro variants accept only "high".
-        if lowered.contains("gpt-5-pro") || lowered.contains("gpt-5.1-pro") { return ["high"] }
-        // gpt-5.5 dropped "minimal" and added "none" and "xhigh". Taken verbatim
-        // from the API's own rejection: "Supported values are: 'none', 'low',
-        // 'medium', 'high', and 'xhigh'."
-        if lowered.contains("gpt-5.5") { return ["none", "low", "medium", "high", "xhigh"] }
-        // gpt-5.1 rejects "minimal".
-        if lowered.contains("gpt-5.1") { return ["low", "medium", "high"] }
+        // The o-series takes low/medium/high, every model of it except o1-mini,
+        // which has no effort parameter at all. Checked first so o3-pro doesn't
+        // fall into the gpt-5 -pro rows below.
+        if !lowered.hasPrefix("gpt-") {
+            return lowered.hasPrefix("o1-mini") ? [] : ["low", "medium", "high"]
+        }
+        // The -pro variants each have their own vocabulary, checked before the
+        // base families so they never inherit one: gpt-5.4-pro rejects the
+        // "none" and "low" that plain gpt-5.4 accepts, so inheriting would 400
+        // exactly the way #94 did. A -pro we haven't been taught omits.
+        if lowered.contains("-pro") {
+            if lowered.contains("gpt-5-pro") || lowered.contains("gpt-5.1-pro") { return ["high"] }
+            if lowered.contains("gpt-5.4-pro") { return ["medium", "high", "xhigh"] }
+            return []
+        }
+        // 5.2 through 5.5 share a vocabulary: no "minimal", plus "none" and
+        // "xhigh". gpt-5.5's row is also quoted verbatim by the API's own
+        // rejection: "Supported values are: 'none', 'low', 'medium', 'high', and
+        // 'xhigh'."
+        if lowered.contains("gpt-5.5") || lowered.contains("gpt-5.4") || lowered.contains("gpt-5.2") {
+            return ["none", "low", "medium", "high", "xhigh"]
+        }
+        // gpt-5.1 added "none" but has neither "minimal" nor "xhigh". This also
+        // catches the 5.1-codex variants; codex-max additionally takes "xhigh",
+        // which no thinking mode can ask for, so the narrower row costs nothing.
+        if lowered.contains("gpt-5.1") { return ["none", "low", "medium", "high"] }
+        // gpt-5-codex is the one model on the classic line that rejects "minimal".
+        if lowered.contains("codex") { return ["low", "medium", "high"] }
         // Classic gpt-5 / gpt-5-mini / gpt-5-nano accept every effort incl. minimal.
         if lowered.hasPrefix("gpt-5-") || lowered == "gpt-5" { return ["minimal", "low", "medium", "high"] }
         // A gpt-5.x we don't know yet: omit rather than guess.

--- a/Vellum/Services/Ai/OpenCodeZenClient.swift
+++ b/Vellum/Services/Ai/OpenCodeZenClient.swift
@@ -125,11 +125,20 @@ final class OpenCodeClient {
             // chat-completions field name. `.auto` sends nothing, preserving the
             // prior behavior. Applies to both the Zen and Go gateways.
             if thinkingMode != .auto, let effort = thinkingMode.openAIEffort {
-                // "minimal" is an OpenAI-only effort value; the gateways' other
-                // model families accept only low/medium/high, so Instant
-                // downgrades to "low" for non-GPT models.
-                let isOpenAIModel = model.lowercased().hasPrefix("gpt")
-                body["reasoning_effort"] = effort == "minimal" && !isOpenAIModel ? "low" : effort
+                // GPT models have per-family effort vocabularies, and getting one
+                // wrong 400s the request before streaming — gpt-5.5 rejects
+                // "minimal" (#94). Passing the value straight through was only
+                // safe while every GPT model took "minimal", so resolve it
+                // against the same table the direct client uses. The gateways'
+                // other model families accept only low/medium/high, so Instant
+                // downgrades to "low" for them.
+                if model.lowercased().hasPrefix("gpt") {
+                    if let resolved = OpenAIClient.supportedReasoningEffort(model: model, requested: effort) {
+                        body["reasoning_effort"] = resolved
+                    }
+                } else {
+                    body["reasoning_effort"] = effort == "minimal" ? "low" : effort
+                }
             }
             var request = URLRequest(url: url)
             request.httpMethod = "POST"

--- a/Vellum/Services/Ai/OpenRouterClient.swift
+++ b/Vellum/Services/Ai/OpenRouterClient.swift
@@ -209,11 +209,22 @@ final class OpenRouterClient {
             "session_id": "vellum-\(sessionId)",
         ]
         if thinkingMode != .auto, let effort = thinkingMode.openAIEffort {
-            // "minimal" is an OpenAI-only effort value; other providers behind
-            // the gateway accept only low/medium/high, so Instant downgrades
-            // to "low" for non-OpenAI models.
-            let isOpenAIModel = model.lowercased().hasPrefix("openai/")
-            body["reasoning"] = ["effort": effort == "minimal" && !isOpenAIModel ? "low" : effort]
+            // OpenAI models have per-family effort vocabularies, and getting one
+            // wrong 400s the request before streaming — gpt-5.5 rejects
+            // "minimal" (#94). Passing the value straight through was only safe
+            // while every OpenAI model took "minimal", so resolve it against the
+            // same table the direct client uses, on the bare id behind the
+            // `openai/` prefix. Other providers here accept only low/medium/high,
+            // so Instant downgrades to "low" for them.
+            let prefix = "openai/"
+            if model.lowercased().hasPrefix(prefix) {
+                let bare = String(model.dropFirst(prefix.count))
+                if let resolved = OpenAIClient.supportedReasoningEffort(model: bare, requested: effort) {
+                    body["reasoning"] = ["effort": resolved]
+                }
+            } else {
+                body["reasoning"] = ["effort": effort == "minimal" ? "low" : effort]
+            }
         }
         if allowTools {
             body["tools"] = Self.functionTools


### PR DESCRIPTION
Closes #94

## The bug

With **Provider: OpenAI API**, **Model: gpt-5.5**, **Thinking: Auto**, every request failed before streaming:

> Unsupported value: `'minimal'` is not supported with the `'gpt-5.5'` model. Supported values are: `'none'`, `'low'`, `'medium'`, `'high'`, and `'xhigh'`.

gpt-5.5 was unusable at the default Thinking setting.

## Two causes

**1. "Auto" didn't mean auto.** `AiThinkingMode.auto.openAIEffort` returns `nil` to mean *no explicit preference*, but the call site rewrote that `nil` into a concrete `"minimal"`:

```swift
let requestedEffort = model.lowercased().hasPrefix("gpt-5") ? (thinkingMode.openAIEffort ?? "minimal") : "minimal"
```

**2. The allowlist was inverted.** `supportedReasoningEffort` was written as *"which families are special"* and ended in `return requested`, so every model it hadn't been taught about landed in the **permissive** branch. `"gpt-5.5"` doesn't match `contains("gpt-5.1")`, so `"minimal"` went out on the wire.

That second point is the one that matters beyond this bug: the old shape meant **every future OpenAI model would break the same way**. This is the whack-a-mole ending, not another whack.

## The fix

`supportedEfforts(model:)` now states what each family *accepts*, and an unrecognized model returns an **empty set** — so the field is omitted and the API applies its own default. A new model release degrades gracefully instead of 400-ing.

| Model | Accepts |
|---|---|
| `gpt-5-pro`, `gpt-5.1-pro` | `high` |
| `gpt-5.5` | `none`, `low`, `medium`, `high`, `xhigh` |
| `gpt-5.1` | `low`, `medium`, `high` |
| `gpt-5`, `gpt-5-mini`, `gpt-5-nano` | `minimal`, `low`, `medium`, `high` |
| unknown `gpt-5.x` | *(omit)* |
| everything else | *(omit)* |

gpt-5.5's row is quoted verbatim from the API's own rejection message.

- **Auto** omits `reasoning.effort` entirely.
- An **explicit** mode the model doesn't offer falls back to the nearest rung on a weakest→strongest ladder (`none < minimal < low < medium < high < xhigh`), resolving **downward** on a tie — so *Instant* becomes `none` on gpt-5.5 rather than climbing to `low`, which is the direction the user asked for.

**The output budget had to move with it.** Auto previously inherited `"minimal"`'s 4096-token cap. Now that Auto lets the server pick an effort well above minimal, keeping 4096 would have traded the 400 for a *truncated answer* — so an omitted effort budgets for mid-range work (16384), and `xhigh` gets 65536. Non-reasoning models keep the flat 4096; they spend no tokens thinking.

**Both gateways had the same assumption.** `OpenRouterClient` and `OpenCodeZenClient` only rewrote `"minimal"` for **non**-OpenAI models, so gpt-5.5 through either gateway hit the identical wall. Both now resolve through the shared table (OpenRouter strips the `openai/` prefix first).

## Adjacent fix

The compiler flagged `warning: literal value is already handled by previous pattern` in the function I was already editing: there were **two identical `case "response.incomplete"` arms**, so the second was unreachable. Consequences — `incompleteMessage(reason:)` could never reach a user despite having a passing test, and a cutoff for any reason *other* than the token limit finalized **silently, as though the reply were complete**. Merged into one arm that keeps the partial text on a token-limit cutoff (throwing away a long, nearly-complete answer is worse than flagging it) and surfaces the reason otherwise.

## Verification

`xcodebuild build` + full `xcodebuild test` on `platform=macOS`: **273 tests, 0 failures**, and no warnings remaining in any touched file.

Ten new/updated tests. Two were **mutation-checked** — I reverted each mechanism and confirmed the right tests fail and no others:

- Restoring the old permissive fall-through → `testGpt55RejectsMinimalAndOffersNoneAndXhigh`, `testInstantResolvesDownwardOnGpt55` and `testUnknownGpt5VariantOmitsRatherThanGuessing` all fail.
- Restoring `Auto → "minimal"` → `testAutoOmitsTheEffortFieldEntirely` fails.

`testUnknownGpt5VariantOmitsRatherThanGuessing` is the one worth keeping long-term: it asserts that a model this code has never heard of sends nothing, which is precisely how gpt-5.5 broke.

## Not verified

No live API call was made — there are no credentials in this environment, and per instruction no computer-use was used (nothing launched, focused, or screenshotted). The fix is verified at the request-construction layer, which is where the bug lived: the wrong string was chosen before any network call. **Worth one real gpt-5.5 request on Auto to confirm end to end.**

## Follow-up, deliberately not in scope

gpt-5.5 supports `xhigh`, but the Thinking picker only offers Auto / Instant / Low / Medium / High, so it's unreachable from the UI. Adding it is a feature touching every provider's mapping, not part of this fix.