### PR TITLE
Unblock main thread in document open/close paths

### DIFF
--- a/Tests/DocumentActionsTests.swift
+++ b/Tests/DocumentActionsTests.swift
@@ -226,6 +226,83 @@ final class DocumentActionsTests: XCTestCase {
         XCTAssertFalse(app.isCurrentWebDocument(identity))
     }
 
+    /// The reopen-races-teardown guard must work ACROSS panes. Teardowns are
+    /// registered workspace-wide: a close in one pane — here one that also
+    /// collapses that pane, discarding its AppStore — must still park an
+    /// immediate reopen of the same file from another pane until the close's
+    /// last_page rewrite has landed. With per-pane tracking the reopen sailed
+    /// through: it read the pre-teardown bytes (stale reading position) and
+    /// anything it wrote was clobbered by the teardown's atomic rename.
+    func testReopenInAnotherPaneWaitsOutCollapsedPanesTeardown() async throws {
+        let file = tempDirectory.appendingPathComponent("Shared.pdf")
+        makePDF(at: file, pages: 4)
+
+        let gate = GatedMetadataSessionService()
+        let workspace = WorkspaceStore(sessions: gate)
+        let paneA = workspace.focusedPane
+        await paneA.app.openFile(path: file.path)
+        let tabId = try XCTUnwrap(paneA.app.activeTabId)
+        paneA.app.setCurrentPage(3)
+
+        workspace.splitFocused(.horizontal)
+        let paneB = workspace.focusedPane
+        XCTAssertNotEqual(paneA.id, paneB.id)
+
+        // Park the teardown's last_page write at the gate, then close pane A's
+        // only tab. The pane collapses, so only the workspace registry still
+        // knows a teardown holds this file.
+        gate.holdNextMetadataWrite()
+        await paneA.app.closeTab(tabId)
+        XCTAssertNil(workspace.root.leaf(id: paneA.id))
+        await gate.waitUntilHeld()
+
+        let reopen = Task { await paneB.app.openFile(path: file.path) }
+        for _ in 0..<50 { await Task.yield() }
+        XCTAssertNil(paneB.app.document, "the reopen must wait for the pending teardown")
+
+        gate.release()
+        await reopen.value
+        XCTAssertEqual(Self.normalized(paneB.app.document?.pdfPath), Self.normalized(file.path))
+        XCTAssertEqual(
+            paneB.app.currentPage, 3,
+            "the reopen must observe the teardown's last_page write, not pre-teardown bytes")
+    }
+
+    /// ⌘Q right after a close that collapsed its pane: the quit path used to
+    /// drain teardowns per leaf, and a collapsed pane has no leaf left to ask —
+    /// its pending write was silently abandoned. The registry outlives the pane
+    /// and the quit path drains it directly.
+    func testQuitDrainCoversTeardownWhosePaneCollapsed() async throws {
+        let file = tempDirectory.appendingPathComponent("Collapsing.pdf")
+        makePDF(at: file, pages: 5)
+
+        let gate = GatedMetadataSessionService()
+        let workspace = WorkspaceStore(sessions: gate)
+        let paneA = workspace.focusedPane
+        await paneA.app.openFile(path: file.path)
+        let tabId = try XCTUnwrap(paneA.app.activeTabId)
+        paneA.app.setCurrentPage(4)
+        workspace.splitFocused(.horizontal)
+
+        gate.holdNextMetadataWrite()
+        await paneA.app.closeTab(tabId)
+        XCTAssertNil(workspace.root.leaf(id: paneA.id))
+        await gate.waitUntilHeld()
+
+        // The orphaned teardown must remain reachable workspace-wide.
+        XCTAssertFalse(workspace.tabTeardowns.isEmpty)
+
+        gate.release()
+        await workspace.tabTeardowns.awaitAll()
+        XCTAssertTrue(workspace.tabTeardowns.isEmpty)
+
+        // The drain returned only after the write landed on disk.
+        let verified = try await gate.inner.openFile(
+            path: file.path, sessionId: "verify-last-page")
+        XCTAssertEqual(verified.lastPage, 4)
+        try await gate.inner.closeFile(sessionId: "verify-last-page")
+    }
+
     /// The session backend reports the filesystem's own path (/private/var/…)
     /// while `FileManager.temporaryDirectory` hands back the /var symlink form,
     /// and Foundation's standardization maps the former onto the latter. Compare
@@ -309,4 +386,102 @@ private final class StubSessionService: SessionService {
     func deleteAnnotation(sessionId: String, id: String) async throws -> Bool { false }
     func setDocumentMetadata(sessionId: String, key: String, value: String) async throws {}
     func ensureDocumentId(sessionId: String) async throws -> String { documentId }
+}
+
+/// The real session manager with one seam: `holdNextMetadataWrite()` parks the
+/// next `setDocumentMetadata` until `release()`, standing in for the ~15s
+/// last_page rewrite of a large PDF so the teardown-race tests can hold a
+/// close's teardown open deterministically.
+@MainActor
+private final class GatedMetadataSessionService: SessionService {
+    let inner = DocumentSessionManager()
+
+    private var holdNextWrite = false
+    private var heldWrites: [CheckedContinuation<Void, Never>] = []
+    private var arrivalWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func holdNextMetadataWrite() { holdNextWrite = true }
+
+    /// Suspends until a gated metadata write has arrived and is parked.
+    func waitUntilHeld() async {
+        if !heldWrites.isEmpty { return }
+        await withCheckedContinuation { arrivalWaiters.append($0) }
+    }
+
+    func release() {
+        holdNextWrite = false
+        let held = heldWrites
+        heldWrites = []
+        for continuation in held { continuation.resume() }
+    }
+
+    func setDocumentMetadata(sessionId: String, key: String, value: String) async throws {
+        if holdNextWrite {
+            holdNextWrite = false
+            await withCheckedContinuation { continuation in
+                heldWrites.append(continuation)
+                let waiters = arrivalWaiters
+                arrivalWaiters = []
+                for waiter in waiters { waiter.resume() }
+            }
+        }
+        try await inner.setDocumentMetadata(sessionId: sessionId, key: key, value: value)
+    }
+
+    func openFile(path: String, sessionId: String) async throws -> DocumentInfo {
+        try await inner.openFile(path: path, sessionId: sessionId)
+    }
+    func openWebDocument(url: String, sessionId: String) async throws -> DocumentInfo {
+        try await inner.openWebDocument(url: url, sessionId: sessionId)
+    }
+    func openVellumwebFile(path: String, sessionId: String) async throws -> DocumentInfo {
+        try await inner.openVellumwebFile(path: path, sessionId: sessionId)
+    }
+    func saveFile(sessionId: String) async throws {
+        try await inner.saveFile(sessionId: sessionId)
+    }
+    func closeFile(sessionId: String) async throws {
+        try await inner.closeFile(sessionId: sessionId)
+    }
+    func readPdfBytes(sessionId: String) async throws -> Data {
+        try await inner.readPdfBytes(sessionId: sessionId)
+    }
+    func setWebpageSaved(sessionId: String, saved: Bool) async throws {
+        try await inner.setWebpageSaved(sessionId: sessionId, saved: saved)
+    }
+    func getWebpageSaved(sessionId: String) async throws -> Bool {
+        try await inner.getWebpageSaved(sessionId: sessionId)
+    }
+    func listSavedWebpages() async throws -> [WebLibraryEntry] {
+        try await inner.listSavedWebpages()
+    }
+    func removeSavedWebpage(url: String) async throws {
+        try await inner.removeSavedWebpage(url: url)
+    }
+    func exportVellumweb(
+        sessionId: String, destPath: String, pages: [WebPageText]
+    ) async throws -> VellumwebExportSummary {
+        try await inner.exportVellumweb(sessionId: sessionId, destPath: destPath, pages: pages)
+    }
+    func archiveWebpageDefault(
+        sessionId: String, pages: [WebPageText], expectedUrl: String
+    ) async throws -> Bool {
+        try await inner.archiveWebpageDefault(
+            sessionId: sessionId, pages: pages, expectedUrl: expectedUrl)
+    }
+    func getAnnotations(sessionId: String, pageNumber: Int?) async throws -> [Annotation] {
+        try await inner.getAnnotations(sessionId: sessionId, pageNumber: pageNumber)
+    }
+    func createAnnotation(sessionId: String, input: CreateAnnotationInput) async throws -> Annotation {
+        try await inner.createAnnotation(sessionId: sessionId, input: input)
+    }
+    func updateAnnotation(sessionId: String, input: UpdateAnnotationInput) async throws -> Bool {
+        try await inner.updateAnnotation(sessionId: sessionId, input: input)
+    }
+    func deleteAnnotation(sessionId: String, id: String) async throws -> Bool {
+        try await inner.deleteAnnotation(sessionId: sessionId, id: id)
+    }
+    func ensureDocumentId(sessionId: String) async throws -> String {
+        try await inner.ensureDocumentId(sessionId: sessionId)
+    }
 }

--- a/Tests/VellumBundleTests.swift
+++ b/Tests/VellumBundleTests.swift
@@ -439,7 +439,7 @@ final class VellumBundleTests: XCTestCase {
 
     /// The core writes the document, stamps + resolves the key, and installs the
     /// sidecar — the whole import minus the NSSavePanel.
-    func testImportCoreWritesDocumentAndInstallsSidecar() throws {
+    func testImportCoreWritesDocumentAndInstallsSidecar() async throws {
         let real = makeRealPdfData()
         let docId = DocumentIdentity.byteHash(real)
         let content = VellumBundle.Content(
@@ -451,7 +451,7 @@ final class VellumBundleTests: XCTestCase {
         let imported = try VellumBundle.read(at: bundleURL)
 
         let dest = scratch.appendingPathComponent("core-written.pdf")
-        let result = try AppStore.importVellumBundleCore(imported, to: dest) { _ in .keepLocal }
+        let result = try await AppStore.importVellumBundleCore(imported, to: dest) { _ in .keepLocal }
 
         XCTAssertEqual(result.path, dest.path)
         XCTAssertTrue(result.failedAttachments.isEmpty)
@@ -465,7 +465,7 @@ final class VellumBundleTests: XCTestCase {
 
     /// Importing over an existing file replaces it atomically (temp + rename, no
     /// pre-delete) and leaves no temp sibling behind.
-    func testImportCoreAtomicallyReplacesExistingDestination() throws {
+    func testImportCoreAtomicallyReplacesExistingDestination() async throws {
         let dest = scratch.appendingPathComponent("existing.pdf")
         let oldBytes = Data("OLD CONTENT that must be replaced".utf8)
         try oldBytes.write(to: dest)
@@ -478,7 +478,7 @@ final class VellumBundleTests: XCTestCase {
         try VellumBundle.write(content, to: bundleURL)
         let imported = try VellumBundle.read(at: bundleURL)
 
-        _ = try AppStore.importVellumBundleCore(imported, to: dest) { _ in .keepLocal }
+        _ = try await AppStore.importVellumBundleCore(imported, to: dest) { _ in .keepLocal }
 
         XCTAssertNotNil(PdfMetadata.documentId(atPath: dest.path), "destination holds the imported PDF")
         XCTAssertNotEqual(try Data(contentsOf: dest), oldBytes)

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -41,7 +41,9 @@ final class VellumAppDelegate: NSObject, NSApplicationDelegate {
                     // A tab closed moments ago finishes its metadata write and
                     // session close behind the UI (AppStore.closeTab); it is no
                     // longer in `tabs`, so nothing else here would await it.
-                    for leaf in leaves { await leaf.app.awaitPendingTabTeardowns() }
+                    // Drained via the workspace registry, not per pane: a close
+                    // that collapsed its pane left no leaf to ask.
+                    await workspace.tabTeardowns.awaitAll()
                     await PageTextPersister.awaitInFlightFlushes()
                     await AiPersistence.awaitPendingFlush()
                     sender.reply(toApplicationShouldTerminate: true)
@@ -51,8 +53,10 @@ final class VellumAppDelegate: NSObject, NSApplicationDelegate {
             Task { @MainActor in
                 // Tabs closed moments ago finish their metadata write and
                 // session close behind the UI (AppStore.closeTab) and are no
-                // longer in `tabs`, so the loop below would miss them.
-                for leaf in leaves { await leaf.app.awaitPendingTabTeardowns() }
+                // longer in `tabs`, so the loop below would miss them. Drained
+                // via the workspace registry, not per pane: a close that
+                // collapsed its pane left no leaf to ask.
+                await workspace.tabTeardowns.awaitAll()
                 for leaf in leaves {
                     for tab in leaf.app.tabs {
                         try? await workspace.sessions.setDocumentMetadata(

--- a/Vellum/App/VellumApp.swift
+++ b/Vellum/App/VellumApp.swift
@@ -38,6 +38,10 @@ final class VellumAppDelegate: NSObject, NSApplicationDelegate {
                 // conversations.json / cache write always lands. Both awaits are
                 // no-ops when nothing is pending.
                 Task { @MainActor in
+                    // A tab closed moments ago finishes its metadata write and
+                    // session close behind the UI (AppStore.closeTab); it is no
+                    // longer in `tabs`, so nothing else here would await it.
+                    for leaf in leaves { await leaf.app.awaitPendingTabTeardowns() }
                     await PageTextPersister.awaitInFlightFlushes()
                     await AiPersistence.awaitPendingFlush()
                     sender.reply(toApplicationShouldTerminate: true)
@@ -45,6 +49,10 @@ final class VellumAppDelegate: NSObject, NSApplicationDelegate {
                 return .terminateLater
             }
             Task { @MainActor in
+                // Tabs closed moments ago finish their metadata write and
+                // session close behind the UI (AppStore.closeTab) and are no
+                // longer in `tabs`, so the loop below would miss them.
+                for leaf in leaves { await leaf.app.awaitPendingTabTeardowns() }
                 for leaf in leaves {
                     for tab in leaf.app.tabs {
                         try? await workspace.sessions.setDocumentMetadata(

--- a/Vellum/Models/PaneTree.swift
+++ b/Vellum/Models/PaneTree.swift
@@ -26,11 +26,12 @@ final class PaneModel: Identifiable {
     init(
         id: String = "pane-" + UUID().uuidString.lowercased(),
         sessions: SessionService,
+        teardowns: TabTeardownRegistry = TabTeardownRegistry(),
         openRouterCatalog: OpenRouterCatalog,
         chatgptAuth: ChatGPTAuth
     ) {
         self.id = id
-        let app = AppStore(sessions: sessions)
+        let app = AppStore(sessions: sessions, teardowns: teardowns)
         let annotations = AnnotationStore(app: app)
         let ai = AiStore()
         ai.app = app

--- a/Vellum/Services/Pdf/PdfSessionBackend.swift
+++ b/Vellum/Services/Pdf/PdfSessionBackend.swift
@@ -28,12 +28,23 @@ final class PdfSessionBackend {
             throw SessionServiceError.invalidDocument("Unsupported file type: .\(ext)")
         }
 
-        let canonical = try PdfDocumentLoader.canonicalize(path)
-        var isDirectory: ObjCBool = false
-        let exists = FileManager.default.fileExists(atPath: canonical, isDirectory: &isDirectory)
-        guard exists, !isDirectory.boolValue else {
-            throw SessionServiceError.invalidDocument("PDF path is not a file: \(canonical)")
-        }
+        // realpath(2) and stat(2) are BLOCKING syscalls. Running them here — on
+        // @MainActor, before the first `await` — put them on the main thread, so
+        // a slow, unmounted, or not-yet-materialized (iCloud placeholder) volume
+        // froze the entire UI for as long as the kernel took to answer. Every
+        // open funnels through this method (Open…, Recents, Save As, launch tab
+        // restore), which is exactly why a stalled volume made the whole home
+        // screen — filter chips included — stop responding. Resolve off the main
+        // actor, like the parse that follows.
+        let canonical = try await Task.detached(priority: .userInitiated) {
+            let canonical = try PdfDocumentLoader.canonicalize(path)
+            var isDirectory: ObjCBool = false
+            let exists = FileManager.default.fileExists(atPath: canonical, isDirectory: &isDirectory)
+            guard exists, !isDirectory.boolValue else {
+                throw SessionServiceError.invalidDocument("PDF path is not a file: \(canonical)")
+            }
+            return canonical
+        }.value
 
         let io = PdfDocumentIO(path: canonical)
         let info = try await io.open()

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -7,6 +7,79 @@ import UniformTypeIdentifiers
 // Tab + viewport state — port of src/stores/pdf-store.ts plus the shell-level
 // sidebar state from App.tsx. Action semantics mirror the zustand store 1:1.
 
+/// Closed tabs' in-flight teardowns, keyed by the closed tab id.
+///
+/// A close's teardown keeps rewriting its document long after the tab left the
+/// strip: the `last_page` metadata write is a read + parse + serialize +
+/// atomic rename of the whole PDF (~15s on a large document). Opening or
+/// writing that same file before the rename lands races it — the reopen reads
+/// stale bytes (wrong reading position), and the rename silently replaces
+/// anything written in the window (lost annotations, a clobbered Save As).
+///
+/// The registry is owned by the WORKSPACE and shared by every pane's AppStore,
+/// not kept per store, for two reasons:
+/// - every pane can open/save any file, so a reopen in pane B must see a
+///   teardown started by a close in pane A;
+/// - closing a split pane's last tab collapses the pane and drops its store,
+///   and the teardown must remain reachable — for the reopen guard and for the
+///   quit drain — after the store that started it is gone.
+@MainActor
+final class TabTeardownRegistry {
+    /// One in-flight teardown: the document path it will rewrite (the backend
+    /// stores canonical paths, so this one is canonical too) and the task
+    /// doing the rewriting.
+    private struct Entry {
+        let documentPath: String
+        let task: Task<Void, Never>
+    }
+
+    private var entries: [String: Entry] = [:]
+
+    /// True when no teardown is pending.
+    var isEmpty: Bool { entries.isEmpty }
+
+    func register(tabId: String, documentPath: String, task: Task<Void, Never>) {
+        entries[tabId] = Entry(documentPath: documentPath, task: task)
+    }
+
+    /// Called by each teardown task as its last step.
+    func finish(tabId: String) {
+        entries[tabId] = nil
+    }
+
+    /// Await every pending teardown. `applicationShouldTerminate` drains this
+    /// so quitting right after closing a tab still persists its reading
+    /// position — including a tab whose close collapsed its pane.
+    func awaitAll() async {
+        for entry in Array(entries.values) {
+            await entry.task.value
+        }
+    }
+
+    /// Await any pending teardown that still holds the file at `path`. Every
+    /// path that opens or writes a document file calls this first. The wait is
+    /// bounded by the teardown itself and only bites when the same file is
+    /// reused immediately; every other open stays instant.
+    func awaitTeardowns(ofDocumentAt path: String) async {
+        guard !entries.isEmpty else { return }
+        // Teardowns record canonical paths, so resolve the incoming path the
+        // same way for the comparison. realpath(2) is a blocking syscall —
+        // PR #113 exists to keep those off the main actor — so it runs
+        // detached. A path that fails to resolve (e.g. a Save As destination
+        // that does not exist yet, which also cannot collide with a file a
+        // teardown holds) is compared as given.
+        let canonical = await Task.detached(priority: .userInitiated) {
+            (try? PdfDocumentLoader.canonicalize(path)) ?? path
+        }.value
+        // Snapshot before awaiting: finished teardowns remove themselves from
+        // the dictionary, and new ones can register across suspension points.
+        let pending = entries.values.filter { $0.documentPath == canonical }
+        for entry in pending {
+            await entry.task.value
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class AppStore {
@@ -103,8 +176,14 @@ final class AppStore {
     /// has (issue #37 PR B).
     var flushPageTextCacheHandler: (() async -> Void)?
 
-    init(sessions: SessionService) {
+    /// Closed tabs' in-flight teardowns. Workspace-owned and shared by every
+    /// pane's store (see `TabTeardownRegistry`); standalone stores (tests) get
+    /// a private one.
+    private let teardowns: TabTeardownRegistry
+
+    init(sessions: SessionService, teardowns: TabTeardownRegistry = TabTeardownRegistry()) {
         self.sessions = sessions
+        self.teardowns = teardowns
     }
 
     // MARK: - Opening documents
@@ -472,56 +551,18 @@ final class AppStore {
 
     // MARK: - Closing / switching tabs
 
-    /// One closed tab's in-flight teardown: the document path it will rewrite
-    /// (the backend stores canonical paths, so this one is canonical too) and
-    /// the task doing the rewriting. The path is recorded so the open and save
-    /// paths can wait out a teardown that still holds the same file.
-    private struct TabTeardown {
-        let documentPath: String
-        let task: Task<Void, Never>
-    }
-
-    /// Teardown work for tabs that have already left `tabs`, keyed by the closed
-    /// tab id. Each task removes its own entry when it finishes.
-    private var tabTeardowns: [String: TabTeardown] = [:]
-
     /// Await every close still finishing its metadata write, text flush, and
     /// session close. `applicationShouldTerminate` drains this so quitting right
     /// after closing a tab still persists that tab's reading position.
     func awaitPendingTabTeardowns() async {
-        for teardown in Array(tabTeardowns.values) {
-            await teardown.task.value
-        }
+        await teardowns.awaitAll()
     }
 
-    /// Await any pending teardown that still holds the file at `path`.
-    ///
-    /// A close's teardown keeps rewriting its document long after the tab left
-    /// the strip: the `last_page` metadata write is a read + parse + serialize +
-    /// atomic rename of the whole PDF (~15s on a large document). Opening or
-    /// writing that same file before the rename lands races it — the reopen
-    /// reads stale bytes (wrong reading position), and the rename silently
-    /// replaces anything written in the window (lost annotations, a clobbered
-    /// Save As). So every path that opens or writes a document file calls this
-    /// first. The wait is bounded by the teardown itself and only bites when
-    /// the same file is reused immediately; every other open stays instant.
+    /// Await any pending teardown that still holds the file at `path` — in ANY
+    /// pane, not just this one. See `TabTeardownRegistry` for why the registry
+    /// is workspace-owned.
     private func awaitTeardowns(ofDocumentAt path: String) async {
-        guard !tabTeardowns.isEmpty else { return }
-        // Teardowns record canonical paths, so resolve the incoming path the
-        // same way for the comparison. realpath(2) is a blocking syscall —
-        // this whole PR exists to keep those off the main actor — so it runs
-        // detached. A path that fails to resolve (e.g. a Save As destination
-        // that does not exist yet, which also cannot collide with a file a
-        // teardown holds) is compared as given.
-        let canonical = await Task.detached(priority: .userInitiated) {
-            (try? PdfDocumentLoader.canonicalize(path)) ?? path
-        }.value
-        // Snapshot before awaiting: finished teardowns remove themselves from
-        // the dictionary, and new ones can register across suspension points.
-        let pending = tabTeardowns.values.filter { $0.documentPath == canonical }
-        for teardown in pending {
-            await teardown.task.value
-        }
+        await teardowns.awaitTeardowns(ofDocumentAt: path)
     }
 
     func closeFile() async {
@@ -556,19 +597,24 @@ final class AppStore {
             let workspace = self.workspace
             // ⌘Q immediately after a close must not lose the reading position:
             // the tab is already gone from `tabs`, so the quit path's per-tab
-            // metadata loop no longer covers it. The task registers itself for
-            // `awaitPendingTabTeardowns`, which quit drains, and records its
-            // document path so an immediate reopen or overwrite of the same
-            // file waits for it (see `awaitTeardowns(ofDocumentAt:)`).
-            tabTeardowns[tabId] = TabTeardown(
+            // metadata loop no longer covers it. The task registers itself in
+            // the workspace-wide teardown registry, which quit drains, and
+            // records its document path so an immediate reopen or overwrite of
+            // the same file — from any pane — waits for it. The registry (not
+            // `self`) is captured for the cleanup: closing a split pane's last
+            // tab collapses the pane and drops this store, and the entry must
+            // outlive it.
+            let teardowns = self.teardowns
+            teardowns.register(
+                tabId: tabId,
                 documentPath: closingDocument.pdfPath,
-                task: Task { [weak self, weak workspace] in
+                task: Task { [weak workspace] in
                     try? await sessions.setDocumentMetadata(
                         sessionId: tabId, key: "last_page", value: lastPage)
                     await runtime?.flushPdfText()
                     try? await sessions.closeFile(sessionId: tabId)
                     workspace?.removeLiveTabRuntime(for: tabId)
-                    self?.tabTeardowns[tabId] = nil
+                    teardowns.finish(tabId: tabId)
                 })
         } else {
             workspace?.removeLiveTabRuntime(for: tabId)

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -108,23 +108,69 @@ final class AppStore {
     }
 
     // MARK: - Opening documents
+    //
+    // `isLoading` disables EVERY open affordance on the home screen (Open a
+    // PDF…, search results, recents, the URL field). An open that never
+    // finished therefore used to lock the user out of opening anything at all,
+    // for the rest of the session, with nothing on screen explaining why. The
+    // helpers below make that impossible: an attempt owns the flag for a
+    // bounded time, and whatever happens the flag comes back.
 
-    func openFile(path: String) async {
+    /// How long an open may hold the home screen's loading state before the UI
+    /// is released and the delay surfaced. The work itself is NOT cancelled —
+    /// a slow volume that answers late still opens its document normally.
+    private static let openLoadingCeiling: Duration = .seconds(20)
+
+    /// Identifies the open attempt that currently owns `isLoading`, so a stale
+    /// attempt finishing late cannot clear a newer one's loading state.
+    private var openGeneration = 0
+    private var openWatchdog: Task<Void, Never>?
+
+    /// Take ownership of the loading state for one open attempt.
+    private func beginOpen() -> Int {
+        openGeneration += 1
+        let generation = openGeneration
         isLoading = true
         error = nil
+        openWatchdog?.cancel()
+        openWatchdog = Task { [weak self] in
+            try? await Task.sleep(for: Self.openLoadingCeiling)
+            guard !Task.isCancelled else { return }
+            self?.endOpen(
+                generation,
+                error: "Opening is taking longer than expected — the file may be on a slow or "
+                    + "disconnected volume. It will open if it becomes available.")
+        }
+        return generation
+    }
+
+    /// Release the loading state, if this attempt still owns it. Safe to call
+    /// more than once and from either the work or the watchdog.
+    private func endOpen(_ generation: Int, error message: String? = nil) {
+        guard generation == openGeneration, isLoading else { return }
+        isLoading = false
+        openWatchdog?.cancel()
+        openWatchdog = nil
+        if let message { error = message }
+    }
+
+    func openFile(path: String) async {
+        let generation = beginOpen()
+        defer { endOpen(generation) }
         do {
             try await openOneFile(path: path)
-            isLoading = false
+            // The watchdog may have already reported a delay; the open landed,
+            // so retract it rather than leaving a stale warning on screen.
+            if generation == openGeneration { error = nil }
         } catch {
-            isLoading = false
             self.error = String(describing: error.localizedDescription)
         }
     }
 
     func openFiles(paths: [String]) async {
         guard !paths.isEmpty else { return }
-        isLoading = true
-        error = nil
+        let generation = beginOpen()
+        defer { endOpen(generation) }
         var errors: [String] = []
         for path in paths {
             do {
@@ -133,20 +179,22 @@ final class AppStore {
                 errors.append("\(path): \(error.localizedDescription)")
             }
         }
-        isLoading = false
-        self.error = errors.isEmpty ? nil : errors.joined(separator: "\n")
+        if !errors.isEmpty {
+            self.error = errors.joined(separator: "\n")
+        } else if generation == openGeneration {
+            error = nil
+        }
     }
 
     func openUrl(_ url: String) async {
-        isLoading = true
-        error = nil
+        let generation = beginOpen()
+        defer { endOpen(generation) }
         do {
             let sessionId = UUID().uuidString.lowercased()
             let doc = try await sessions.openWebDocument(url: url, sessionId: sessionId)
             await adoptOpenedDocument(doc, sessionId: sessionId)
-            isLoading = false
+            if generation == openGeneration { error = nil }
         } catch {
-            isLoading = false
             self.error = error.localizedDescription
         }
     }
@@ -347,9 +395,16 @@ final class AppStore {
         // so stamp that fallback into the destination before reopening it. This
         // keeps its conversation/scratchpad identity continuous instead of
         // assigning a fresh id after the source becomes writable by copying.
-        if PdfMetadata.documentId(atPath: destinationURL.path) == nil {
-            try PdfMetadata.stampDocumentId(atPath: destinationURL.path, id: preservedDocumentId)
-        }
+        //
+        // Both calls are a full synchronous read + parse (+ atomic rewrite) of
+        // the copy, so they run off the main actor — on it they blocked the UI
+        // for the whole cost of the file, which is seconds on a large PDF.
+        let destinationPath = destinationURL.path
+        try await Task.detached(priority: .userInitiated) {
+            if PdfMetadata.documentId(atPath: destinationPath) == nil {
+                try PdfMetadata.stampDocumentId(atPath: destinationPath, id: preservedDocumentId)
+            }
+        }.value
 
         try await sessions.closeFile(sessionId: tabId)
         let rebound: DocumentInfo
@@ -414,27 +469,64 @@ final class AppStore {
 
     // MARK: - Closing / switching tabs
 
+    /// Teardown work for tabs that have already left `tabs`, keyed by the closed
+    /// tab id. Each task removes its own entry when it finishes.
+    private var tabTeardowns: [String: Task<Void, Never>] = [:]
+
+    /// Await every close still finishing its metadata write, text flush, and
+    /// session close. `applicationShouldTerminate` drains this so quitting right
+    /// after closing a tab still persists that tab's reading position.
+    func awaitPendingTabTeardowns() async {
+        for task in Array(tabTeardowns.values) {
+            await task.value
+        }
+    }
+
     func closeFile() async {
         if let activeTabId {
             await closeTab(activeTabId)
         }
     }
 
+    /// Close a tab and tear its backend session down.
+    ///
+    /// The tab leaves `tabs` — and therefore the tab strip — BEFORE any of the
+    /// teardown work runs. That work is a `last_page` metadata write, which is a
+    /// full read + parse + serialize + atomic rewrite of the PDF on the IO actor
+    /// (~15s on a large document), plus a page-text flush. Awaiting it first
+    /// meant the tab sat visibly in the strip for that whole time after the user
+    /// clicked ×, so closing looked broken. Ordering WITHIN the teardown is
+    /// unchanged and still matters: metadata (which changes the file's
+    /// validation hash) → text flush (re-keys the cache to the bytes that will
+    /// reopen) → session close → drop the runtime.
     func closeTab(_ tabId: String) async {
         guard let closingIndex = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let closingTab = tabs[closingIndex]
         // Start tabs carry no backend session — skip the metadata/close round
         // trips that would otherwise fire against a nonexistent session id.
         if closingTab.document != nil {
-            try? await sessions.setDocumentMetadata(
-                sessionId: closingTab.id, key: "last_page", value: String(closingTab.currentPage))
-            // Metadata rewrites the PDF and therefore its validation hash.
-            // Flush extraction after that rewrite and before dropping the
-            // runtime so the cache is keyed to the bytes that will reopen.
-            await workspace?.existingLiveTabRuntime(for: tabId)?.flushPdfText()
-            try? await sessions.closeFile(sessionId: closingTab.id)
+            let lastPage = String(closingTab.currentPage)
+            // Resolved now: the runtime is dropped from the workspace at the end
+            // of the teardown, and holding it here keeps it alive until its
+            // pending text has been flushed.
+            let runtime = workspace?.existingLiveTabRuntime(for: tabId)
+            let sessions = self.sessions
+            let workspace = self.workspace
+            // ⌘Q immediately after a close must not lose the reading position:
+            // the tab is already gone from `tabs`, so the quit path's per-tab
+            // metadata loop no longer covers it. The task registers itself for
+            // `awaitPendingTabTeardowns`, which quit drains.
+            tabTeardowns[tabId] = Task { [weak self, weak workspace] in
+                try? await sessions.setDocumentMetadata(
+                    sessionId: tabId, key: "last_page", value: lastPage)
+                await runtime?.flushPdfText()
+                try? await sessions.closeFile(sessionId: tabId)
+                workspace?.removeLiveTabRuntime(for: tabId)
+                self?.tabTeardowns[tabId] = nil
+            }
+        } else {
+            workspace?.removeLiveTabRuntime(for: tabId)
         }
-        workspace?.removeLiveTabRuntime(for: tabId)
 
         var remaining = tabs
         remaining.removeAll { $0.id == tabId }
@@ -494,8 +586,8 @@ final class AppStore {
         // a per-path lock, so duplicate live webpage sessions are safe.
         guard sourceDocument.kind == .web else { return }
 
-        isLoading = true
-        error = nil
+        let generation = beginOpen()
+        defer { endOpen(generation) }
         let sessionId = UUID().uuidString.lowercased()
         do {
             // Web only, per the guard above.
@@ -509,7 +601,6 @@ final class AppStore {
             // as an unexpected new tab; release the just-opened session.
             guard let currentSourceIndex = tabs.firstIndex(where: { $0.id == tabId }) else {
                 try? await sessions.closeFile(sessionId: sessionId)
-                isLoading = false
                 return
             }
             let duplicate = PdfTab(
@@ -530,7 +621,6 @@ final class AppStore {
         } catch {
             self.error = error.localizedDescription
         }
-        isLoading = false
     }
 
     func activateTab(_ tabId: String) {
@@ -951,7 +1041,7 @@ final class AppStore {
         }
         guard panel.runModal() == .OK, let destination = panel.url else { return nil }
 
-        let result = try Self.importVellumBundleCore(imported, to: destination) { title in
+        let result = try await Self.importVellumBundleCore(imported, to: destination) { title in
             let alert = NSAlert()
             alert.messageText = "Notes already exist for \(title)"
             alert.informativeText =
@@ -992,7 +1082,7 @@ final class AppStore {
         _ imported: VellumBundle.Imported,
         to destination: URL,
         resolveScratchpadConflict resolveConflict: (_ title: String) -> VellumBundle.ScratchpadDecision
-    ) throws -> (path: String, failedAttachments: [String]) {
+    ) async throws -> (path: String, failedAttachments: [String]) {
         let manifest = imported.manifest
         let kind: DocumentKind = manifest.kind == "web" ? .web : .pdf
 
@@ -1029,19 +1119,30 @@ final class AppStore {
         // writable). Best-effort: a stamp failure falls back to the prior
         // behavior — installing under manifest.docId — never failing the import.
         // Web bundles are never stamped (their identity is the URL hash).
-        if kind == .pdf, PdfMetadata.documentId(atPath: destination.path) == nil {
-            try? PdfMetadata.stampDocumentId(atPath: destination.path, id: manifest.docId)
-        }
-
-        // Resolve the install key. For a PDF, prefer the written file's own
-        // /VellumDocId stamp when it differs from the manifest (the file is
-        // authoritative). For web, the identity is the URL hash carried in the
-        // manifest.
+        //
+        // The stamp and the key resolution below are each a full synchronous
+        // read + parse of the just-written PDF (the stamp also rewrites it), so
+        // they share ONE hop off the main actor: on it they blocked the UI for
+        // the file's whole cost right after the save panel closed. Nothing here
+        // touches main-actor state, and no PDFKit/CGPDF value escapes the hop.
+        //
+        // Key resolution: for a PDF, prefer the written file's own /VellumDocId
+        // stamp when it differs from the manifest (the file is authoritative).
+        // For web, the identity is the URL hash carried in the manifest.
         let key: String
-        if kind == .pdf,
-           let raw = try? PdfDocumentLoader.loadRaw(path: destination.path),
-           let stamped = PdfMetadata.documentId(raw) {
-            key = stamped
+        if kind == .pdf {
+            let destinationPath = destination.path
+            let manifestId = manifest.docId
+            key = await Task.detached(priority: .userInitiated) {
+                if PdfMetadata.documentId(atPath: destinationPath) == nil {
+                    try? PdfMetadata.stampDocumentId(atPath: destinationPath, id: manifestId)
+                }
+                if let raw = try? PdfDocumentLoader.loadRaw(path: destinationPath),
+                   let stamped = PdfMetadata.documentId(raw) {
+                    return stamped
+                }
+                return manifestId
+            }.value
         } else {
             key = manifest.docId
         }

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -386,6 +386,9 @@ final class AppStore {
         await syncDocumentId(sessionId: tabId)
         try await sessions.saveFile(sessionId: tabId)
         let bytes = try await sessions.readPdfBytes(sessionId: tabId)
+        // Saving over a file whose tab was just closed: that close's teardown
+        // still holds the old bytes and would rename them over this write.
+        await awaitTeardowns(ofDocumentAt: destinationURL.path)
         try await Task.detached {
             try bytes.write(to: destinationURL, options: .atomic)
         }.value
@@ -469,16 +472,55 @@ final class AppStore {
 
     // MARK: - Closing / switching tabs
 
+    /// One closed tab's in-flight teardown: the document path it will rewrite
+    /// (the backend stores canonical paths, so this one is canonical too) and
+    /// the task doing the rewriting. The path is recorded so the open and save
+    /// paths can wait out a teardown that still holds the same file.
+    private struct TabTeardown {
+        let documentPath: String
+        let task: Task<Void, Never>
+    }
+
     /// Teardown work for tabs that have already left `tabs`, keyed by the closed
     /// tab id. Each task removes its own entry when it finishes.
-    private var tabTeardowns: [String: Task<Void, Never>] = [:]
+    private var tabTeardowns: [String: TabTeardown] = [:]
 
     /// Await every close still finishing its metadata write, text flush, and
     /// session close. `applicationShouldTerminate` drains this so quitting right
     /// after closing a tab still persists that tab's reading position.
     func awaitPendingTabTeardowns() async {
-        for task in Array(tabTeardowns.values) {
-            await task.value
+        for teardown in Array(tabTeardowns.values) {
+            await teardown.task.value
+        }
+    }
+
+    /// Await any pending teardown that still holds the file at `path`.
+    ///
+    /// A close's teardown keeps rewriting its document long after the tab left
+    /// the strip: the `last_page` metadata write is a read + parse + serialize +
+    /// atomic rename of the whole PDF (~15s on a large document). Opening or
+    /// writing that same file before the rename lands races it — the reopen
+    /// reads stale bytes (wrong reading position), and the rename silently
+    /// replaces anything written in the window (lost annotations, a clobbered
+    /// Save As). So every path that opens or writes a document file calls this
+    /// first. The wait is bounded by the teardown itself and only bites when
+    /// the same file is reused immediately; every other open stays instant.
+    private func awaitTeardowns(ofDocumentAt path: String) async {
+        guard !tabTeardowns.isEmpty else { return }
+        // Teardowns record canonical paths, so resolve the incoming path the
+        // same way for the comparison. realpath(2) is a blocking syscall —
+        // this whole PR exists to keep those off the main actor — so it runs
+        // detached. A path that fails to resolve (e.g. a Save As destination
+        // that does not exist yet, which also cannot collide with a file a
+        // teardown holds) is compared as given.
+        let canonical = await Task.detached(priority: .userInitiated) {
+            (try? PdfDocumentLoader.canonicalize(path)) ?? path
+        }.value
+        // Snapshot before awaiting: finished teardowns remove themselves from
+        // the dictionary, and new ones can register across suspension points.
+        let pending = tabTeardowns.values.filter { $0.documentPath == canonical }
+        for teardown in pending {
+            await teardown.task.value
         }
     }
 
@@ -504,7 +546,7 @@ final class AppStore {
         let closingTab = tabs[closingIndex]
         // Start tabs carry no backend session — skip the metadata/close round
         // trips that would otherwise fire against a nonexistent session id.
-        if closingTab.document != nil {
+        if let closingDocument = closingTab.document {
             let lastPage = String(closingTab.currentPage)
             // Resolved now: the runtime is dropped from the workspace at the end
             // of the teardown, and holding it here keeps it alive until its
@@ -515,15 +557,19 @@ final class AppStore {
             // ⌘Q immediately after a close must not lose the reading position:
             // the tab is already gone from `tabs`, so the quit path's per-tab
             // metadata loop no longer covers it. The task registers itself for
-            // `awaitPendingTabTeardowns`, which quit drains.
-            tabTeardowns[tabId] = Task { [weak self, weak workspace] in
-                try? await sessions.setDocumentMetadata(
-                    sessionId: tabId, key: "last_page", value: lastPage)
-                await runtime?.flushPdfText()
-                try? await sessions.closeFile(sessionId: tabId)
-                workspace?.removeLiveTabRuntime(for: tabId)
-                self?.tabTeardowns[tabId] = nil
-            }
+            // `awaitPendingTabTeardowns`, which quit drains, and records its
+            // document path so an immediate reopen or overwrite of the same
+            // file waits for it (see `awaitTeardowns(ofDocumentAt:)`).
+            tabTeardowns[tabId] = TabTeardown(
+                documentPath: closingDocument.pdfPath,
+                task: Task { [weak self, weak workspace] in
+                    try? await sessions.setDocumentMetadata(
+                        sessionId: tabId, key: "last_page", value: lastPage)
+                    await runtime?.flushPdfText()
+                    try? await sessions.closeFile(sessionId: tabId)
+                    workspace?.removeLiveTabRuntime(for: tabId)
+                    self?.tabTeardowns[tabId] = nil
+                })
         } else {
             workspace?.removeLiveTabRuntime(for: tabId)
         }
@@ -997,6 +1043,11 @@ final class AppStore {
     }
 
     private func openDocumentFile(path: String) async throws {
+        // Close-then-immediately-reopen: a teardown from a preceding close may
+        // still be rewriting this exact file. Opening before it lands would
+        // restore a stale reading position and lose any write the new session
+        // makes before the teardown's atomic rename.
+        await awaitTeardowns(ofDocumentAt: path)
         let sessionId = UUID().uuidString.lowercased()
         // .vellumweb archives import as web documents; everything else is a PDF.
         let isArchive = path.lowercased().hasSuffix(".vellumweb")
@@ -1040,6 +1091,12 @@ final class AppStore {
             panel.allowedContentTypes = [.pdf]
         }
         guard panel.runModal() == .OK, let destination = panel.url else { return nil }
+
+        // The core writes the bundle's document bytes to `destination` before
+        // `openDocumentFile` (and its own teardown guard) ever runs. If the
+        // user picked a file whose tab was just closed, wait out that close's
+        // teardown here so its rename cannot clobber the imported bytes.
+        await awaitTeardowns(ofDocumentAt: destination.path)
 
         let result = try await Self.importVellumBundleCore(imported, to: destination) { title in
             let alert = NSAlert()

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -21,6 +21,11 @@ final class WorkspaceStore {
 
     let sessions: SessionService
 
+    /// Closed tabs' in-flight teardowns, shared by every pane's AppStore so a
+    /// reopen or Save As in one pane waits out a close started in another —
+    /// including a pane that has since collapsed. Quit drains it directly.
+    let tabTeardowns = TabTeardownRegistry()
+
     /// The layout tree. Reassigned wholesale on every structural change.
     private(set) var root: PaneNode
     /// Id of the focused leaf — drives the toolbar, inspector, and menu commands.
@@ -237,7 +242,9 @@ final class WorkspaceStore {
         self.openRouterCatalog = catalog
         self.chatgptAuth = auth
         self.settingsAi = settingsAi
-        let pane = PaneModel(sessions: sessions, openRouterCatalog: catalog, chatgptAuth: auth)
+        let pane = PaneModel(
+            sessions: sessions, teardowns: tabTeardowns,
+            openRouterCatalog: catalog, chatgptAuth: auth)
         self.root = .leaf(pane)
         self.focusedPaneId = pane.id
         // `self` is fully initialized now: give the pane its workspace back-ref.
@@ -337,7 +344,8 @@ final class WorkspaceStore {
 
     private func makePane(startTab: Bool) -> PaneModel {
         let pane = PaneModel(
-            sessions: sessions, openRouterCatalog: openRouterCatalog, chatgptAuth: chatgptAuth)
+            sessions: sessions, teardowns: tabTeardowns,
+            openRouterCatalog: openRouterCatalog, chatgptAuth: chatgptAuth)
         pane.app.workspace = self
         if startTab { pane.app.newStartTab() }
         return pane


### PR DESCRIPTION
## Symptoms

Opening and closing documents felt sluggish, opening sometimes silently did nothing, and while that was happening even Home's filter chips (PDFs / Webpages / Saved) stopped responding.

## Root causes

All four are main-thread stalls on the open/close paths.

**A1 — the primary one.** `PdfSessionBackend.open(path:sessionId:)` is `@MainActor` and ran `PdfDocumentLoader.canonicalize(path)` (a raw `realpath()`) plus `FileManager.fileExists(atPath:isDirectory:)` (a `stat()`) *before its first `await`* — so both blocking syscalls ran on the main thread. On a slow, unmounted, or not-yet-materialized iCloud-placeholder volume that freezes the entire UI for as long as the kernel takes to answer. Every open funnels through this method (`openDocumentFile`, `WelcomeScreen.open`, `restoreTabs`, `savePdfAs`), which is exactly why unrelated home-screen controls went dead at the same time.

**A2.** `AppStore.savePdfAs` and `AppStore.importVellumBundleCore` called `PdfMetadata.documentId(atPath:)` / `PdfMetadata.stampDocumentId(atPath:)` — a full synchronous PDF read + parse (+ atomic rewrite) — directly on the main actor.

**A3.** `closeTab` awaited `sessions.setDocumentMetadata` (read + parse + serialize + atomic write on the IO actor; the code's own comments note ~15s on large PDFs) and `flushPdfText()` **before** removing the tab from the `tabs` array the tab strip renders. The tab visibly hung around after the user clicked ×. `activateTab` already fires its equivalent metadata write fire-and-forget.

**A4.** `AppStore.isLoading` gates *every* open affordance on Home (`Open a PDF`, search results, recents, the URL field). A wedged open left it `true` forever with no error surfaced — a silent lockout of all opens for the rest of the session.

## Fixes

- **A1** — canonicalization + existence check moved into a `Task.detached(priority: .userInitiated)`, so `open()` reaches its first suspension without touching the disk on the main thread.
- **A2** — both call sites hop off the main actor via `Task.detached`, matching the pattern already used in this file (`renameDocument`, the Save As byte write). In `importVellumBundleCore` the stamp *and* the subsequent `loadRaw` key resolution share one hop; no PDFKit/CGPDF value escapes it. The function becomes `async`; its two tests are updated.
- **A3** — the tab leaves `tabs` immediately; teardown runs in a trailing task with the ordering that matters preserved: metadata write → page-text flush → `closeFile` → drop the live runtime. Teardowns are tracked per tab, and `applicationShouldTerminate` now drains them (`awaitPendingTabTeardowns`) so ⌘Q immediately after a close still persists `last_page` — the quit path's per-tab loop no longer covers a tab that has already left `tabs`.
- **A4** — each open attempt takes the loading flag under a generation token and releases it via `defer` on every path (including the early return in `duplicateTab`). A 20s watchdog releases the flag and surfaces a user-visible message if the work has not landed. The work itself is never cancelled — a slow volume that answers late still opens its document, and the warning is retracted when it does. A stale attempt finishing late can no longer clear a newer attempt's loading state.

## Verification

Build: `xcodebuild -project Vellum.xcodeproj -scheme Vellum -destination 'platform=macOS' build` succeeds warning-free (the target builds with `SWIFT_TREAT_WARNINGS_AS_ERRORS`).

Tests: 88 tests across `PaneTreeTests`, `DocumentActionsTests`, `VellumBundleTests`, `PdfPersistenceTests`, `DocumentIdentityTests`, and `HighlightResizeTests` — 0 failures.

Runtime (built app driven through the accessibility API):

| Check | Result |
|---|---|
| Open a 12-page PDF | tab appears **0.3s** after the open event; document renders (page 1/12) |
| Close the tab (×) | tab is gone from the strip in **0.2s** |
| New tab → Home | Home renders in **0.4s** |
| PDFs filter chip | applies immediately; list filters to PDFs, chip highlights |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reopening, saving, importing, or duplicating documents while recently closed panes are still finishing cleanup.
  * Ensured quitting waits for pending tab cleanup and persistence operations to complete.
  * Preserved the latest page position when closing and reopening documents.
  * Reduced main-window interruptions during PDF opening, saving, and bundle importing.
  * Added clearer feedback when opening a document takes unusually long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->