### PR TITLE
Fix crash when adding a webpage

### DIFF
--- a/UITests/VellumConsistencyUITests.swift
+++ b/UITests/VellumConsistencyUITests.swift
@@ -56,6 +56,28 @@ final class VellumConsistencyUITests: VellumUITestCase {
         XCTAssertEqual(tabs.count, initialTabCount + 1)
     }
 
+    /// `AddWebpageSheet` reads `@Environment(AppStore.self)`, and the `.sheet`
+    /// presenting it was chained AFTER ContentView's `.environment(focused.app)`
+    /// write. Modifiers compose outside-in, so the presentation sat above that
+    /// write, resolved no `AppStore`, and SwiftUI trapped the instant the sheet
+    /// appeared — clicking "Add Webpage" killed the app. Only presenting the
+    /// sheet catches this: it is view-tree wiring with no non-UI seam.
+    func testAddWebpageFromHomePresentsUrlSheet() {
+        let app = makeApp()
+        app.launch()
+
+        let addWebpage = app.buttons["welcome.addWebpage"].firstMatch
+        XCTAssertTrue(addWebpage.waitForExistence(timeout: 8))
+        addWebpage.tap()
+
+        XCTAssertTrue(
+            app.textFields["addWebpage.urlField"].waitForExistence(timeout: 5),
+            "Add Webpage must present its URL sheet, not trap on a missing AppStore")
+        XCTAssertEqual(
+            app.state, .runningForeground,
+            "The app must survive presenting the Add Webpage sheet")
+    }
+
     func testCorruptedRestorationRecoversToUsableHome() {
         let app = makeApp(corruptRestoration: true)
         app.launch()

--- a/Vellum/App/ContentView.swift
+++ b/Vellum/App/ContentView.swift
@@ -20,6 +20,15 @@ struct ContentView: View {
         // inside WindowChrome's own body would leave the toolbar without an
         // AppStore. Each pane's subtree re-injects its own triple, overriding this.
         WindowChrome(sidebarHovering: $sidebarHovering)
+            // BEFORE the `.environment` writes below, so those writes are applied
+            // OUTSIDE this presentation and the sheet's content inherits them.
+            // Modifiers compose outside-in: a `.sheet` chained *after* an
+            // `.environment` sits above it, so `AddWebpageSheet`'s
+            // `@Environment(AppStore.self)` would find nothing and SwiftUI would
+            // trap the moment the sheet is presented.
+            .sheet(isPresented: $addWebpagePresented) {
+                AddWebpageSheet()
+            }
             .environment(focused.app)
             .environment(focused.annotations)
             .environment(focused.ai)
@@ -27,9 +36,6 @@ struct ContentView: View {
             .task { await workspace.restoreFromDisk() }
             .onReceive(NotificationCenter.default.publisher(for: .vellumAddWebpage)) { _ in
                 addWebpagePresented = true
-            }
-            .sheet(isPresented: $addWebpagePresented) {
-                AddWebpageSheet()
             }
             // Commands belong to the main window, not whichever nested
             // PDFKit/WebKit/AppKit responder happens to own keyboard focus.

--- a/Vellum/Views/PDF/ToolbarView.swift
+++ b/Vellum/Views/PDF/ToolbarView.swift
@@ -107,6 +107,7 @@ struct AddWebpageSheet: View {
                 .font(.system(size: 13))
                 .focused($fieldFocused)
                 .onSubmit(submit)
+                .accessibilityIdentifier("addWebpage.urlField")
             HStack {
                 Spacer()
                 Button("Cancel", role: .cancel) { dismiss() }


### PR DESCRIPTION
## Bug

Clicking **Add Webpage** on Home killed the app instantly. Same for the two other entry points that post the same `.vellumAddWebpage` notification: ⌘L (`File ▸ Add Webpage…`) and the tab-bar `+ ▸ Open Webpage…` item.

No `.ips` crash report is generated for this — it is a Swift runtime trap that `ReportCrash` did not capture on this machine, so it only shows up on the app's stderr.

## Crashing frame

```
SwiftUICore/Environment+Objects.swift:34: Fatal error: No Observable object of
type AppStore found. A View.environmentObject(_:) for AppStore may be missing
as an ancestor of this view.
```

Captured by running the app with stderr redirected to a file and pressing `welcome.addWebpage` via the accessibility API.

## Root cause

`AddWebpageSheet` (`Vellum/Views/PDF/ToolbarView.swift`) reads `@Environment(AppStore.self)`. In `ContentView.body` the `.sheet` presenting it was chained **after** the `.environment(focused.app)` write:

```swift
WindowChrome(sidebarHovering: $sidebarHovering)
    .environment(focused.app)        // inner
    …
    .sheet(isPresented: $addWebpagePresented) {   // outer
        AddWebpageSheet()
    }
```

SwiftUI composes modifiers outside-in, so the last-applied modifier is the **outermost**. The presentation node therefore sat *above* the environment writes and its content inherited none of them. `AppStore` resolved to nothing and SwiftUI trapped the moment the sheet was presented.

Nothing else covered for it: `AppStore` is injected only here and inside each pane's own subtree — never at the scene level in `VellumApp`. The sheets that do work are either inside a pane subtree (`TabBarView`, `WelcomeScreen`) or use scene-level environment only.

## Fix

Move `.sheet` so it is applied to `WindowChrome` **before** the `.environment` writes. Those writes are then applied outside the presentation, so the sheet's content inherits them.

This is the structural fix rather than a local guard, and it:
- preserves the existing deliberate invariant that the store-triple stays an ancestor of `WindowChrome`'s `.toolbar`/`.inspector` declarations (both are hosted separately and only see ancestor environment);
- means any future sheet added at this level inherits the environment for free.

Also adds an `addWebpage.urlField` accessibility identifier so the sheet is a durable automation target.

## Test

Added `VellumConsistencyUITests.testAddWebpageFromHomePresentsUrlSheet`: from a fresh Home, tap `welcome.addWebpage` and assert the URL sheet appears and the app is still running.

It lives in the XCUITest target on purpose — this is view-tree wiring with no non-UI seam. `WorkspaceService` has no storage-root override, so `restoreFromDisk()` (which also re-saves) means mounting `ContentView` in a hosted unit test would clobber the developer's real workspace state. `VellumUITests` already exists precisely for deterministic, isolated launches.

Per `UITests/README.md` the XCUITests drive the real desktop and must not be run unattended, so this one was **not executed** here; it is verified to compile (`xcodebuild build-for-testing -scheme VellumUITests` → `TEST BUILD SUCCEEDED`).

## Verification

- `xcodebuild -scheme Vellum -destination 'platform=macOS' build` → **BUILD SUCCEEDED**, warning-free.
- `xcodebuild build-for-testing -scheme VellumUITests` → **TEST BUILD SUCCEEDED**, warning-free.
- Reproduced the crash on the pre-fix build: pressing `welcome.addWebpage` → process dead in under 2s with the fatal error above.
- On the fixed build: the sheet presents, the app stays alive, stderr is clean, and submitting `https://example.com` runs `AppStore.openUrl` and opens a web tab titled "Example Domain".

🤖 Generated with [Claude Code](https://claude.com/claude-code)