### PR TITLE
Expand inspector switcher hit targets to full segment

### DIFF
--- a/Vellum/Views/Shared/InspectorTabSwitcher.swift
+++ b/Vellum/Views/Shared/InspectorTabSwitcher.swift
@@ -122,20 +122,29 @@ struct InspectorTabSwitcher: View {
                         selection = tab
                     }
                 } label: {
-                    if showTitles {
-                        Label(tab.title, systemImage: tab.systemImage)
-                            .labelStyle(.titleAndIcon)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.85)
-                    } else {
-                        Label(tab.title, systemImage: tab.systemImage)
-                            .labelStyle(.iconOnly)
+                    Group {
+                        if showTitles {
+                            Label(tab.title, systemImage: tab.systemImage)
+                                .labelStyle(.titleAndIcon)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.85)
+                        } else {
+                            Label(tab.title, systemImage: tab.systemImage)
+                                .labelStyle(.iconOnly)
+                        }
                     }
+                    // `.buttonStyle(.plain)` hit-tests a macOS button against
+                    // its label's own rendered content, not against any
+                    // frame/contentShape chained onto the Button itself —
+                    // that outer chain (the previous placement) only affects
+                    // layout. Expanding and shaping the hit target here,
+                    // inside the label, is what actually grows the clickable
+                    // region to the full pill instead of just the glyph.
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(isSelected ? .primary : .secondary)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .contentShape(Rectangle())
                 .background {
                     if isSelected {
                         Capsule()


### PR DESCRIPTION
## Bug

In the right inspector panel, the three-way tab switcher (annotations = highlighter icon, AI = sparkles, scratchpad = note.text) only responded to clicks placed exactly on the icon glyph. Clicking anywhere else within a segment's visible pill area did nothing.

## Root cause

In `Vellum/Views/Shared/InspectorTabSwitcher.swift`, `segmentedControl(showTitles:)` built each segment as:

```swift
Button { ... } label: { Label(...).labelStyle(.iconOnly) }
  .buttonStyle(.plain)
  .foregroundStyle(...)
  .frame(maxWidth: .infinity, maxHeight: .infinity)
  .contentShape(Rectangle())
  .background { ... }
```

`.frame` and `.contentShape` were chained onto the `Button` wrapper *after* `.buttonStyle(.plain)`. On macOS, a `.plain`-style button hit-tests against its label's own rendered content, not against frame/contentShape applied outside the label — the outer chain affected layout (how much space the button claimed in the HStack) but not what the button actually hit-tests against. For an icon-only label, that meant the clickable region was just the glyph's bounding box.

## Fix

Moved `.frame(maxWidth: .infinity, maxHeight: .infinity)` and `.contentShape(Rectangle())` inside the label closure (frame first, then contentShape), applied to a shared `Group` wrapper so both the titled (`showTitles: true`) and icon-only branches are covered. The selected-segment capsule background and all accessibility modifiers are unchanged and stay outside on the `Button`.

The `.menu` fallback path (`compactMenu`, used at very narrow inspector widths) uses `.menuStyle(.borderlessButton)`, which is backed by a single clickable control rather than per-item plain buttons, so it doesn't share this failure mode and needed no change.

## Verification

- `xcodebuild -project Vellum.xcodeproj -scheme Vellum -destination 'platform=macOS' build` — succeeds.
- `xcodebuild test ... -only-testing:VellumTests/InspectorTabSwitcherTests` — all 7 tests pass (these cover layout thresholds and accessibility identifiers, unaffected by this change).
- Visually confirmed via screenshot that the selected-segment capsule background renders identically to before (no visual regression).
- I attempted live interactive click verification (both via a macOS UI-driving tool and a throwaway XCUITest), but this dev machine currently has multiple other automated agents concurrently launching/driving their own Vellum builds on the same desktop session, which caused window loss, focus theft mid-click, and even a canceled system authentication dialog during the UI test run. I confirmed this was pure environmental contention, not a signal about the fix, by re-running an untouched pre-existing UI test (`testDragCropAddsAttachmentToNote`) — it failed identically under the same contention. I did not want to draw a conclusion about the fix from a broken test environment, so I'm relying on the build, the passing unit tests, and the code-level reasoning above (a standard, well-documented SwiftUI pattern for expanding `.plain` button hit targets on macOS). Recommend a manual click-through pass once the shared machine is less contested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)