### PR TITLE
Decode AI conversations per message instead of all-or-nothing

### DIFF
--- a/Tests/AiConversationStoreTests.swift
+++ b/Tests/AiConversationStoreTests.swift
@@ -158,6 +158,123 @@ final class AiConversationStoreTests: XCTestCase {
                        "retry against a writable root persists the retained data")
     }
 
+    // MARK: - One bad message must not cost the whole conversation (#90)
+
+    /// A transcript in the shape written before `references`/`toolSummaries`
+    /// existed still loads through the per-element decode. Guards against the
+    /// lossy wrapper quietly swallowing every old record.
+    func testOldFormatConversationStillLoads() throws {
+        let doc = pdfDocument()
+        let key = DocumentIdentity.storageKey(for: doc)
+        let legacy = """
+        [
+          {"id":"a1","role":"user","content":"older question",
+           "createdAt":"2025-01-01T00:00:00.000Z"},
+          {"id":"a2","role":"assistant","content":"older answer",
+           "createdAt":"2025-01-01T00:00:01.000Z",
+           "usage":{"inputTokens":10,"cachedInputTokens":0,"cacheWriteTokens":0,
+                    "reasoningTokens":0,"outputTokens":3}}
+        ]
+        """
+        try DocumentDataStore.saveConversationsData(
+            forKey: key, data: XCTUnwrap(legacy.data(using: .utf8)))
+
+        let loaded = AiPersistence.loadConversation(for: doc)
+        XCTAssertEqual(loaded.map(\.content), ["older question", "older answer"])
+        XCTAssertEqual(loaded.last?.usage?.inputTokens, 10)
+        XCTAssertEqual(loaded.map(\.references), [[], []])
+    }
+
+    /// The core regression: one undecodable message in the middle of a
+    /// conversation costs the user that message and nothing else. The survivors
+    /// must come back whole — references and toolSummaries included — because a
+    /// wrapper that fell back to some looser per-field decode would "pass" this
+    /// test while silently dropping their structured payloads.
+    func testOneCorruptMessageDropsOnlyItself() throws {
+        let doc = pdfDocument()
+        let key = DocumentIdentity.storageKey(for: doc)
+
+        var user = AiPersistence.makeMessage(
+            role: .user, content: "explain figure 2",
+            references: [AiReference(kind: .selection(text: "the mitochondrion", page: 2))])
+        user.id = "keep-user"
+        var assistant = AiPersistence.makeMessage(role: .assistant, content: "it is the powerhouse")
+        assistant.id = "keep-assistant"
+        assistant.toolSummaries = [
+            AiToolSummary(
+                id: "summary-a", title: "Read pages 2-3", detail: "2 pages",
+                sources: [AiToolSummary.Source(id: "src-a", page: 2, excerpt: "…mitochondrion…")],
+                destinationPage: 2)
+        ]
+
+        // Encode the two good messages for real, then splice a record that this
+        // build cannot decode (no `content`, and `role` is not an AiRole) between
+        // them — the shape a truncated write or a future schema would leave.
+        let goodData = try JSONEncoder().encode([user, assistant])
+        var array = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: goodData) as? [Any])
+        array.insert(["id": "corrupt", "role": "system", "createdAt": "2025-01-01T00:00:00.000Z"],
+                     at: 1)
+        try DocumentDataStore.saveConversationsData(
+            forKey: key, data: JSONSerialization.data(withJSONObject: array))
+
+        let loaded = AiPersistence.loadConversation(for: doc)
+
+        XCTAssertEqual(loaded.map(\.id), ["keep-user", "keep-assistant"],
+                       "only the undecodable message may be dropped")
+        XCTAssertEqual(loaded.first?.references.first?.text, "the mitochondrion")
+        XCTAssertEqual(loaded.first?.references.first?.page, 2)
+        XCTAssertEqual(loaded.last?.toolSummaries?.map(\.title), ["Read pages 2-3"])
+        XCTAssertEqual(loaded.last?.toolSummaries?.first?.sources.map(\.page), [2])
+        XCTAssertEqual(loaded.last?.toolSummaries?.first?.destinationPage, 2)
+    }
+
+    /// The second guard: when NOTHING in the file decodes, the resulting empty
+    /// conversation is our failure to read, not the user's chat — so the next
+    /// empty save must leave the bytes alone instead of hard-deleting them. A
+    /// build that can decode the file must still find it there.
+    func testFullyCorruptFileIsNotOverwrittenByTheNextSave() async throws {
+        let doc = pdfDocument()
+        let key = DocumentIdentity.storageKey(for: doc)
+        // Well-formed JSON array, but not one message in it is decodable.
+        let corrupt = Data(#"[{"id":"x","role":"user"},{"nope":true}]"#.utf8)
+        try DocumentDataStore.saveConversationsData(forKey: key, data: corrupt)
+
+        XCTAssertTrue(AiPersistence.loadConversation(for: doc).isEmpty,
+                      "nothing decodes, so nothing is shown")
+
+        // The empty in-memory transcript is saved back (the path that used to
+        // delete the file).
+        AiPersistence.saveConversation(for: doc, messages: [])
+        await AiPersistence.awaitPendingFlush()
+
+        XCTAssertTrue(DocumentDataStore.conversationsExist(forKey: key),
+                      "an unreadable conversation must not be deleted by an empty save")
+        XCTAssertEqual(DocumentDataStore.loadConversationsData(forKey: key), corrupt,
+                       "the original bytes must survive byte-for-byte")
+    }
+
+    /// The guard is scoped to the empty write: once the user actually says
+    /// something, that real conversation is persisted normally rather than being
+    /// suppressed forever by the earlier failed read.
+    func testSaveWithRealMessagesStillWritesOverAnUnreadableFile() async throws {
+        let doc = pdfDocument()
+        let key = DocumentIdentity.storageKey(for: doc)
+        try DocumentDataStore.saveConversationsData(
+            forKey: key, data: Data(#"[{"id":"x","role":"user"}]"#.utf8))
+        XCTAssertTrue(AiPersistence.loadConversation(for: doc).isEmpty)
+
+        AiPersistence.saveConversation(
+            for: doc, messages: [AiPersistence.makeMessage(role: .user, content: "starting over")])
+        await AiPersistence.awaitPendingFlush()
+
+        XCTAssertEqual(try fileMessages(forKey: key).map(\.content), ["starting over"])
+        // And the key is no longer protected: a later clear deletes as usual.
+        AiPersistence.saveConversation(for: doc, messages: [])
+        await AiPersistence.awaitPendingFlush()
+        XCTAssertFalse(DocumentDataStore.conversationsExist(forKey: key))
+    }
+
     // MARK: - Cache invalidation on import merge
 
     /// After a `.vellum` import merges a fresh conversation into the folder file,

--- a/Tests/AiConversationStoreTests.swift
+++ b/Tests/AiConversationStoreTests.swift
@@ -275,6 +275,75 @@ final class AiConversationStoreTests: XCTestCase {
         XCTAssertFalse(DocumentDataStore.conversationsExist(forKey: key))
     }
 
+    /// The protection must be scoped to a FAILED read: a file that legitimately
+    /// stores `[]` decodes fine, so clearing it still deletes as before. Pins the
+    /// "had elements but none decoded" half of the classification — without it,
+    /// treating every empty decode as unreadable would pass the tests above and
+    /// quietly break the hard-delete contract.
+    func testLegitimatelyEmptyFileIsStillDeletableByAnEmptySave() async throws {
+        let doc = pdfDocument()
+        let key = DocumentIdentity.storageKey(for: doc)
+        try DocumentDataStore.saveConversationsData(forKey: key, data: Data("[]".utf8))
+        XCTAssertTrue(AiPersistence.loadConversation(for: doc).isEmpty)
+
+        AiPersistence.saveConversation(for: doc, messages: [])
+        await AiPersistence.awaitPendingFlush()
+
+        XCTAssertFalse(DocumentDataStore.conversationsExist(forKey: key),
+                       "an empty-but-readable file is the user's empty chat, not ours")
+    }
+
+    /// Invalidation (a `.vellum` import replacing the file, a Storage-pane
+    /// delete) drops the undecodable verdict too — it was about bytes that are
+    /// no longer there, and keeping it would swallow later empty saves forever.
+    func testInvalidateClearsTheUndecodableProtection() async throws {
+        let doc = pdfDocument()
+        let key = DocumentIdentity.storageKey(for: doc)
+        try DocumentDataStore.saveConversationsData(
+            forKey: key, data: Data(#"[{"id":"x","role":"user"}]"#.utf8))
+        XCTAssertTrue(AiPersistence.loadConversation(for: doc).isEmpty)
+
+        // The file is replaced with something readable, exactly as an import does.
+        try DocumentDataStore.saveConversationsData(
+            forKey: key,
+            data: try JSONEncoder().encode(
+                [AiPersistence.makeMessage(role: .user, content: "readable now")]))
+        AiPersistence.invalidateCachedConversation(forKey: key)
+
+        XCTAssertEqual(AiPersistence.loadConversation(for: doc).map(\.content), ["readable now"])
+        AiPersistence.saveConversation(for: doc, messages: [])
+        await AiPersistence.awaitPendingFlush()
+        XCTAssertFalse(DocumentDataStore.conversationsExist(forKey: key),
+                       "a stale verdict must not block a real clear")
+    }
+
+    /// A PDF can acquire its /VellumDocId between the read and the write. The
+    /// undecodable verdict is recorded against the path-hash key and must ride
+    /// along to the stamped key with the folder, or the very next empty save
+    /// would delete the file the read had just refused to trust.
+    func testUndecodableProtectionFollowsTheRekeyToTheStampedKey() async throws {
+        let path = "/tmp/ai-conv-\(UUID().uuidString).pdf"
+        func document(docId: String?) -> DocumentInfo {
+            DocumentInfo(kind: .pdf, pdfPath: path, title: "Doc",
+                         pageCount: 1, lastPage: 1, docId: docId)
+        }
+        let stamped = document(docId: "99999999-8888-7777-6666-555555555555")
+        let docId = try XCTUnwrap(stamped.docId)
+        let pathKey = DocumentIdentity.sha256Hex(path)
+        let corrupt = Data(#"[{"id":"x","role":"user"}]"#.utf8)
+        try DocumentDataStore.saveConversationsData(forKey: pathKey, data: corrupt)
+
+        // Read before the stamp: the verdict lands on the path-hash key.
+        XCTAssertTrue(AiPersistence.loadConversation(for: document(docId: nil)).isEmpty)
+
+        // Write after the stamp: folder and verdict both move to the docId key.
+        AiPersistence.saveConversation(for: stamped, messages: [])
+        await AiPersistence.awaitPendingFlush()
+
+        XCTAssertEqual(DocumentDataStore.loadConversationsData(forKey: docId), corrupt,
+                       "the rekeyed file must keep its protection")
+    }
+
     // MARK: - Cache invalidation on import merge
 
     /// After a `.vellum` import merges a fresh conversation into the folder file,

--- a/Tests/VellumBundleTests.swift
+++ b/Tests/VellumBundleTests.swift
@@ -288,6 +288,63 @@ final class VellumBundleTests: XCTestCase {
         XCTAssertEqual(references.last?.page, 4)
     }
 
+    // MARK: - Import must not destroy a local conversation it can't read (#90)
+
+    /// The merge rewrites conversations.json in one shot, with no write-behind
+    /// cache to fall back on. It used to decode the LOCAL file all-or-nothing, so
+    /// one bad record collapsed it to `[]` and the import destroyed every good
+    /// local message on the spot. Only the unreadable record may be lost.
+    func testImportKeepsLocalMessagesAroundAnUndecodableOne() throws {
+        let key = "convo-lossy-merge-key"
+        let good = message(id: "local-1", role: .user, content: "local question",
+                           createdAt: "2026-01-01T00:00:00Z")
+        var array = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: try JSONEncoder().encode([good])) as? [Any])
+        array.append(["id": "local-bad", "role": "system"])
+        try DocumentDataStore.saveConversationsData(
+            forKey: key, data: try JSONSerialization.data(withJSONObject: array))
+
+        let incoming = message(id: "imp-1", role: .assistant, content: "imported answer",
+                               createdAt: "2026-01-02T00:00:00Z")
+        let imported = VellumBundle.Imported(
+            manifest: validPdfManifest(documentBytes: Data("d".utf8)),
+            documentData: Data("d".utf8),
+            scratchpad: nil,
+            attachments: [],
+            conversations: try JSONEncoder().encode([incoming]))
+        try VellumBundle.installSidecar(imported, forKey: key) { _ in .keepLocal }
+
+        let data = try XCTUnwrap(DocumentDataStore.loadConversationsData(forKey: key))
+        let stored = try JSONDecoder().decode([AiMessage].self, from: data)
+        XCTAssertEqual(stored.map(\.id), ["local-1", "imp-1"],
+                       "the readable local message must survive the merge")
+    }
+
+    /// When NOTHING in the local file decodes, the merge would write the
+    /// imported messages over bytes we merely failed to read — the same loss
+    /// `AiPersistence`'s write guard refuses. The import must not be a way
+    /// around it: the file is left byte-for-byte intact and the failure is
+    /// surfaced rather than swallowed.
+    func testImportRefusesToOverwriteAnUndecodableLocalConversation() throws {
+        let key = "convo-undecodable-merge-key"
+        let corrupt = Data(#"[{"id":"local-bad","role":"system"}]"#.utf8)
+        try DocumentDataStore.saveConversationsData(forKey: key, data: corrupt)
+
+        let incoming = message(id: "imp-1", role: .assistant, content: "imported answer",
+                               createdAt: "2026-01-02T00:00:00Z")
+        let imported = VellumBundle.Imported(
+            manifest: validPdfManifest(documentBytes: Data("d".utf8)),
+            documentData: Data("d".utf8),
+            scratchpad: nil,
+            attachments: [],
+            conversations: try JSONEncoder().encode([incoming]))
+
+        XCTAssertThrowsError(
+            try VellumBundle.installSidecar(imported, forKey: key) { _ in .keepLocal })
+        XCTAssertEqual(DocumentDataStore.loadConversationsData(forKey: key), corrupt,
+                       "the unreadable local conversation must be left untouched")
+    }
+
     // MARK: - Version rejection
 
     func testVersionTwoRejected() throws {

--- a/Vellum/Services/Ai/AiPersistence.swift
+++ b/Vellum/Services/Ai/AiPersistence.swift
@@ -211,7 +211,7 @@ enum AiPersistence {
         // read (#90). Returning without caching or dirtying leaves the on-disk
         // bytes intact for a build that can decode them.
         if limited.isEmpty, undecodableKeys.contains(key) {
-            NSLog("[Vellum] Skipping empty AI conversation write for a document whose stored chat could not be decoded; leaving the file on disk")
+            NSLog("[Vellum] Skipping empty AI conversation write for \(key): its stored chat could not be decoded, so the file is left on disk")
             return
         }
         undecodableKeys.remove(key)
@@ -335,23 +335,47 @@ enum AiPersistence {
     /// drops just that element, mirroring what `LossyAiReference` does one level
     /// down for `AiMessage.references`.
     private static func readConversationsFile(forKey key: String) -> ConversationRead {
-        // No bytes at all (absent file, or an evicted iCloud placeholder that
-        // reads as nothing) — nothing to protect, and the caller's eviction
-        // check distinguishes those two.
-        guard let data = DocumentDataStore.loadConversationsData(forKey: key),
-              !data.isEmpty
-        else { return .messages([]) }
-        // The top level isn't even an array of objects: a truncated or
-        // hand-mangled file. Nothing survives, and we must not call that "empty".
+        guard let data = DocumentDataStore.loadConversationsData(forKey: key), !data.isEmpty else {
+            // Nothing was read. A file that IS there but wouldn't open
+            // (permissions, I/O error) is a failed read, not an absent chat —
+            // classify it as such so the write guard protects it. A genuinely
+            // absent file, and an evicted iCloud placeholder (which the caller
+            // separates out), are the real empties.
+            return DocumentDataStore.conversationsExist(forKey: key) ? .undecodable : .messages([])
+        }
+        guard let decoded = decodeMessages(data) else { return .undecodable }
+        // A partial drop is permanent — the next turn rewrites the file without
+        // the dropped record — so leave evidence for a "a message vanished"
+        // report, the way every other data-loss-adjacent path here does.
+        if decoded.dropped > 0 {
+            NSLog("[Vellum] Dropped \(decoded.dropped) undecodable message(s) while reading the AI conversation for \(key)")
+        }
+        return .messages(limitedMessages(decoded.messages))
+    }
+
+    /// The single decode boundary for a conversations.json payload, shared by
+    /// cold loads and `.vellum` imports so both degrade identically.
+    ///
+    /// Per-element rather than all-or-nothing (#90): `AiMessage`'s own
+    /// `init(from:)` already degrades field-by-field, but a message that is
+    /// missing a required field, was truncated by an interrupted write, or uses
+    /// a shape this build predates would still fail — and failing one element of
+    /// `[AiMessage]` discards the user's whole conversation. `LossyAiMessage`
+    /// drops just that element, mirroring what `LossyAiReference` does one level
+    /// down for `AiMessage.references`.
+    ///
+    /// Returns nil when the payload could not be read at all: either its top
+    /// level isn't an array of objects, or it held records and not one of them
+    /// decoded. That is OUR failure to read and must never be mistaken for the
+    /// user having no chat — a payload that legitimately stores `[]` comes back
+    /// as an empty, non-nil result.
+    static func decodeMessages(_ data: Data) -> (messages: [AiMessage], dropped: Int)? {
         guard let entries = try? JSONDecoder().decode([LossyAiMessage].self, from: data) else {
-            return .undecodable
+            return nil
         }
         let messages = entries.compactMap(\.value)
-        // A file that stores `[]` legitimately has no messages; a file whose
-        // every element failed to decode does not — that emptiness is our
-        // failure to read, not the user's chat history.
-        if messages.isEmpty, !entries.isEmpty { return .undecodable }
-        return .messages(limitedMessages(messages))
+        if messages.isEmpty, !entries.isEmpty { return nil }
+        return (messages, entries.count - messages.count)
     }
 
     /// Await any scheduled write — called from applicationShouldTerminate.
@@ -398,9 +422,14 @@ enum AiPersistence {
         if dirtyKeys.remove(oldKey) != nil {
             dirtyKeys.insert(newKey)
         }
-        // The undecodable file moves with the folder, so its protection must too.
+        // The undecodable file moves with the folder, so its protection must
+        // too. When the source carried no such verdict, drop any the DESTINATION
+        // held: the rekey merge may have just replaced its conversations.json,
+        // and a stale flag there would silently swallow a later user Clear.
         if undecodableKeys.remove(oldKey) != nil {
             undecodableKeys.insert(newKey)
+        } else {
+            undecodableKeys.remove(newKey)
         }
     }
 

--- a/Vellum/Services/Ai/AiPersistence.swift
+++ b/Vellum/Services/Ai/AiPersistence.swift
@@ -174,7 +174,15 @@ enum AiPersistence {
         if !DocumentDataStore.conversationsExist(forKey: key) {
             migrateLegacyIfNeeded(document: document, key: key)
         }
-        let loaded = readConversationsFile(forKey: key)
+        // Bytes on disk that yielded no readable message at all. Same reasoning
+        // as the iCloud case below: the empty is OURS, not the user's, so it
+        // never enters the cache — and `undecodableKeys` stops a later empty
+        // save from turning "we couldn't read it" into "it's deleted" (#90).
+        guard case .messages(let loaded) = readConversationsFile(forKey: key) else {
+            undecodableKeys.insert(key)
+            return []
+        }
+        undecodableKeys.remove(key)
         // A conversation stuck in iCloud (an unmaterialized placeholder that
         // couldn't download) reads as empty — but that empty is NOT authoritative.
         // Leaving the cache unset means a later load, once the bytes land, re-reads
@@ -186,10 +194,27 @@ enum AiPersistence {
         return loaded
     }
 
+    /// storageKeys whose conversations.json holds bytes this build could not
+    /// decode into a single message. The delete-on-empty write path is suppressed
+    /// for these (#90): an empty in-memory conversation for such a key can only
+    /// have come from the failed read, never from the user clearing a chat — the
+    /// Clear command is disabled while the transcript is empty. A save carrying
+    /// real messages still writes, because that is the user deliberately starting
+    /// a new conversation over a file we cannot show them.
+    @MainActor private static var undecodableKeys: Set<String> = []
+
     @MainActor static func saveConversation(for document: DocumentInfo?, messages: [AiMessage]) {
         guard let document, let key = storageKey(for: document) else { return }
         migrateToCurrentStorageKeyIfNeeded(document: document, key: key)
         let limited = limitedMessages(messages)
+        // Refuse to let an empty result overwrite a file we simply failed to
+        // read (#90). Returning without caching or dirtying leaves the on-disk
+        // bytes intact for a build that can decode them.
+        if limited.isEmpty, undecodableKeys.contains(key) {
+            NSLog("[Vellum] Skipping empty AI conversation write for a document whose stored chat could not be decoded; leaving the file on disk")
+            return
+        }
+        undecodableKeys.remove(key)
         cache[key] = limited
         // A non-empty conversation is real class-B data; ensure meta.json exists
         // so recents can re-resolve the document by its docId later. The actual
@@ -289,14 +314,44 @@ enum AiPersistence {
         }
     }
 
+    /// What a read of conversations.json produced. The two cases are NOT
+    /// interchangeable: `.messages([])` means "this document has no stored
+    /// chat", while `.undecodable` means "there are bytes on disk we could not
+    /// turn into a single message". Only the first is authoritative enough to
+    /// cache and later flush back (#90).
+    private enum ConversationRead {
+        case messages([AiMessage])
+        case undecodable
+    }
+
     /// Read and decode a document's conversations.json (the plain JSON array
-    /// form), applying the per-message caps defensively. Empty when absent or
-    /// unreadable.
-    private static func readConversationsFile(forKey key: String) -> [AiMessage] {
+    /// form), applying the per-message caps defensively.
+    ///
+    /// Decoding is per-element rather than all-or-nothing (#90): `AiMessage`'s
+    /// own `init(from:)` already degrades field-by-field, but a message that is
+    /// missing a required field, was truncated by an interrupted write, or uses
+    /// a shape this build predates would still fail — and failing one element of
+    /// `[AiMessage]` discards the user's whole conversation. `LossyAiMessage`
+    /// drops just that element, mirroring what `LossyAiReference` does one level
+    /// down for `AiMessage.references`.
+    private static func readConversationsFile(forKey key: String) -> ConversationRead {
+        // No bytes at all (absent file, or an evicted iCloud placeholder that
+        // reads as nothing) — nothing to protect, and the caller's eviction
+        // check distinguishes those two.
         guard let data = DocumentDataStore.loadConversationsData(forKey: key),
-              let messages = try? JSONDecoder().decode([AiMessage].self, from: data)
-        else { return [] }
-        return limitedMessages(messages)
+              !data.isEmpty
+        else { return .messages([]) }
+        // The top level isn't even an array of objects: a truncated or
+        // hand-mangled file. Nothing survives, and we must not call that "empty".
+        guard let entries = try? JSONDecoder().decode([LossyAiMessage].self, from: data) else {
+            return .undecodable
+        }
+        let messages = entries.compactMap(\.value)
+        // A file that stores `[]` legitimately has no messages; a file whose
+        // every element failed to decode does not — that emptiness is our
+        // failure to read, not the user's chat history.
+        if messages.isEmpty, !entries.isEmpty { return .undecodable }
+        return .messages(limitedMessages(messages))
     }
 
     /// Await any scheduled write — called from applicationShouldTerminate.
@@ -326,6 +381,10 @@ enum AiPersistence {
     @MainActor static func invalidateCachedConversation(forKey key: String) {
         cache.removeValue(forKey: key)
         dirtyKeys.remove(key)
+        // The file behind the key was just replaced (or deleted) out from under
+        // us, so any "couldn't decode it" verdict is about bytes that no longer
+        // exist. The next load re-reads and re-decides.
+        undecodableKeys.remove(key)
     }
 
     /// Keep the main-actor write-behind state aligned with an on-disk rekey.
@@ -338,6 +397,10 @@ enum AiPersistence {
         }
         if dirtyKeys.remove(oldKey) != nil {
             dirtyKeys.insert(newKey)
+        }
+        // The undecodable file moves with the folder, so its protection must too.
+        if undecodableKeys.remove(oldKey) != nil {
+            undecodableKeys.insert(newKey)
         }
     }
 
@@ -629,6 +692,24 @@ enum AiPersistence {
             if let key = try? JSONDecoder().decode(String.self, from: encoded) { keys.append(key) }
         }
         return keys
+    }
+}
+
+/// Array-element wrapper that turns a failed `AiMessage` decode into `nil`
+/// instead of failing the enclosing array — the message-level counterpart to
+/// `LossyAiReference` (see `AiStore.swift`), which does the same for a single
+/// message's `references`.
+///
+/// It wraps `AiMessage.init(from:)` rather than replacing it, so the hand-written
+/// per-field compatibility handling in that initializer (`decodeIfPresent` for
+/// `usage`/`references`/`toolSummaries`, the lossy reference array) still runs and
+/// is the FIRST line of defence. This is only the outer net for a record that
+/// initializer cannot salvage at all.
+private struct LossyAiMessage: Decodable {
+    let value: AiMessage?
+
+    init(from decoder: any Decoder) throws {
+        value = try? AiMessage(from: decoder)
     }
 }
 

--- a/Vellum/Services/VellumBundle.swift
+++ b/Vellum/Services/VellumBundle.swift
@@ -427,10 +427,26 @@ enum VellumBundle {
     /// Union the imported conversation with any local one by message id, sort by
     /// created_at, then apply the per-document caps (AiPersistence contract).
     private static func mergeConversations(_ incomingData: Data, forKey key: String) throws {
-        let decoder = JSONDecoder()
-        let incoming = (try? decoder.decode([AiMessage].self, from: incomingData)) ?? []
-        let local = DocumentDataStore.loadConversationsData(forKey: key)
-            .flatMap { try? decoder.decode([AiMessage].self, from: $0) } ?? []
+        // Both sides go through the same lossy decode the live loader uses, so
+        // one unreadable message costs that message rather than a conversation
+        // (#90). Without it, a single bad record in the LOCAL file collapsed it
+        // to `[]` and the merge — which rewrites the file in one shot, with no
+        // write-behind cache to fall back on — destroyed every good local
+        // message on the spot.
+        let incoming = AiPersistence.decodeMessages(incomingData)?.messages ?? []
+        var local: [AiMessage] = []
+        if let localData = DocumentDataStore.loadConversationsData(forKey: key), !localData.isEmpty {
+            guard let decoded = AiPersistence.decodeMessages(localData) else {
+                // Nothing in the local file decoded. Merging would write the
+                // imported messages over bytes we simply failed to read, which is
+                // exactly the loss `AiPersistence`'s write guard refuses — and an
+                // import must not be the way around it. Leave the file alone and
+                // say so, like the evicted-iCloud guard on the write itself.
+                throw SessionServiceError.io(
+                    "This document's existing AI conversation couldn't be read, so the imported chat was not merged into it. The existing file was left untouched.")
+            }
+            local = decoded.messages
+        }
         guard !incoming.isEmpty || !local.isEmpty else { return }
 
         // Local kept on an id collision (first occurrence wins).

--- a/Vellum/Stores/AiStore.swift
+++ b/Vellum/Stores/AiStore.swift
@@ -95,9 +95,12 @@ extension AiMessage {
     /// `references` is absent from every conversation persisted before this
     /// field existed (handled by `decodeIfPresent` + the `[]` default), and a
     /// reference whose `kind` tag this build doesn't recognise would otherwise
-    /// throw. `AiPersistence` decodes the whole file as `[AiMessage]`, which is
-    /// all-or-nothing — one unreadable reference would silently discard the
-    /// user's entire conversation. Unreadable entries are dropped instead.
+    /// throw — and failing here fails the whole message. Unreadable entries are
+    /// dropped instead, so an unknown reference costs the user one chip rather
+    /// than the message carrying it. `AiPersistence.decodeMessages` applies the
+    /// same idea one level up (`LossyAiMessage`), so a message this initializer
+    /// cannot salvage at all costs them that message rather than the whole
+    /// conversation.
     ///
     /// Declared in an extension so the memberwise initializer survives (several
     /// call sites build `AiMessage` field-by-field).


### PR DESCRIPTION
Closes #90

## Root cause

`AiPersistence.readConversationsFile` decoded a document's whole `conversations.json` as `[AiMessage]`. That is all-or-nothing: one message the build couldn't read threw, the conversation came back as `[]`, and because an empty list is the *delete* signal on the write path, the next save wrote that emptiness back over the file. A single truncated record from an interrupted write — or one schema change an older build can't read — meant total loss of a document's chat, silently.

PR #66 had already made this exact argument one level down (`LossyAiReference`, for `AiMessage.references`); the message level was still all-or-nothing.

## The fix

**1. Per-element decode.** `LossyAiMessage` wraps `AiMessage.init(from:)` rather than replacing it, so that initializer's hand-written per-field compatibility handling (`decodeIfPresent` for `usage`/`references`/`toolSummaries`, plus the lossy reference array) still runs and is the first line of defence. Only a record it cannot salvage at all is dropped, and only that record.

**2. "We couldn't read it" is not "there is no chat."** `decodeMessages` returns nil when the payload held records and not one decoded (or its top level isn't an array at all); `readConversationsFile` also classifies a file that exists but wouldn't open as undecodable. Such a key is never cached — mirroring the existing iCloud-eviction path directly above it — and an empty save for it is refused, so a decode failure cannot hard-delete data that is still intact on disk. A save carrying real messages still writes: that is the user deliberately starting over, not a failed read.

The guard cannot suppress a legitimate delete. Of the eight `saveConversation` call sites, only `clearConversation` (guarded by `!messages.isEmpty`) and `redoClear` (reachable only after a successful decode, which clears the flag) can pass `[]`.

## Reviewer findings

A fresh-context reviewer went at `git diff origin/main` adversarially. All findings applied:

- **HIGH — `VellumBundle.mergeConversations` was issue #90 verbatim, one layer over, and defeated the new guard.** It decoded the *local* `conversations.json` all-or-nothing, then rewrote it in one shot. One bad local record collapsed it to `[]` and the merge destroyed every good local message on the spot — strictly worse than the bug being fixed, since there is no write-behind cache and no "next save" delay. It also wrote straight over a file the new guard had just protected. Both sides now use the shared `AiPersistence.decodeMessages`, and a local file that decodes to nothing refuses the merge (throwing `SessionServiceError.io`, the same shape as the evicted-iCloud guard) instead of overwriting bytes we merely failed to read.
- **MEDIUM — a present-but-unreadable file (permissions, I/O) was misclassified as "no chat"** and cached as authoritative, so the next empty save deleted it. Now classified undecodable.
- **MEDIUM — partial drops were silent and are permanent** (the next turn rewrites the file without the dropped record). Now logged with the key, like every other data-loss-adjacent path in this file.
- **MEDIUM — three new behaviours weren't pinned.** Notably, an implementation that treated *any* empty decode as undecodable would have passed the original tests while breaking the hard-delete contract. Added tests for a legitimately-empty (`[]`) file staying deletable, `invalidateCachedConversation` clearing the verdict, and the verdict following a path-hash → docId rekey.
- **LOW — the rekey inherited a verdict but never cleared a stale one on the destination**, which could combine with the inherited dirty state to silently swallow a user Clear. Now cleared.
- **NIT — the `LossyAiReference` doc comment still claimed the file is decoded all-or-nothing**, which this PR makes false. Rewritten.

Nothing declined. The reviewer separately confirmed that `try?` does not weaken per-field decoding (the initializer runs in full and unchanged; `JSONDecoder` works over a pre-parsed value tree, so a nested throw can't desync the outer array), that `undecodableKeys` is correctly `@MainActor` alongside `cache`/`dirtyKeys` and never touched by the detached flush, and that the legacy-blob migration, both Storage-pane delete paths, and the iCloud-placeholder ordering all still behave.

## Tests

`xcodebuild test`, macOS, Debug, clean build with warnings-as-errors: **480 XCTest passed** (471 on `main` + 9 new) and **147 Swift Testing passed in 22 suites**. Zero failures, zero new warnings.

Each new test was mutation-checked — it fails when its mechanism is reverted:

| Test | Reverted mechanism |
|---|---|
| `testOneCorruptMessageDropsOnlyItself` | `LossyAiMessage` back to a strict element decode |
| `testFullyCorruptFileIsNotOverwrittenByTheNextSave` | the empty-save guard removed |
| `testImportKeepsLocalMessagesAroundAnUndecodableOne` / `testImportRefusesToOverwriteAnUndecodableLocalConversation` | `mergeConversations` back to all-or-nothing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
