### PR TITLE
Fix DocumentDataStoreTests rekey flake by making the attachment sweep awaitable

### DIFF
--- a/Tests/DocumentDataStoreTests.swift
+++ b/Tests/DocumentDataStoreTests.swift
@@ -10,6 +10,10 @@ import XCTest
 final class DocumentDataStoreTests: XCTestCase {
     private var root: URL!
     private var legacyPool: URL!
+    /// Every `ScratchpadStore` a test built, so teardown can join the background
+    /// attachment sweeps they started before the scratch tree is torn down — no
+    /// sweep may outlive the test that armed it (#100).
+    private var stores: [ScratchpadStore] = []
 
     override func setUp() async throws {
         let base = FileManager.default.temporaryDirectory
@@ -24,6 +28,8 @@ final class DocumentDataStoreTests: XCTestCase {
     }
 
     override func tearDown() async throws {
+        await drainAttachmentSweeps()
+        stores.removeAll()
         DocumentDataStore.rootDirectoryOverride = nil
         ScratchpadAttachmentStore.directoryOverride = nil
         ScratchpadAttachmentStore.activeDirectory = nil
@@ -35,6 +41,23 @@ final class DocumentDataStoreTests: XCTestCase {
                 [.posixPermissions: 0o755], ofItemAtPath: root.path)
             try? FileManager.default.removeItem(at: root.deletingLastPathComponent())
         }
+    }
+
+    /// A store whose background attachment sweeps this suite owns. Loading a
+    /// document ends in a sweep dispatched to a background task; tracking the
+    /// store lets teardown join it. A test that ASSERTS on attachment files must
+    /// also `await drainAttachmentSweeps()` first — joining at teardown bounds
+    /// the leak, it does not order the sweep against in-test assertions.
+    private func makeStore() -> ScratchpadStore {
+        let store = ScratchpadStore()
+        stores.append(store)
+        return store
+    }
+
+    /// Join every attachment sweep started by this test's stores, so the
+    /// assertions that follow describe the settled state on disk.
+    private func drainAttachmentSweeps() async {
+        for store in stores { await store.attachmentSweepTask?.value }
     }
 
     private func pdfDocument(path: String, docId: String? = nil) -> DocumentInfo {
@@ -140,7 +163,7 @@ final class DocumentDataStoreTests: XCTestCase {
         let note = "Legacy ![img](vellum-scratchpad://\(id)) note"
         try seedLegacyBlob([BlobEntry(key: path, text: note)])
 
-        let store = ScratchpadStore()
+        let store = makeStore()
         store.loadForDocument(pdfDocument(path: path))
 
         let key = DocumentIdentity.sha256Hex(path)
@@ -255,7 +278,7 @@ final class DocumentDataStoreTests: XCTestCase {
         try DocumentDataStore.saveScratchpad(forKey: key, text: "folder note")
         try seedLegacyBlob([BlobEntry(key: path, text: "blob note")])
 
-        let store = ScratchpadStore()
+        let store = makeStore()
         store.loadForDocument(pdfDocument(path: path))
 
         // Folder note wins; blob is left intact for its own (unmigrated) doc.
@@ -265,26 +288,37 @@ final class DocumentDataStoreTests: XCTestCase {
 
     // MARK: - Rekey
 
-    func testRekeyMovesFallbackFolderToStampedKey() throws {
+    func testRekeyMovesFallbackFolderToStampedKey() async throws {
         let path = "/tmp/stamp-\(UUID().uuidString).pdf"
         let pathKey = DocumentIdentity.sha256Hex(path)
         let docId = "11111111-2222-3333-4444-555555555555"
         // Seed data in the path-hash fallback folder (as if written pre-stamp).
-        try DocumentDataStore.saveScratchpad(forKey: pathKey, text: "carried note")
+        // The note REFERENCES the attachment, which is what a document that
+        // carried one across a rekey actually looks like: an attachment no note
+        // points at is an orphan, and the sweep every load ends in is right to
+        // collect it, so requiring it to survive would pin a value that only
+        // holds until that sweep lands (#100).
+        let note = "carried note ![x](attachments/ab.jpg)"
+        try DocumentDataStore.saveScratchpad(forKey: pathKey, text: note)
         let fallbackAttachments = DocumentDataStore.attachmentsDir(forKey: pathKey)
         try FileManager.default.createDirectory(
             at: fallbackAttachments, withIntermediateDirectories: true)
         try Data([1]).write(to: fallbackAttachments.appendingPathComponent("ab.jpg"))
 
-        let store = ScratchpadStore()
+        let store = makeStore()
         store.loadForDocument(pdfDocument(path: path, docId: docId))
+        // Join the load's attachment sweep, so what follows is the settled state
+        // rather than a window that closes when the sweep lands.
+        await drainAttachmentSweeps()
 
         XCTAssertFalse(exists(DocumentDataStore.documentDir(forKey: pathKey)),
                        "old fallback folder must be gone")
-        XCTAssertEqual(DocumentDataStore.loadScratchpad(forKey: docId), "carried note")
-        XCTAssertTrue(exists(
-            DocumentDataStore.attachmentsDir(forKey: docId).appendingPathComponent("ab.jpg")))
-        XCTAssertEqual(store.text, "carried note")
+        XCTAssertEqual(DocumentDataStore.loadScratchpad(forKey: docId), note)
+        XCTAssertTrue(
+            exists(DocumentDataStore.attachmentsDir(forKey: docId)
+                .appendingPathComponent("ab.jpg")),
+            "the rekey carried the referenced attachment across and the sweep spared it")
+        XCTAssertEqual(store.text, "carried note ![x](vellum-scratchpad://ab)")
     }
 
     func testRekeyMergesNewestWinsOnCollision() throws {
@@ -481,7 +515,7 @@ final class DocumentDataStoreTests: XCTestCase {
         let placeholder = WebICloud.placeholderURL(for: DocumentDataStore.scratchpadPath(forKey: key))
         try Data("stub".utf8).write(to: placeholder)
 
-        let store = ScratchpadStore()
+        let store = makeStore()
         store.loadForDocument(doc)
         XCTAssertTrue(store.isPersistencePaused, "an evicted note pauses persistence")
         XCTAssertNotNil(store.dropWarning, "a banner explains why editing is paused")
@@ -510,7 +544,7 @@ final class DocumentDataStoreTests: XCTestCase {
         let doc = pdfDocument(path: "/tmp/del-\(UUID().uuidString).pdf")
         let key = DocumentIdentity.storageKey(for: doc)
 
-        let store = ScratchpadStore()
+        let store = makeStore()
         store.loadForDocument(doc)
         store.text = "important note"
         store.flush()  // persist synchronously
@@ -554,7 +588,7 @@ final class DocumentDataStoreTests: XCTestCase {
 
         // The pane holds an unsaved edit with a debounced save ARMED (didSet
         // schedules a 400 ms write). This is the pre-import in-memory state.
-        let store = ScratchpadStore()
+        let store = makeStore()
         store.loadForDocument(doc)
         store.text = "stale"   // schedules a save targeting `key`
 

--- a/Tests/DocumentDataStoreTests.swift
+++ b/Tests/DocumentDataStoreTests.swift
@@ -12,7 +12,9 @@ final class DocumentDataStoreTests: XCTestCase {
     private var legacyPool: URL!
     /// Every `ScratchpadStore` a test built, so teardown can join the background
     /// attachment sweeps they started before the scratch tree is torn down — no
-    /// sweep may outlive the test that armed it (#100).
+    /// sweep may outlive the test that armed it (#100). Sweeps chain per store,
+    /// so joining each store's latest covers every sweep it armed, including on
+    /// the tests that load a document more than once.
     private var stores: [ScratchpadStore] = []
 
     override func setUp() async throws {
@@ -297,13 +299,18 @@ final class DocumentDataStoreTests: XCTestCase {
         // carried one across a rekey actually looks like: an attachment no note
         // points at is an orphan, and the sweep every load ends in is right to
         // collect it, so requiring it to survive would pin a value that only
-        // holds until that sweep lands (#100).
-        let note = "carried note ![x](attachments/ab.jpg)"
+        // holds until that sweep lands (#100). The id has to be a real one —
+        // both ref rewrites only recognise `[0-9a-fA-F-]+`, so a prose filename
+        // would silently stop counting as a reference and the sweep would reap
+        // the file again.
+        let attachmentId = "00000000-0000-0000-0000-0000000000ab"
+        let attachmentFile = "\(attachmentId).jpg"
+        let note = "carried note ![x](attachments/\(attachmentFile))"
         try DocumentDataStore.saveScratchpad(forKey: pathKey, text: note)
         let fallbackAttachments = DocumentDataStore.attachmentsDir(forKey: pathKey)
         try FileManager.default.createDirectory(
             at: fallbackAttachments, withIntermediateDirectories: true)
-        try Data([1]).write(to: fallbackAttachments.appendingPathComponent("ab.jpg"))
+        try Data([1]).write(to: fallbackAttachments.appendingPathComponent(attachmentFile))
 
         let store = makeStore()
         store.loadForDocument(pdfDocument(path: path, docId: docId))
@@ -316,9 +323,9 @@ final class DocumentDataStoreTests: XCTestCase {
         XCTAssertEqual(DocumentDataStore.loadScratchpad(forKey: docId), note)
         XCTAssertTrue(
             exists(DocumentDataStore.attachmentsDir(forKey: docId)
-                .appendingPathComponent("ab.jpg")),
+                .appendingPathComponent(attachmentFile)),
             "the rekey carried the referenced attachment across and the sweep spared it")
-        XCTAssertEqual(store.text, "carried note ![x](vellum-scratchpad://ab)")
+        XCTAssertEqual(store.text, "carried note ![x](vellum-scratchpad://\(attachmentId))")
     }
 
     func testRekeyMergesNewestWinsOnCollision() throws {

--- a/Vellum/Stores/ScratchpadStore.swift
+++ b/Vellum/Stores/ScratchpadStore.swift
@@ -103,6 +103,14 @@ final class ScratchpadStore {
     private var isRestoring = false
     private var saveTask: Task<Void, Never>?
     @ObservationIgnored private var dropWarningTask: Task<Void, Never>?
+    /// The in-flight background attachment sweep, if any (see
+    /// `pruneOrphanedAttachments`). Production never waits on it — the sweep is
+    /// best-effort and must not delay a document open — but keeping the handle
+    /// instead of dropping it makes the sweep awaitable, so a test can join it
+    /// rather than race it. A fire-and-forget sweep is what made the rekey
+    /// coverage flake (#100): it deleted the very attachment the test was about
+    /// to assert on, whenever the background task won.
+    @ObservationIgnored private(set) var attachmentSweepTask: Task<Void, Never>?
 
     /// Capture the note and every referenced attachment before clearing. If any
     /// referenced byte cannot be read, fail closed: leaving the note untouched
@@ -413,7 +421,7 @@ final class ScratchpadStore {
         // would be deleted out from under the note. Collect only against files
         // that already existed when the snapshot was taken.
         let referencedAsOf = Date()
-        Task.detached(priority: .utility) {
+        attachmentSweepTask = Task.detached(priority: .utility) {
             ScratchpadAttachmentStore.collectGarbage(
                 in: dir, referencedIds: referenced, referencedAsOf: referencedAsOf)
         }

--- a/Vellum/Stores/ScratchpadStore.swift
+++ b/Vellum/Stores/ScratchpadStore.swift
@@ -103,13 +103,12 @@ final class ScratchpadStore {
     private var isRestoring = false
     private var saveTask: Task<Void, Never>?
     @ObservationIgnored private var dropWarningTask: Task<Void, Never>?
-    /// The in-flight background attachment sweep, if any (see
-    /// `pruneOrphanedAttachments`). Production never waits on it — the sweep is
-    /// best-effort and must not delay a document open — but keeping the handle
-    /// instead of dropping it makes the sweep awaitable, so a test can join it
-    /// rather than race it. A fire-and-forget sweep is what made the rekey
-    /// coverage flake (#100): it deleted the very attachment the test was about
-    /// to assert on, whenever the background task won.
+    /// The tail of this store's chain of background attachment sweeps (see
+    /// `pruneOrphanedAttachments`). Kept rather than dropped so the sweep is
+    /// joinable: production never waits on it — it is best-effort and must not
+    /// delay a document open — but a test can join it instead of racing it
+    /// (#100). Each sweep awaits its predecessor, so this one handle covers
+    /// every sweep the store has armed.
     @ObservationIgnored private(set) var attachmentSweepTask: Task<Void, Never>?
 
     /// Capture the note and every referenced attachment before clearing. If any
@@ -421,7 +420,13 @@ final class ScratchpadStore {
         // would be deleted out from under the note. Collect only against files
         // that already existed when the snapshot was taken.
         let referencedAsOf = Date()
+        // Chain onto the previous sweep rather than running alongside it: two
+        // sweeps interleaving over one directory is pointless work, and it keeps
+        // `attachmentSweepTask` a handle on ALL of this store's sweeps, not just
+        // the latest — a document can be loaded more than once.
+        let previous = attachmentSweepTask
         attachmentSweepTask = Task.detached(priority: .utility) {
+            await previous?.value
             ScratchpadAttachmentStore.collectGarbage(
                 in: dir, referencedIds: referenced, referencedAsOf: referencedAsOf)
         }


### PR DESCRIPTION
Closes #100

## Root cause — the filed hypothesis was wrong

#100 guessed this was intra-suite: an unawaited GC sweep from an alphabetically-earlier test bleeding into `testRekeyMovesFallbackFolderToStampedKey`. It isn't. The test was racing **its own store**.

`ScratchpadStore.restore(document:)` ends *every* document load with `pruneOrphanedAttachments()`, which dispatched the sweep via `Task.detached` and threw the handle away. The test seeded `attachments/ab.jpg` alongside a note reading `"carried note"` — which references no attachment. So `ab.jpg` was an orphan by the GC's own definition, and collecting it was **correct behaviour**. The assert only passed when the main thread beat the background task.

That also explains the exact reported symptom: the assert above it (old fallback folder is gone) passed, because the folder really did move; the attachment was deleted afterwards.

### Reproduction evidence (proof, not inference)

Inserting a 500 ms sleep after `loadForDocument` makes it fail **running alone**:

```
xcodebuild test ... -only-testing:VellumTests/DocumentDataStoreTests/testRekeyMovesFallbackFolderToStampedKey
Tests/DocumentDataStoreTests.swift:288: error: XCTAssertTrue failed
** TEST FAILED **
```

Running alone rules out any earlier test being involved. The reviewer independently confirmed the supporting filesystem fact: `rekey` runs before `touch`, so the destination folder doesn't exist yet and `moveOrMergeDirectory` takes the plain `fm.moveItem` path — and a POSIX rename preserves both mtime and birthtime, so the `referencedAsOf` grace in `collectGarbage` cannot spare the moved file. **The deletion is deterministic once the sweep runs; only the scheduling was racy.**

The intra-suite hypothesis is refuted structurally too: `pruneOrphanedAttachments` resolves `activeDirectory` to an absolute URL *before* dispatching, and every test gets a fresh `vellum-docstore-<UUID>` root, so a leaked sweep holds a URL under its own already-deleted tree and cannot reach a later test's files under any scheduling.

## Fix

**Production (`ScratchpadStore`, 15 lines, behaviour-preserving).** Keep the sweep's `Task` handle instead of dropping it, so it can be *joined* rather than raced. Production never awaits it — the sweep is best-effort and must not delay a document open. Sweeps also chain (each awaits its predecessor), so one handle covers every sweep a store armed, and two sweeps can no longer interleave over the same directory. This mirrors the existing `AiPersistence.pendingFlush` / `awaitPendingFlush()` seam already used by `SafeClearTests`.

**Tests.** The suite routes stores through `makeStore()` and `tearDown` drains their sweeps, so none outlives the test that armed it. `testRekeyMovesFallbackFolderToStampedKey` now seeds a note that actually **references** the attachment — what a document that carried one across a rekey really looks like — and joins the sweep before asserting.

No assertion was loosened and no test was reordered. The rewritten test is strictly stronger: the old `XCTAssertEqual(store.text, "carried note")` was a passthrough, while the new expectation also pins the `relativeToScheme` rewrite. It still catches the original failure mode — if the rekey failed to carry the file, the note reads back empty and the `exists` assert fails.

## Reviewer findings (fresh-context opus, adversarial)

Confirmed the diagnosis and re-verified it independently. Two real defects, both fixed in 65601e8:

1. **The stated invariant was false.** `attachmentSweepTask` was *overwritten* on each load, so joining it covered only the newest sweep — but three tests in this suite load twice. The comment promised a guarantee the code didn't provide, which is exactly how the flake returns. Fixed by chaining sweeps so the single handle genuinely covers all of them.
2. **The fixture's immunity silently depended on `ab` being hex.** Both ref rewrites only recognise `[0-9a-fA-F-]+`, so renaming the file to anything prose-like (`img.jpg`) would have stopped it counting as a reference and reintroduced the flake — under a comment claiming immunity. Fixed with a real UUID-shaped id plus a note saying why.

Non-blocking notes accepted as-is: exposing the handle is consistent with existing shipped seams (`rootDirectoryOverride`, `directoryOverride`); Swift 6 isolation is clean (`Task` is Sendable, both types are `@MainActor`, so the drain suspends without holding the actor).

## Verification

Keychain guard confirmed intact (4 env/class disjuncts + the UI-test flag) before running. Clean build, warnings-as-errors on, zero new warnings.

- **Before review fixes:** 3/3 consecutive green full-suite runs.
- **After review fixes:** 4 consecutive green full-suite runs, **471 XCTest tests, 0 failures** each.
- One run in between aborted mid-run with no final summary. Not this change: `DocumentDataStoreTests` passed inside it (25/25), and its log is full of `mach_vm_allocate() failed` and WebKit process-assertion errors — three *other* `xcodebuild test` runs of this same project were executing concurrently from sibling worktrees, all sharing one bundle id. (That shared-state hazard is the subject of #102.)
- **Mutation checks**, both caught:
  - revert the seed to `"carried note"` → fails deterministically in 0.24 s (no race), proving the drain now orders the sweep;
  - make `collectGarbage` ignore `referencedIds` → fails, proving the assertion genuinely pins sweep-sparing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Other flakes reported in the same suites — a DIFFERENT cause

Three further intermittent failures were observed by other agents during unrelated full-suite runs (each re-ran green). Checking them against this root cause:

| Observed failure | Explained by this fix? |
| --- | --- |
| `DocumentDataStoreTests.testRekeyMovesFallbackFolderToStampedKey` | **Yes** — this PR. |
| `DocumentDataStoreTests.testLazyMigrationCopiesSharedAttachmentForSecondNote` (4 asserts in one run) | **No** — different mechanism, see below. |
| `StorageManagementTests.testAiLegacyListAndRemove` | **No** — same different mechanism. |
| WebKit content-process crash-restarts (sidebar drop suite; `WebStorageLocationTests.testPrettyLayoutDirectories` with a `mach_vm_allocate` failure) | **No** — observed, not addressed. |

I deliberately am not stretching this fix over the other two. The attachment sweep is not involved in either: `testLazyMigrationCopiesSharedAttachmentForSecondNote` never constructs a `ScratchpadStore`, so no sweep is ever armed in it, and a sweep leaked from an earlier test holds an absolute URL under that test's own already-deleted temp root.

**Their actual mechanism is #102's, not this one.** Both suites drive migration coverage through `ScratchpadPersistence.notesKey`, which on `main` lives in `UserDefaults.standard` — the developer's real domain, shared by every concurrently running test host:

- `Tests/DocumentDataStoreTests.swift:126` seeds it, `:30` deletes it in `tearDown`
- `Tests/StorageManagementTests.swift:369` seeds it, `:23` deletes it in `setUp`

So one suite's setUp/teardown wipes the key another suite's test just seeded — which is exactly what "4 asserts failed at once, re-ran green" looks like. That is fixed on the `fix-test-seams` branch (#102), which routes the legacy blob through `AppDefaults` so it lands in a per-process scratch domain. Corroborating evidence: the real `com.vellum.app` recents list on this machine currently holds `/tmp/safe-clear-*.pdf` and `/tmp/safe-note-*.pdf` entries written by unseamed test runs.

The WebKit crash-restarts are process-level, not state-level, and are not addressed here. I saw the same family directly while verifying this PR: with several `xcodebuild test` runs of this project executing concurrently from sibling worktrees, one run aborted mid-suite with `mach_vm_allocate() failed` and WebKit process-assertion errors, and another attributed a failure to `testSchemeToRelativeHandlesEmojiBeforeRef` — a pure string function with no I/O, defaults, or concurrency, which cannot fail on logic grounds. Treat host-abort failures under parallel load as environmental unless they reproduce alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment cleanup reliability by ensuring background cleanup operations run sequentially.
  * Prevented overlapping cleanup tasks from causing inconsistent attachment states.
  * Improved handling of attachment preservation and reference updates during document rekeying.

* **Tests**
  * Expanded coverage for attachment cleanup completion, carry-over, and reference rewriting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->