### PR TITLE
Transfer tab ownership when merging panes

### DIFF
--- a/Tests/PaneTreeTests.swift
+++ b/Tests/PaneTreeTests.swift
@@ -83,6 +83,99 @@ final class PaneTreeTests: XCTestCase {
         XCTAssertEqual(ws.focusedPane.app.activeTabId, firstActiveTabId)
     }
 
+    /// Merging must *transfer* tabs, not copy them (issue #91). A `PdfTab` is a
+    /// value type, so appending it to the surviving pane while leaving it in the
+    /// donor's array left two AppStores claiming the same tab id — and the donor
+    /// still reporting it as its active tab. Everything keyed on tab-to-pane
+    /// ownership then resolved the tab to the pane it had just left; the web
+    /// controller's `activateSharedHandlers` guard (`app.activeTabId ==
+    /// mountTabId`) is the one that bit, binding find / scroll-to-page /
+    /// AI-capture hooks to the discarded pane's stores.
+    func testMergeAllTransfersTabOwnershipInsteadOfCopying() {
+        let ws = makeWorkspace()
+        let keep = ws.focusedPane
+        keep.app.attachTab(makeTab(id: "keep-a", document: pdfDocument(path: "/tmp/keep-a.pdf")))
+        keep.app.attachTab(makeTab(id: "keep-b", document: pdfDocument(path: "/tmp/keep-b.pdf")))
+        keep.app.activateTab("keep-a")
+
+        ws.splitFocused(.horizontal)
+        let donor = ws.focusedPane
+        // `donor-a` is a WEB tab: the migrating web view is the case the issue is
+        // actually about, and the only tab kind whose native state is bound to a
+        // pane's stores rather than rebuilt per host.
+        donor.app.attachTab(makeTab(
+            id: "donor-a",
+            document: DocumentInfo(
+                kind: .web, pdfPath: "https://example.com", title: "Example",
+                pageCount: 1, lastPage: 1)))
+        donor.app.attachTab(makeTab(id: "donor-b", document: pdfDocument(path: "/tmp/donor-b.pdf")))
+        let donorRuntime = ws.liveTabRuntime(for: "donor-a")
+
+        ws.focus(keep.id)
+        ws.mergeAll()
+
+        // The donor gave the tabs up: no lingering claim on any of them. The
+        // middle assertion is the one the web controller's mount guard reads.
+        XCTAssertTrue(donor.app.tabs.isEmpty)
+        XCTAssertNil(donor.app.activeTabId)
+        XCTAssertNil(donor.app.document)
+
+        // …and the survivor holds each exactly once, in visual order, with the
+        // tabs it already had still ahead of the migrated ones. (The split's
+        // own start tab rides along between them, hence the filter.)
+        XCTAssertEqual(
+            keep.app.tabs.map(\.id).filter { !$0.hasPrefix("start-") },
+            ["keep-a", "keep-b", "donor-a", "donor-b"])
+        XCTAssertEqual(keep.app.tabs.count, 5)
+        XCTAssertEqual(Set(keep.app.tabs.map(\.id)).count, keep.app.tabs.count)
+        // Migrating a tab must not disturb its live runtime — it is workspace
+        // owned and keyed by tab id, so it follows the tab across the move.
+        XCTAssertTrue(ws.liveTabRuntime(for: "donor-a") === donorRuntime)
+        // The user's current document still wins over each attach's activation.
+        XCTAssertEqual(keep.app.activeTabId, "keep-a")
+    }
+
+    /// Detaching mutates the array the merge is walking, so the ids are
+    /// snapshotted first. With three panes and two tabs each, a merge that lost
+    /// its place would drop every other tab.
+    func testMergeAllMigratesEveryTabAcrossNestedSplits() {
+        let ws = makeWorkspace()
+        let keep = ws.focusedPane
+        keep.app.attachTab(makeTab(id: "keep-a", document: pdfDocument(path: "/tmp/keep-a.pdf")))
+        keep.app.attachTab(makeTab(id: "keep-b", document: pdfDocument(path: "/tmp/keep-b.pdf")))
+
+        var donors: [PaneModel] = []
+        for index in 0..<2 {
+            ws.focus(keep.id)
+            ws.splitFocused(index == 0 ? .horizontal : .vertical)
+            let donor = ws.focusedPane
+            donor.app.attachTab(
+                makeTab(id: "donor-\(index)-a", document: pdfDocument(path: "/tmp/d\(index)a.pdf")))
+            donor.app.attachTab(
+                makeTab(id: "donor-\(index)-b", document: pdfDocument(path: "/tmp/d\(index)b.pdf")))
+            donors.append(donor)
+        }
+        XCTAssertEqual(ws.root.allLeaves().count, 3)
+
+        ws.focus(keep.id)
+        ws.mergeAll()
+
+        XCTAssertEqual(ws.root.allLeaves().count, 1)
+        // 2 kept + 4 migrated + 1 start tab from each of the two splits.
+        XCTAssertEqual(keep.app.tabs.count, 8)
+        for id in ["donor-0-a", "donor-0-b", "donor-1-a", "donor-1-b"] {
+            XCTAssertTrue(keep.app.tabs.contains { $0.id == id }, "lost \(id)")
+        }
+        for donor in donors {
+            XCTAssertTrue(donor.app.tabs.isEmpty)
+            XCTAssertNil(donor.app.activeTabId)
+        }
+    }
+
+    private func pdfDocument(path: String) -> DocumentInfo {
+        DocumentInfo(kind: .pdf, pdfPath: path, title: path, pageCount: 4, lastPage: 1)
+    }
+
     func testMoveTabBetweenPanes() {
         let ws = makeWorkspace()
         let source = ws.focusedPane

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -448,13 +448,35 @@ final class WorkspaceStore {
         // the last migrated tab instead of the user's current document.
         let keepActiveTabId = keep.app.activeTabId
         for leaf in leaves where leaf.id != keep.id {
-            for tab in leaf.app.tabs {
+            // Ownership is *transferred*, exactly as in `moveTab` — detach from
+            // the donor before attaching to `keep`. Copying instead would leave
+            // two AppStores claiming the same tab id, and anything keyed on
+            // tab-to-pane ownership (the web controller's mount guard, find and
+            // note-placement state, the residency pin) would still resolve the
+            // tab to the pane it just left (issue #91). Ids are snapshotted
+            // first because `detachTab` mutates the array being walked.
+            for tabId in leaf.app.tabs.map(\.id) {
+                guard let tab = leaf.app.detachTab(tabId) else {
+                    // Unreachable: the ids came from this pane a line ago and
+                    // nothing between here and there can remove one. Losing a
+                    // tab silently is the worst outcome available, so say so.
+                    assertionFailure("mergeAll: \(tabId) vanished from its own pane mid-merge")
+                    continue
+                }
                 keep.app.attachTab(tab)
             }
             // Same reasoning as closePane: the absorbed pane is discarded, so
             // drop its residency pin. Its tabs are now pinned (or not) by `keep`.
             // Their runtimes are workspace-owned and keyed by tab id, so they
             // migrate with the tabs untouched.
+            //
+            // Emptying the pane above has in fact already dropped the pin —
+            // the last `detachTab` re-points the pane at nothing, which reports
+            // `markActive(nil)` — so this is normally a no-op. It stays because
+            // the one case it isn't is a donor whose `activeTabId` disagrees
+            // with its `tabs`: the pin would then outlive the pane, and a stale
+            // `ObjectIdentifier` key aliases whatever AppStore is allocated at
+            // that address next.
             forgetPanePin(leaf.app)
         }
         if let keepActiveTabId {

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -324,11 +324,11 @@ private struct WebViewRepresentable: NSViewRepresentable {
         // The web view now outlives any single host: it belongs to the tab's
         // `LiveTabRuntime`, and the host is remounted whenever the tab is
         // dragged to another pane or its runtime comes back from eviction. An
-        // NSView may only have one superview, and `WorkspaceStore.mergeAll`
-        // copies tabs into the surviving pane before the donor pane's subtree
-        // is torn down — a window in which two hosts can briefly claim the same
-        // tab. Detaching first means the new host always adopts a parentless
-        // view, exactly as it would a freshly created one.
+        // NSView may only have one superview, and a tab that migrates panes is
+        // mounted at its destination before the donor pane's subtree is torn
+        // down — a window in which two hosts can briefly claim the same tab.
+        // Detaching first means the new host always adopts a parentless view,
+        // exactly as it would a freshly created one.
         let webView = controller.webView
         webView.removeFromSuperview()
         return webView


### PR DESCRIPTION
Closes #91

## Verdict: the bug is still live on `main`

Re-verified against `62b7f33` before touching anything, since #74 (`LiveTabRuntime` / `TabResidencyManager`), the #83 residency-pin fix, and the web-controller rebinding all landed after the issue was filed. Two of the three concerns the issue raises **are** already handled:

- **Residency pins** — `mergeAll` already called `forgetPanePin(leaf.app)` for each absorbed pane, and runtimes are workspace-owned and keyed by tab id, so they migrate untouched.
- **The symptom** — `WebViewerController.attach` rebinds pane-scoped stores unconditionally, so a moved web tab does re-bind.

The **ownership transfer itself was still missing**, exactly as filed. The clearest evidence is in the codebase's own comment: `WebViewRepresentable.makeNSView` calls `removeFromSuperview()` defensively and names this function as the reason —

> An NSView may only have one superview, and `WorkspaceStore.mergeAll` copies tabs into the surviving pane before the donor pane's subtree is torn down — a window in which two hosts can briefly claim the same tab.

The trigger was defused downstream, never removed.

## Root cause

`PdfTab` is a value type. `mergeAll` did:

```swift
for tab in leaf.app.tabs {
    keep.app.attachTab(tab)
}
```

That appends a **copy** to the survivor and leaves the original in the donor's `tabs`, with the donor's `activeTabId` still pointing at it. Two `AppStore`s claim the same tab id until the donor is deallocated.

The consequence that bites is `WebViewerController.activateSharedHandlers`, whose guard is `app.activeTabId == mountTabId`. During the window before the donor's subtree is torn down, the donor's still-mounted host satisfies that guard, so `scrollToPageHandler`, `scrollToWebPositionHandler`, `captureWebPositionHandler` and the AI locate/capture hooks get installed against the **discarded** pane's stores.

## Fix

Route the migration through `AppStore.detachTab` / `attachTab` — the same transfer path `moveTab` and `splitWithTab` already use — snapshotting the ids first because `detachTab` mutates the array being walked.

Detaching every tab empties the donor, which reports `markActive(nil)` and so drops its residency pin on the way out. That makes `forgetPanePin` a no-op on every reachable path; it is kept as a guard for a donor whose `activeTabId` disagrees with its `tabs`, where a leaked `ObjectIdentifier` key would alias whatever `AppStore` is allocated at that address next. The `WebViewRepresentable` comment is updated so it no longer describes `mergeAll` as the copying trigger.

## Tests

Two regression tests in `Tests/PaneTreeTests.swift`:

- `testMergeAllTransfersTabOwnershipInsteadOfCopying` — donor ends with no tabs, no `activeTabId`, no `document` (the exact invariant the web controller's mount guard reads); survivor holds each tab once, in order; runtime identity preserved; the user's active tab still wins over each attach's activation. One migrated tab is `kind: .web`, the case the issue is about.
- `testMergeAllMigratesEveryTabAcrossNestedSplits` — three panes, nested splits; nothing is dropped or duplicated when the array is mutated mid-walk.

**Mutation-checked**: reverting `mergeAll` to the copy loop fails both new tests (7 assertion failures), on the donor still reporting `donor-b` as its active tab and document. Restoring the fix returns 36/36.

## Numbers

- Full suite, clean build, `-derivedDataPath .dd/fix`: **473 XCTest** (471 baseline + 2 new) and **147 Swift Testing in 22 suites**, 0 failures, `** TEST SUCCEEDED **`, first run — no #100 flake.
- Zero new warnings (warnings-as-errors is on; the only `warning:` lines in the log are `appintentsmetadataprocessor` noise from the toolchain).

## Reviewer findings

A fresh-context Opus reviewer adversarially reviewed `git diff origin/main`. Verdict: fix correct, genuinely closes #91; it could not construct a lost or duplicated tab across any ownership path. Findings applied:

1. **(must-fix)** My `forgetPanePin` comment — and the original commit message — stated the mechanism backwards, claiming the call had to *follow* the detaches because emptying a pane re-pins. It is the opposite: emptying a pane *un*-pins it, so the call is a guaranteed no-op on reachable paths. Comment and commit message rewritten to say that honestly, and to record why the call is still worth keeping.
2. `else { continue }` on a nil `detachTab` would silently lose a tab. Unreachable today, but now `assertionFailure`s first.
3. Neither test used a `kind: .web` tab — the case #91 is actually about. Added.

Considered and deliberately not taken: collapsing the loop into a new `AppStore.detachAllTabs()` (would also fold away the ~2N `serialize()` calls a merge now performs). It is a reasonable cleanup but a wider change to `AppStore`'s API than this fix needs, and the serialization cost is bounded by a debounce and by realistic tab counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pane merging so tabs are transferred cleanly without duplication.
  * Preserved web tab runtime state and the active document during merges.
  * Ensured tabs from nested splits are consolidated correctly and donor panes are emptied.

* **Documentation**
  * Clarified web view behavior during tab pane migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->