### PR TITLE
Stop repeated Documents access prompts (stable signing + security-scoped bookmarks)

### DIFF
--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		290AF491B1EFDE622262DCD7 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1784468C7F465AAEB5C63E9 /* Models.swift */; };
 		29224D491ACDF76C81E58473 /* WelcomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E282C555B1B420914134C74 /* WelcomeScreen.swift */; };
 		295053CF2F22E8765D18B315 /* KaTeX_Main-Italic.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = C283744BF352A2D7CDB6FB52 /* KaTeX_Main-Italic.woff2 */; };
+		29757DBD2CB38B5DF2FA8DE3 /* SecurityScopedBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4352F4BA23CA855F4267806D /* SecurityScopedBookmark.swift */; };
 		2A30A8B49C2A710A8CBB0008 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 73294273D1991135AD0F100E /* index.html */; };
 		2E35DAA98C4A45A551382874 /* PaneTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 524641B76B46DE4D791F4E6A /* PaneTreeTests.swift */; };
 		2F52BBA445E0EE94526EC6E5 /* editor.bundle.js in Resources */ = {isa = PBXBuildFile; fileRef = 88261ED7614D2528C41ED0E5 /* editor.bundle.js */; };
@@ -248,6 +249,7 @@
 		3E8AC4A486031931558B1541 /* HelpCenterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCenterView.swift; sourceTree = "<group>"; };
 		3E954582457ABFF5574EC93C /* tool-descriptions.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "tool-descriptions.md"; sourceTree = "<group>"; };
 		3F26F0ACC6F7B4DFEA39EB78 /* HomeSearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchEngineTests.swift; sourceTree = "<group>"; };
+		4352F4BA23CA855F4267806D /* SecurityScopedBookmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityScopedBookmark.swift; sourceTree = "<group>"; };
 		43D27ECCD653EDD01DC2A624 /* ComposerReferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerReferences.swift; sourceTree = "<group>"; };
 		43F3FC8BBC540C8F18FE3B31 /* StorageInventory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageInventory.swift; sourceTree = "<group>"; };
 		460DC0522689EC17EC0D233B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -575,6 +577,7 @@
 				D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */,
 				D82487970E20F6628200C4BE /* KeychainStore.swift */,
 				7E4C07C56943274B9E062A70 /* RecentFilesService.swift */,
+				4352F4BA23CA855F4267806D /* SecurityScopedBookmark.swift */,
 				7280818785023514C87C04C9 /* SessionService.swift */,
 				4FA50A523F4D87396EC11A8B /* StorageHousekeeping.swift */,
 				4E69330A4F460353FBCB25AB /* TabResidency.swift */,
@@ -915,7 +918,17 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					15BDAAE9AA57BC95F9AD6FBB = {
+						DevelopmentTeam = 9DCG97VASG;
+						ProvisioningStyle = Automatic;
+					};
+					65E775B7223FE8550067535A = {
+						DevelopmentTeam = 9DCG97VASG;
+						ProvisioningStyle = Automatic;
+					};
 					F0B1727997018498FA5D9430 = {
+						DevelopmentTeam = 9DCG97VASG;
+						ProvisioningStyle = Automatic;
 						TestTargetID = 15BDAAE9AA57BC95F9AD6FBB;
 					};
 				};
@@ -1073,6 +1086,7 @@
 				016BFAA281D7CA51CCED4B92 /* ScratchpadPanel.swift in Sources */,
 				AF8BDBA91282CA03F019C0F5 /* ScratchpadPersistence.swift in Sources */,
 				74FEEDFFEA81B37C496C03F7 /* ScratchpadStore.swift in Sources */,
+				29757DBD2CB38B5DF2FA8DE3 /* SecurityScopedBookmark.swift in Sources */,
 				9E702B90F8729B9145F7D31B /* SelectableMessageText.swift in Sources */,
 				CCD31E1E8A71BB0E987EC90B /* SelectionPopover.swift in Sources */,
 				47362B3C5DF753594BDEC3E9 /* SentReferenceChips.swift in Sources */,
@@ -1218,11 +1232,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 9DCG97VASG;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1401,11 +1416,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 9DCG97VASG;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -1484,11 +1500,12 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 9DCG97VASG;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;

--- a/Vellum/Models/Models.swift
+++ b/Vellum/Models/Models.swift
@@ -138,6 +138,14 @@ struct DocumentInfo: Codable, Equatable, Sendable {
     /// open. Class-B/C stores resolve their storage key from this via
     /// DocumentIdentity.
     var docId: String? = nil
+    /// Security-scoped bookmark for `pdfPath` (PDFs only), minted the moment the
+    /// document is opened while read access is guaranteed. Defense-in-depth
+    /// alongside stable code signing: durably grants access to files outside
+    /// the app's own container so a relaunch can regain access to a restored
+    /// tab without depending solely on TCC's per-identity grant. Optional so
+    /// data written before this field existed (or web docs, which never carry
+    /// one) decodes cleanly; readers must fall back to `pdfPath` when nil.
+    var bookmarkData: Data? = nil
 
     enum CodingKeys: String, CodingKey {
         case kind
@@ -146,6 +154,7 @@ struct DocumentInfo: Codable, Equatable, Sendable {
         case pageCount = "page_count"
         case lastPage = "last_page"
         case docId = "doc_id"
+        case bookmarkData = "bookmark_data"
     }
 }
 

--- a/Vellum/Services/SecurityScopedBookmark.swift
+++ b/Vellum/Services/SecurityScopedBookmark.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+// Durable, out-of-container file access for PDFs opened via the panel, a
+// Finder drop/double-click, or restored from a saved tab. This app is not
+// sandboxed (ENABLE_APP_SANDBOX: NO), so these bookmarks are defense-in-depth
+// rather than a hard requirement: the primary fix for repeated "Vellum wants
+// access to your Documents folder" prompts is a stable code-signing identity
+// (see project.yml), since TCC grants persist per identity across relaunches.
+// Bookmarks add resilience — if the app is ever sandboxed, or a TCC grant is
+// ever revoked, a resolved bookmark can still regain access to a restored
+// tab without a fresh picker round-trip. Every operation here is best-effort
+// and never throws: callers always have the raw path to fall back to.
+enum SecurityScopedBookmark {
+    /// Mint a security-scoped bookmark for `url`. Must be called while the app
+    /// already has read access (right after a successful open) — minting is
+    /// what fails silently for locations that can't be bookmarked (some
+    /// network volumes, already-unreachable paths, etc.).
+    static func make(for url: URL) -> Data? {
+        try? url.bookmarkData(
+            options: [.withSecurityScope],
+            includingResourceValuesForKeys: nil,
+            relativeTo: nil)
+    }
+
+    /// Convenience overload for the raw paths `DocumentInfo`/`AppStore` pass
+    /// around.
+    static func make(forPath path: String) -> Data? {
+        make(for: URL(fileURLWithPath: path))
+    }
+
+    struct Resolved {
+        let url: URL
+        /// True when the bookmark's saved path no longer matches disk (the
+        /// file moved/renamed but bookmark resolution could still follow it).
+        /// Callers should mint a fresh bookmark from `url` when this is set.
+        let isStale: Bool
+    }
+
+    /// Resolve a previously stored bookmark back to a URL. Returns nil if the
+    /// bookmark can't be resolved at all (deleted file, unreachable volume,
+    /// corrupted data) — callers fall back to the last known raw path.
+    static func resolve(_ data: Data) -> Resolved? {
+        var isStale = false
+        guard let url = try? URL(
+            resolvingBookmarkData: data,
+            options: [.withSecurityScope],
+            relativeTo: nil,
+            bookmarkDataIsStale: &isStale
+        ) else { return nil }
+        return Resolved(url: url, isStale: isStale)
+    }
+}

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -352,14 +352,18 @@ final class AppStore {
         }
 
         try await sessions.closeFile(sessionId: tabId)
-        let rebound: DocumentInfo
+        var rebound: DocumentInfo
         do {
             rebound = try await sessions.openFile(path: destinationURL.path, sessionId: tabId)
+            // Fresh bookmark for the new location — the old one (if any) still
+            // points at sourceURL.
+            rebound.bookmarkData = SecurityScopedBookmark.make(for: destinationURL)
         } catch let reopenError {
             do {
                 // The original file is untouched, and a successful rollback
                 // restores the exact live tab rather than stranding it.
-                let restored = try await sessions.openFile(path: sourceURL.path, sessionId: tabId)
+                var restored = try await sessions.openFile(path: sourceURL.path, sessionId: tabId)
+                restored.bookmarkData = SecurityScopedBookmark.make(for: sourceURL)
                 updateTab(tabId) { $0.document = restored }
                 if activeTabId == tabId {
                     document = restored
@@ -619,7 +623,26 @@ final class AppStore {
                             url: savedDocument.pdfPath, sessionId: sessionId)
                     }
                 } else {
-                    opened = try await sessions.openFile(path: savedDocument.pdfPath, sessionId: sessionId)
+                    // Resolve a stored bookmark before falling back to the raw
+                    // path — see SecurityScopedBookmark. Access only needs to
+                    // stay open for the duration of the read that opens the
+                    // file; PDFKit/CGPDF have finished parsing what they need
+                    // by the time `openFile` returns.
+                    var resolvedPath = savedDocument.pdfPath
+                    var resolvedURL: URL?
+                    var bookmarkNeedsRefresh = false
+                    if let bookmarkData = savedDocument.bookmarkData,
+                       let resolved = SecurityScopedBookmark.resolve(bookmarkData) {
+                        resolvedPath = resolved.url.path
+                        resolvedURL = resolved.url
+                        bookmarkNeedsRefresh = resolved.isStale
+                    }
+                    let accessStarted = resolvedURL?.startAccessingSecurityScopedResource() ?? false
+                    defer { if accessStarted { resolvedURL?.stopAccessingSecurityScopedResource() } }
+                    opened = try await sessions.openFile(path: resolvedPath, sessionId: sessionId)
+                    opened.bookmarkData = bookmarkNeedsRefresh || savedDocument.bookmarkData == nil
+                        ? SecurityScopedBookmark.make(forPath: resolvedPath)
+                        : savedDocument.bookmarkData
                 }
                 // Preserve a title learned by the prior web session until the
                 // re-opened page reports a newer document title.
@@ -1070,6 +1093,13 @@ final class AppStore {
     }
 
     private func adoptOpenedDocument(_ doc: DocumentInfo, sessionId: String) async {
+        var doc = doc
+        // Mint a security-scoped bookmark right now, while the just-completed
+        // open guarantees read access — see SecurityScopedBookmark. Web docs
+        // have no filesystem path to bookmark.
+        if doc.kind == .pdf {
+            doc.bookmarkData = SecurityScopedBookmark.make(forPath: doc.pdfPath)
+        }
         RecentFilesService.record(doc)
         // Was the active tab a start tab? If so, opening a document from it
         // replaces that tab in place rather than appending a new one. Track it

--- a/project.yml
+++ b/project.yml
@@ -17,8 +17,19 @@ settings:
     SWIFT_VERSION: "6.0"
     SWIFT_STRICT_CONCURRENCY: minimal
     MACOSX_DEPLOYMENT_TARGET: "26.0"
-    CODE_SIGN_IDENTITY: "-"
-    CODE_SIGNING_REQUIRED: "NO"
+    # Ad-hoc signing ("-") mints a fresh, anonymous code identity on every
+    # build. macOS TCC keys its Documents/Desktop/Downloads access grants to
+    # that identity, so every rebuild looked like a brand-new app and
+    # re-prompted for folder access. Signing with a real Apple Development
+    # identity + team keeps the identity stable across rebuilds so TCC's
+    # grant sticks. Team 9DCG97VASG (ayush.deolasee@icloud.com) matches the
+    # identity already used by the other Vellum worktrees (ipad-app,
+    # apple-pencil-on-webpages) and other active local projects — swap
+    # DEVELOPMENT_TEAM to PXY5MW3W8Q (pypdeveloper@deolasee.org) if you'd
+    # rather sign with that identity instead.
+    CODE_SIGN_IDENTITY: "Apple Development"
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: 9DCG97VASG
     DEAD_CODE_STRIPPING: "YES"
 schemes:
   # The default scheme's test action stays exactly what it was: the hosted unit


### PR DESCRIPTION
## Summary

Dev builds of Vellum keep re-prompting "Vellum wants access to your Documents folder" — one prompt per rebuild, across 54+ DerivedData builds. Two causes, addressed here:

**Primary — ad-hoc signing.** `project.yml` set `CODE_SIGN_IDENTITY: "-"` / `CODE_SIGNING_REQUIRED: "NO"`. Ad-hoc signing mints a fresh, anonymous code identity on every build (confirmed: the built app had `Signature=adhoc`, no `TeamIdentifier`). macOS TCC keys its Documents/Desktop/Downloads grants to the app's code identity, so every rebuild looked like a brand-new, never-before-seen app and re-prompted.

**Secondary (defense-in-depth) — no security-scoped bookmarks.** The app persisted only raw file paths for tab restore (`TabDescriptor`/`DocumentInfo.pdfPath`, `AppStore.restoreTabs`) and never used `bookmarkData`/`startAccessingSecurityScopedResource` (zero prior usages in the codebase). Fine once the identity is stable, but brittle — a revoked TCC grant or a future move to a sandboxed build would silently regress to raw-path opens with no durable grant to fall back on.

## Changes

- **`project.yml`**: sign with `CODE_SIGN_IDENTITY: "Apple Development"` + `CODE_SIGN_STYLE: Automatic` + `DEVELOPMENT_TEAM: 9DCG97VASG`, dropping `CODE_SIGNING_REQUIRED: "NO"`. Regenerated `Vellum.xcodeproj` via `xcodegen generate`.
- **`Vellum/Services/SecurityScopedBookmark.swift`** (new): best-effort helpers to mint (`make(for:)`) and resolve (`resolve(_:)`) security-scoped bookmarks. Every operation is non-throwing — callers always have the raw path to fall back to.
- **`Vellum/Models/Models.swift`**: `DocumentInfo.bookmarkData: Data?` — optional (`bookmark_data` in JSON) so existing saved workspaces / recents decode unchanged.
- **`Vellum/Stores/AppStore.swift`**:
  - `adoptOpenedDocument` mints a bookmark for every opened PDF the moment read access is guaranteed (covers the open-panel, Finder drop/double-click, and `.vellum` bundle import paths — they all funnel through here).
  - `savePdfAs` mints a fresh bookmark for the new destination (and for the rollback path, if reopening the new location fails).
  - `restoreTabs` resolves a stored bookmark before falling back to the raw path, calls `startAccessingSecurityScopedResource()` around the reopen, and refreshes the bookmark if it comes back stale.

## Verification

- `xcodegen generate` — regenerated cleanly, no errors.
- `xcodebuild -project Vellum.xcodeproj -scheme Vellum -destination 'platform=macOS' clean build` — **BUILD SUCCEEDED**, no compiler warnings.
- `codesign -dv` on the built app now shows:
  ```
  TeamIdentifier=9DCG97VASG
  ```
  (previously unset/adhoc).
- Full `VellumTests` suite: **147 tests / 22 suites, 0 failures** (includes `PaneTreeTests.testWorkspaceStateRoundTrips` for `TabDescriptor`/`DocumentInfo` Codable back-compat, and `RecentsResolveTests`).

## Test plan

- [ ] Delete the app's existing TCC grant (`tccutil reset SystemPolicyDocumentsFolder com.vellum.app` or via System Settings ▸ Privacy & Security), do a couple of clean rebuilds from Xcode, and confirm the Documents prompt only appears once (not on every rebuild).
- [ ] Open a PDF from Documents, quit and relaunch Vellum, confirm the tab restores without a fresh prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)