### PR TITLE
Stop attachment GC from reaping images written after its snapshot

### DIFF
--- a/Tests/DocumentDataStoreTests.swift
+++ b/Tests/DocumentDataStoreTests.swift
@@ -438,6 +438,34 @@ final class DocumentDataStoreTests: XCTestCase {
                       "another document's attachment must be untouched")
     }
 
+    /// A sweep collects against a reference set captured at some moment, and it
+    /// can run after that moment — `pruneOrphanedAttachments` hands the work to
+    /// a background task. An attachment written in that gap is absent from the
+    /// set but is not garbage, and deleting it leaves a broken image in the
+    /// note. This is what made `SafeClearTests` flake under full-suite load:
+    /// opening a document sweeps with an empty reference set, and the image
+    /// saved immediately afterwards could be reaped before the note referenced
+    /// it.
+    func testGCSparesAttachmentsWrittenAfterTheReferenceSnapshot() throws {
+        let dir = DocumentDataStore.attachmentsDir(forKey: "gc-cutoff")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let old = dir.appendingPathComponent("old.jpg")
+        try Data([1]).write(to: old)
+
+        // Everything already on disk predates the snapshot; the new file does not.
+        let referencedAsOf = Date()
+        let fresh = dir.appendingPathComponent("fresh.jpg")
+        try Data([2]).write(to: fresh)
+
+        ScratchpadAttachmentStore.collectGarbage(
+            in: dir, referencedIds: [], referencedAsOf: referencedAsOf)
+
+        XCTAssertFalse(exists(old), "an attachment older than the snapshot is still collected")
+        XCTAssertTrue(
+            exists(fresh),
+            "an attachment written after the snapshot belongs to a later edit and must survive")
+    }
+
     // MARK: - F3 #3: read-only session when the note is stuck in iCloud
 
     /// When a document's note exists only as an unmaterialized iCloud placeholder,

--- a/Tests/SafeClearTests.swift
+++ b/Tests/SafeClearTests.swift
@@ -13,6 +13,10 @@ final class SafeClearTests: XCTestCase {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         DocumentDataStore.rootDirectoryOverride = root
         ScratchpadAttachmentStore.directoryOverride = root.appendingPathComponent("legacy")
+        // These seams are process-global (#102), so claim all three on the way in
+        // as well as releasing them on the way out — this suite must not inherit
+        // an attachment directory from whatever ran before it.
+        ScratchpadAttachmentStore.activeDirectory = nil
         sessions = SafeClearSessionService()
         app = AppStore(sessions: sessions)
     }

--- a/Vellum/Services/Scratchpad/ScratchpadPersistence.swift
+++ b/Vellum/Services/Scratchpad/ScratchpadPersistence.swift
@@ -264,15 +264,48 @@ enum ScratchpadAttachmentStore {
     /// Delete files in `directory` whose id isn't in `referencedIds`. Scoped to
     /// one document's attachments dir, so it can never touch another document's
     /// still-referenced images.
-    static func collectGarbage(in directory: URL, referencedIds: Set<String>) {
+    /// Delete files in `directory` whose id isn't in `referencedIds`.
+    ///
+    /// `referencedIds` is a snapshot of the note as it read at some moment, and
+    /// this sweep can run later — `pruneOrphanedAttachments` dispatches it to a
+    /// background task, and a debounced save persists text captured earlier. An
+    /// attachment written in that gap is, correctly, not in the snapshot, but it
+    /// is also not garbage: it belongs to an edit the snapshot predates. Passing
+    /// the moment the snapshot was taken as `referencedAsOf` keeps the sweep
+    /// from reaping it. Without that, dropping an image immediately after
+    /// opening a document (which sweeps with an empty reference set) could
+    /// delete the bytes just written and leave a broken reference in the note.
+    ///
+    /// A file spared this way is not leaked: if it really is an orphan, the next
+    /// sweep sees it as older than that snapshot and collects it.
+    static func collectGarbage(
+        in directory: URL, referencedIds: Set<String>, referencedAsOf: Date? = nil
+    ) {
         guard let entries = try? FileManager.default.contentsOfDirectory(
-            at: directory, includingPropertiesForKeys: nil) else { return }
+            at: directory, includingPropertiesForKeys: [
+                .creationDateKey, .contentModificationDateKey,
+            ]) else { return }
         for url in entries {
             let id = url.deletingPathExtension().lastPathComponent.lowercased()
-            if !referencedIds.contains(id) {
-                try? FileManager.default.removeItem(at: url)
-            }
+            guard !referencedIds.contains(id) else { continue }
+            if let referencedAsOf, isNewerThan(referencedAsOf, url: url) { continue }
+            try? FileManager.default.removeItem(at: url)
         }
+    }
+
+    /// True when the file was created or last written at or after `date` — i.e.
+    /// it may postdate the reference snapshot being collected against.
+    private static func isNewerThan(_ date: Date, url: URL) -> Bool {
+        guard let values = try? url.resourceValues(
+            forKeys: [.creationDateKey, .contentModificationDateKey])
+        else {
+            // Unreadable timestamps: keep the file. A missed collection is
+            // recoverable, deleting a live attachment is not.
+            return true
+        }
+        return [values.creationDate, values.contentModificationDate]
+            .compactMap { $0 }
+            .contains { $0 >= date }
     }
 
     /// Copy the given ids' files from the legacy global pool into `dir` (lazy

--- a/Vellum/Stores/ScratchpadStore.swift
+++ b/Vellum/Stores/ScratchpadStore.swift
@@ -407,8 +407,15 @@ final class ScratchpadStore {
         if text.isEmpty, let key = currentKey,
            DocumentDataStore.scratchpadExists(forKey: key) { return }
         let referenced = ScratchpadAttachmentStore.referencedIds(in: text)
+        // The sweep runs on a background task while this actor keeps going, so
+        // an attachment saved right after this line (a drop or region snapshot
+        // landing on a freshly opened note) would not be in `referenced` and
+        // would be deleted out from under the note. Collect only against files
+        // that already existed when the snapshot was taken.
+        let referencedAsOf = Date()
         Task.detached(priority: .utility) {
-            ScratchpadAttachmentStore.collectGarbage(in: dir, referencedIds: referenced)
+            ScratchpadAttachmentStore.collectGarbage(
+                in: dir, referencedIds: referenced, referencedAsOf: referencedAsOf)
         }
     }
 


### PR DESCRIPTION
Fixes the flaky red on `main` after #79.

## Root cause

`ScratchpadStore.pruneOrphanedAttachments` snapshots the note's referenced attachment ids and hands the sweep to a detached background task:

```swift
let referenced = ScratchpadAttachmentStore.referencedIds(in: text)
Task.detached(priority: .utility) {
    ScratchpadAttachmentStore.collectGarbage(in: dir, referencedIds: referenced)
}
```

The sweep therefore runs at an unpredictable moment *after* the snapshot was taken, and any attachment written in that gap is — correctly — absent from `referenced`. It was deleted as garbage even though it belongs to an edit the snapshot simply predates.

**This is a product bug, not a test artifact.** Opening a document whose note is empty dispatches a sweep with an *empty* reference set. Saving an image immediately afterwards — a drop, a paste, or a region snapshot on a freshly opened note — races that sweep. Losing the race deletes the bytes just written and leaves a broken `vellum-scratchpad://` reference in the note.

## Why it looked like cross-suite pollution

`clearText()` fails closed when a referenced image is unreadable, returning nil. Under full-suite load the detached `.utility` task is scheduled late enough to land between `ScratchpadAttachmentStore.save(...)` and `clearText()`, so the attachment vanishes mid-test and the `XCTUnwrap` fails:

- `SafeClearTests.testScratchpadClearFollowsSameSessionStampForUndoRedoAndAttachments` (line 162)
- `SafeClearTests.testScratchpadUndoRestoresAttachmentBytesAndRedoPreservesNewWork` (line 73)

Both pass in isolation because the sweep lands *early*, before the save — which is exactly why the failures varied between runs and read as ordering-dependent state leakage. The shared state is real (these seams are process-global, #102) but it was not the cause; the two tests were poisoning themselves through a genuine race in product code.

## The fix

`collectGarbage` now takes the moment the reference set was captured and skips any file created or modified at or after it:

```swift
static func collectGarbage(
    in directory: URL, referencedIds: Set<String>, referencedAsOf: Date? = nil
)
```

A file spared this way is not leaked — if it really is an orphan, the next sweep sees it as older than that snapshot and collects it. Timestamps that cannot be read keep the file, since a missed collection is recoverable and deleting a live attachment is not.

The synchronous save path is deliberately left alone: it computes its reference set from the *current* text microseconds earlier, so it does not have this defect, and passing a cutoff there would change GC semantics on the main persistence path for no proven gain.

## Verification

Causality was established by widening the window rather than by inference. A 400 microsecond sleep before the sweep:

- **before** this change: fails `testScratchpadUndoRestoresAttachmentBytesAndRedoPreservesNewWork` deterministically, in isolation, with the identical `XCTUnwrap` signature — one timing knob reproduces both observed failures;
- **after** this change: 31/31 green with that same sleep still in place.

Then, with the probe removed:

- **6 consecutive full-suite runs, all green**: 442 XCTest + 147 Swift Testing, 0 failures (441 + 1 new test). Before the change, the first full run on a pristine `origin/main` worktree reproduced the failure.
- `SafeClearTests` and `ScratchpadMarkdownExporterTests` green in isolation.
- Regression test `testGCSparesAttachmentsWrittenAfterTheReferenceSnapshot` mutation-checked: disabling the cutoff fails that test and nothing else.

Also resets `ScratchpadAttachmentStore.activeDirectory` on the way *into* `SafeClearTests`, not only on the way out, so the suite cannot inherit that process-global from whatever ran before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)