### PR TITLE
Keep tests out of the real login keychain

### DIFF
--- a/Vellum/Services/KeychainStore.swift
+++ b/Vellum/Services/KeychainStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Security
+import os
 
 /// Thin wrapper over the macOS Keychain for storing AI provider API keys as
 /// generic passwords. All keys live under one service; the account string is
@@ -7,8 +8,27 @@ import Security
 enum KeychainStore {
     static let service = "com.vellum.ai"
 
+    /// Test runs must never touch the real login keychain: the test host is an
+    /// ad-hoc-signed Debug build whose signature changes on every rebuild, so
+    /// each `xcodebuild test` launch would re-trigger the keychain password
+    /// prompt — and tests have no business reading the user's real API keys.
+    /// Detected via the XCTest environment (set from process start, before the
+    /// test bundle is injected) with the class lookup as a fallback.
+    private static let isRunningTests: Bool = {
+        let env = ProcessInfo.processInfo.environment
+        return env["XCTestConfigurationFilePath"] != nil
+            || env["XCTestSessionIdentifier"] != nil
+            || env["XCTestBundlePath"] != nil
+            || NSClassFromString("XCTestCase") != nil
+    }()
+
+    /// In-memory stand-in used instead of the keychain while under test, so
+    /// set/get/delete still round-trip within a test process.
+    private static let testStore = OSAllocatedUnfairLock<[String: String]>(initialState: [:])
+
     /// Returns the stored secret for an account, or nil if absent/unreadable.
     static func get(_ account: String) -> String? {
+        if isRunningTests { return testStore.withLock { $0[account] } }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
@@ -33,6 +53,10 @@ enum KeychainStore {
         guard !trimmed.isEmpty else {
             return delete(account)
         }
+        if isRunningTests {
+            testStore.withLock { $0[account] = trimmed }
+            return true
+        }
         let data = Data(trimmed.utf8)
         let baseQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -52,6 +76,10 @@ enum KeychainStore {
     /// absent afterwards (either deleted now or already missing).
     @discardableResult
     static func delete(_ account: String) -> Bool {
+        if isRunningTests {
+            testStore.withLock { $0[account] = nil }
+            return true
+        }
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,


### PR DESCRIPTION
## Problem
Background agent sessions repeatedly run `xcodebuild test`, and every run launches the ad-hoc-signed Debug test host. An ad-hoc signature changes on each rebuild, so when `AiStore` primes the AI provider API keys from the keychain at launch, macOS treats each build as a brand-new app and prompts for the login keychain password — "Always Allow" can never stick. This produced continuous keychain password prompts during automated test runs.

## Fix
`KeychainStore` now detects the XCTest environment (env vars set from process start, with an `NSClassFromString("XCTestCase")` fallback) and swaps the real keychain for a lock-protected in-memory dictionary:

- set/get/delete still round-trip within a test process
- tests never read or mutate the user's real API keys
- `KeychainStore` is the single choke point, so the ChatGPT OAuth token path is covered too

No test behavior changes — nothing in the suite exercised the real keychain.

## Verification
`xcodebuild build-for-testing` compiles both the app and VellumTests targets cleanly; no new warnings in `KeychainStore.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)