### PR TITLE
Exempt just-written attachments from scratchpad GC

### DIFF
--- a/Tests/SafeClearTests.swift
+++ b/Tests/SafeClearTests.swift
@@ -17,6 +17,15 @@ final class SafeClearTests: XCTestCase {
         // as well as releasing them on the way out — this suite must not inherit
         // an attachment directory from whatever ran before it.
         ScratchpadAttachmentStore.activeDirectory = nil
+        // The pending-attachment registry and its grace period are process-global
+        // for the same reason. The grace period is the one that matters — a test
+        // here sets it to 0, and leaving it there would stop every later suite's
+        // freshly written attachment from being exempt — so capture the real
+        // value rather than asserting a literal. Clearing the registry is defence
+        // in depth: its keys are UUIDs, so a leftover entry cannot match anything
+        // another test creates.
+        savedGracePeriod = ScratchpadAttachmentStore.pendingGracePeriod
+        ScratchpadAttachmentStore.resetPending()
         sessions = SafeClearSessionService()
         app = AppStore(sessions: sessions)
     }
@@ -26,8 +35,12 @@ final class SafeClearTests: XCTestCase {
         DocumentDataStore.rootDirectoryOverride = nil
         ScratchpadAttachmentStore.directoryOverride = nil
         ScratchpadAttachmentStore.activeDirectory = nil
+        ScratchpadAttachmentStore.resetPending()
+        ScratchpadAttachmentStore.pendingGracePeriod = savedGracePeriod
         try? FileManager.default.removeItem(at: root)
     }
+
+    private var savedGracePeriod: TimeInterval = 60
 
     private func open(_ path: String) async -> DocumentInfo {
         await app.openFile(path: path)
@@ -193,6 +206,99 @@ final class SafeClearTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: stampedAttachment.path))
         XCTAssertFalse(DocumentDataStore.scratchpadExists(forKey: oldKey))
         XCTAssertFalse(FileManager.default.fileExists(atPath: oldAttachment.path))
+    }
+
+    // MARK: - Attachment GC vs. an in-flight markdown reference (#105)
+
+    /// Drop an image and hold its markdown in flight — exactly what the editor's
+    /// WebView round trip does — then return the store, the captured markdown,
+    /// and the file the bytes landed in.
+    private func dropImageHoldingItsReference(
+        _ store: ScratchpadStore
+    ) throws -> (markdown: String, id: String, attachment: URL) {
+        var inFlight: String?
+        store.insertMarkdownHandler = { inFlight = $0 }
+        store.addImage(
+            ScratchpadImageCapture(
+                data: Data([0x89, 0x50, 0x4e, 0x47, 9, 9, 9]), fileExtension: "png",
+                mediaType: "image/png", width: 1, height: 1, pageNumber: nil),
+            label: "Image")
+        let markdown = try XCTUnwrap(inFlight, "addImage must produce a reference to insert")
+        let id = try XCTUnwrap(ScratchpadAttachmentStore.referencedIds(in: markdown).first)
+        let attachment = try XCTUnwrap(ScratchpadAttachmentStore.fileURL(for: id))
+        XCTAssertTrue(
+            store.text.isEmpty,
+            "precondition: the reference has not reached the note yet")
+        return (markdown, id, attachment)
+    }
+
+    private func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+
+    /// The bytes are written before the markdown reference exists. A debounced
+    /// save landing in that window computes a reference set that is genuinely
+    /// current and genuinely does not mention the new attachment, so #104's
+    /// snapshot cutoff cannot tell it from an orphan — the file is older than
+    /// the sweep, not newer. Marking it pending at write time is what keeps it.
+    func testAttachmentSurvivesASaveFiredBeforeItsReferenceLands() async throws {
+        let store = ScratchpadStore()
+        store.app = app
+        store.loadForDocument(await open("/tmp/pending-gc-\(UUID().uuidString).pdf"))
+        let dropped = try dropImageHoldingItsReference(store)
+
+        // The debounced save fires inside the window.
+        store.flush()
+        XCTAssertTrue(
+            exists(dropped.attachment),
+            "an attachment whose reference is still in flight must not be collected")
+
+        // The round trip completes; the note now points at it.
+        store.text = dropped.markdown
+        store.flush()
+        XCTAssertTrue(exists(dropped.attachment))
+    }
+
+    /// The exemption is not permanent. Once the reference has been observed in
+    /// saved text the attachment is settled, and from then on ordinary
+    /// reachability governs it: deleting the reference collects the bytes.
+    func testSettledAttachmentIsCollectedOnceItsReferenceIsRemoved() async throws {
+        let store = ScratchpadStore()
+        store.app = app
+        store.loadForDocument(await open("/tmp/pending-settle-\(UUID().uuidString).pdf"))
+        let dropped = try dropImageHoldingItsReference(store)
+
+        // Reference lands and is saved — this is what settles it.
+        store.text = dropped.markdown
+        store.flush()
+        XCTAssertTrue(exists(dropped.attachment))
+
+        // The user deletes the image from the note.
+        store.text = "no image here"
+        store.flush()
+        XCTAssertFalse(
+            exists(dropped.attachment),
+            "a settled attachment the note no longer references is ordinary garbage")
+    }
+
+    /// If the reference never arrives, the exemption lapses and the next sweep
+    /// collects the bytes. The window is deliberately generous (a minute against
+    /// a round trip of a couple of frames) because the two failure modes are not
+    /// symmetric: an exemption held too long only delays a collection that will
+    /// still happen, while one released too early deletes bytes the note is
+    /// about to point at and leaves a broken image.
+    func testPendingExemptionLapsesSoAnAbandonedAttachmentIsStillCollected() async throws {
+        ScratchpadAttachmentStore.pendingGracePeriod = 0
+        let store = ScratchpadStore()
+        store.app = app
+        store.loadForDocument(await open("/tmp/pending-lapse-\(UUID().uuidString).pdf"))
+        let dropped = try dropImageHoldingItsReference(store)
+
+        // The reference never lands — the editor went away mid-round-trip.
+        store.flush()
+        XCTAssertFalse(
+            exists(dropped.attachment),
+            "an attachment past its grace period is collectable like any orphan")
     }
 
     func testEmptyClearsAreNoOps() {

--- a/Tests/ScratchpadImportTests.swift
+++ b/Tests/ScratchpadImportTests.swift
@@ -25,6 +25,10 @@ final class ScratchpadImportTests: XCTestCase {
     override func tearDown() async throws {
         ScratchpadAttachmentStore.directoryOverride = nil
         ScratchpadAttachmentStore.activeDirectory = nil
+        // This suite calls `addImage`, which claims a GC exemption for each id it
+        // writes (#105). Harmless if it leaks — the keys are UUIDs — but the
+        // registry is process-global, so leave it as we found it.
+        ScratchpadAttachmentStore.resetPending()
         if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
     }
 

--- a/Vellum/Services/Scratchpad/ScratchpadPersistence.swift
+++ b/Vellum/Services/Scratchpad/ScratchpadPersistence.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Per-document scratchpad notes, persisted to `documents/<key>/scratchpad.md`
 /// via `DocumentDataStore` (class-B user data — see plans/storage-design.html
@@ -223,6 +224,70 @@ enum ScratchpadAttachmentStore {
         }
     }
 
+    // MARK: - Pending attachments (written, reference not landed yet)
+
+    /// Ids written but not yet seen in any saved note text, mapped to the moment
+    /// their exemption lapses.
+    ///
+    /// A lock rather than main-actor isolation because the readers are not all
+    /// on the main actor: `pruneOrphanedAttachments` dispatches `collectGarbage`
+    /// to a detached task. The state is a plain Sendable dictionary, so this
+    /// stays a lock around a value — no actor hop on the drop path.
+    private static let pendingAttachments = OSAllocatedUnfairLock<[String: Date]>(
+        initialState: [:])
+
+    /// How long a written attachment stays exempt from collection while its
+    /// reference is in flight.
+    ///
+    /// The window it has to cover is the editor delivering the snippet, posting
+    /// its "change" message back, and the 400 ms save debounce — a fraction of a
+    /// second. It deliberately does NOT have to cover the editor's WebView still
+    /// loading: an insert requested before the bundle is ready is buffered, and
+    /// the mark is re-armed when it is finally delivered (see
+    /// `ScratchpadLiveEditor.Coordinator.flush`), so a slow cold start cannot eat
+    /// the budget. A minute against a sub-second window is generous on purpose,
+    /// because the failure modes are not symmetric: an exemption held too long
+    /// only delays a sweep that will collect the file anyway, while one released
+    /// too early deletes bytes the note is about to point at. Settable so a test
+    /// can exercise the lapse without waiting a minute.
+    nonisolated(unsafe) static var pendingGracePeriod: TimeInterval = 60
+
+    /// Declare that `id`'s bytes are on disk and its markdown reference is on
+    /// its way. Until that reference lands in saved text (or `pendingGracePeriod`
+    /// elapses), `collectGarbage` will not reap the file.
+    ///
+    /// Called by the code that is *about to* insert a reference, not by `save`
+    /// itself: writing bytes does not on its own imply a reference is coming
+    /// (imports and tests write attachments whose text already exists, or none).
+    static func markPending(_ id: String) {
+        let deadline = Date().addingTimeInterval(pendingGracePeriod)
+        pendingAttachments.withLock { $0[id.lowercased()] = deadline }
+    }
+
+    /// Drop every pending id that has now been observed in saved text — its
+    /// reference landed, so ordinary reachability governs it from here — along
+    /// with any whose grace period has lapsed. Returns what is still exempt.
+    ///
+    /// Keyed by id alone, so this registry spans documents while a sweep is
+    /// scoped to one. That asymmetry is safe in the direction that matters: an
+    /// entry can only ever spare a file, and a sweep only deletes from its own
+    /// directory, so a document can neither reap another's pending attachment
+    /// nor be made to keep a file it has no entry for. Ids are fresh UUIDs, so
+    /// two documents sharing one is not reachable from the write path.
+    private static func settlePending(observing referencedIds: Set<String>) -> Set<String> {
+        let now = Date()
+        return pendingAttachments.withLock { pending in
+            pending = pending.filter { !referencedIds.contains($0.key) && $0.value > now }
+            return Set(pending.keys)
+        }
+    }
+
+    /// Test seam: the registry is process-global (#102), so a suite touching it
+    /// must not inherit or leak entries.
+    static func resetPending() {
+        pendingAttachments.withLock { $0.removeAll() }
+    }
+
     /// Extensions a saved attachment can carry, probed directly so a lookup is
     /// O(1) rather than scanning a directory.
     private static let knownExtensions = [
@@ -261,10 +326,11 @@ enum ScratchpadAttachmentStore {
         return ids
     }
 
-    /// Delete files in `directory` whose id isn't in `referencedIds`. Scoped to
-    /// one document's attachments dir, so it can never touch another document's
-    /// still-referenced images.
-    /// Delete files in `directory` whose id isn't in `referencedIds`.
+    /// Delete files in `directory` whose id isn't in `referencedIds`. Deletion is
+    /// scoped to one document's attachments dir, so it can never touch another
+    /// document's images. (The pending registry consulted below is *not* so
+    /// scoped — see `settlePending` — but it can only ever spare a file, never
+    /// select one for deletion.)
     ///
     /// `referencedIds` is a snapshot of the note as it read at some moment, and
     /// this sweep can run later — `pruneOrphanedAttachments` dispatches it to a
@@ -278,9 +344,21 @@ enum ScratchpadAttachmentStore {
     ///
     /// A file spared this way is not leaked: if it really is an orphan, the next
     /// sweep sees it as older than that snapshot and collects it.
+    ///
+    /// The cutoff cannot cover the *other* half of the race (issue #105). When an
+    /// image is dropped, the bytes are written first and the markdown reference
+    /// arrives afterwards, through the editor's WebView round trip. A debounced
+    /// save landing in between computes a reference set that is genuinely current
+    /// and genuinely does not mention the new attachment — nothing about the
+    /// timestamps distinguishes it from an orphan. `markPending` closes that
+    /// window instead, by naming the attachment before its reference exists; this
+    /// sweep also settles pending ids it can now see referenced, so the exemption
+    /// lasts until the first save that observes the reference rather than for a
+    /// fixed span.
     static func collectGarbage(
         in directory: URL, referencedIds: Set<String>, referencedAsOf: Date? = nil
     ) {
+        let stillPending = settlePending(observing: referencedIds)
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: directory, includingPropertiesForKeys: [
                 .creationDateKey, .contentModificationDateKey,
@@ -288,6 +366,7 @@ enum ScratchpadAttachmentStore {
         for url in entries {
             let id = url.deletingPathExtension().lastPathComponent.lowercased()
             guard !referencedIds.contains(id) else { continue }
+            guard !stillPending.contains(id) else { continue }
             if let referencedAsOf, isNewerThan(referencedAsOf, url: url) { continue }
             try? FileManager.default.removeItem(at: url)
         }

--- a/Vellum/Stores/ScratchpadStore.swift
+++ b/Vellum/Stores/ScratchpadStore.swift
@@ -313,6 +313,19 @@ final class ScratchpadStore {
             showWarning("Couldn't save that image to the scratchpad. Please try again.")
             return
         }
+        // The bytes exist now, but the reference below only reaches the note
+        // after a round trip through the editor's WebView. A debounced save
+        // firing inside that window sees a note that genuinely does not mention
+        // this attachment and would collect it (issue #105). Claim it before
+        // opening the window, not after (`insertMarkdownHandler` can hand the
+        // markdown straight to a ready editor, so "after" can already be late).
+        //
+        // The bytes land one line above this claim rather than atomically with
+        // it. Nothing can sweep in between: this is main-actor code with no
+        // suspension point, and the only concurrent sweeper —
+        // `pruneOrphanedAttachments` — always passes `referencedAsOf`, whose
+        // cutoff (#104) covers exactly that gap.
+        ScratchpadAttachmentStore.markPending(id)
         // Keep the alt text single-line and free of the `]` that would close it.
         let safeLabel = label
             .replacingOccurrences(of: "\n", with: " ")

--- a/Vellum/Views/Scratchpad/ScratchpadPanel.swift
+++ b/Vellum/Views/Scratchpad/ScratchpadPanel.swift
@@ -783,6 +783,17 @@ private struct ScratchpadLiveEditor: NSViewRepresentable {
                 let inserts = pendingInserts
                 pendingInserts = []
                 for markdown in inserts {
+                    // Restart the attachment's GC exemption from the moment the
+                    // snippet actually reaches the editor (issue #105). An insert
+                    // requested before `ready` sits in `pendingInserts` for the
+                    // whole of editor.html + the JS bundle load, which on a cold
+                    // start is not the couple of frames the window is sized for —
+                    // measuring from here means the grace period only ever has to
+                    // cover the part that is genuinely brief: this call, the
+                    // editor's "change" message back, and the save debounce.
+                    for id in ScratchpadAttachmentStore.referencedIds(in: markdown) {
+                        ScratchpadAttachmentStore.markPending(id)
+                    }
                     webView.evaluateJavaScript(
                         "window.ScratchpadEditor.insertSnippet(\(jsString(markdown)));")
                 }


### PR DESCRIPTION
Closes #105

## Root cause

Dropping an image into the scratchpad is two steps with a gap between them. `ScratchpadStore.addImage` writes the bytes to the attachment store and *then* hands `![label](vellum-scratchpad://<id>)` to the editor, which only reaches the note after a round trip through the WebView (`insertSnippet` → the editor's `change` message → `parent.text`).

Inside that gap the attachment exists on disk and no note text references it. The 400 ms debounced save firing there calls `ScratchpadPersistence.save`, which ends in:

```swift
ScratchpadAttachmentStore.collectGarbage(in: attachmentDirectory, referencedIds: referenced)
```

`referenced` is computed from the text being persisted, so the just-written attachment is correctly absent from it — and gets deleted. When the markdown lands a moment later it points at nothing.

**Why #104's snapshot cutoff can't help.** That fix spares files *newer* than the reference snapshot, for the case where the snapshot is stale. Here the snapshot is current and the file is *older* than the sweep. The two situations are indistinguishable by timestamp — the attachment looks exactly like an orphan, because on the evidence available it is one. The missing information is that a reference is on its way.

## Fix

Say so explicitly. A pending registry in `ScratchpadAttachmentStore`:

- `markPending(id)` is called at the drop site the moment the bytes exist, before the markdown is handed over.
- `collectGarbage` skips pending ids, and **settles** them as soon as it sees the reference in the text it is collecting against. The exemption therefore lasts exactly until the first save that observes the reference — not a fixed span — and settled attachments are governed by ordinary reachability again.
- An id whose reference never arrives lapses after `pendingGracePeriod` (60 s) and is collected by the next sweep.

The asymmetry is deliberate and mirrors #104: an exemption held too long only delays a collection that will still happen, while one released too early destroys user data.

Three details worth flagging:

- **Marking is at the drop site, not inside `save`.** Writing bytes does not on its own imply an incoming reference — the `.vellumbundle` import writes a note and its attachments in the same operation, and undo-of-clear restores bytes alongside text that already contains the refs. Neither needs (or should get) an exemption.
- **The mark is re-armed when the editor actually delivers the snippet** (`Coordinator.flush`). An insert requested before the JS bundle finishes loading is buffered for the whole load, so measuring the grace period from `addImage` would spend it on a cold start — reopening the window on exactly the machines least able to afford it. Re-arming means the 60 s only ever has to cover a sub-second window.
- **The registry is a lock around a `Sendable` dictionary**, not main-actor state, because `pruneOrphanedAttachments` runs its sweep on a `Task.detached`.

## Tests

Three in `Tests/SafeClearTests.swift`, driving the real production path (`ScratchpadStore.addImage` → `flush()` → `ScratchpadPersistence.save` → `collectGarbage`) with the markdown held in flight to stand in for the WebView round trip:

- `testAttachmentSurvivesASaveFiredBeforeItsReferenceLands` — the regression test.
- `testSettledAttachmentIsCollectedOnceItsReferenceIsRemoved` — the exemption is not permanent.
- `testPendingExemptionLapsesSoAnAbandonedAttachmentIsStillCollected` — the timeout.

**Mutation matrix** — each test fails under exactly one targeted mutation, so none is redundant and none is passing by accident:

| Mutation | Fails |
|---|---|
| `markPending` made a no-op (pre-fix behaviour) | survives-the-save test only |
| expiry filter removed (exemption never lapses) | lapses test only |
| reference-settles rule removed | settled test only |

## Numbers

- Full suite, clean build, `-derivedDataPath .dd/fix`: **474 XCTest** (471 baseline + 3 new) and **147 Swift Testing in 22 suites**, 0 failures, `** TEST SUCCEEDED **`. Zero new warnings (warnings-as-errors is on).
- One intervening run died with a WebContent process crash (`mach_vm_allocate() failed`) in `WebStorageLocationTests.testPrettyLayoutDirectories` — an unrelated suite, not #100, and not reproducible; the run before and the run after were both clean.

## Reviewer findings

A fresh-context Opus reviewer adversarially reviewed `git diff origin/main`. Verdict: correct, closes #105, composes correctly with #104 (the two guards cover complementary halves of the race). It confirmed no data race on the new state, that `addImage` is genuinely the only production writer needing this, and that the accepted timeout leak is actually recovered by a nameable sweep. Findings applied:

1. **My 60 s justification was false.** I had written that the round trip is "a couple of frames"; the reviewer found `Coordinator.enqueueInsert` buffers inserts until the WebView posts `ready`, which on a cold start is far longer — leaving a residual variant of #105 if `ready` fired after the grace period. Fixed properly rather than by editing the comment: the mark is now re-armed at delivery.
2. **Test teardown hardcoded `60`** instead of capturing the real default, so if the production value ever changed this suite would silently rewrite the process-global for every later suite. Now captures and restores.
3. Comment corrections: "lasts exactly as long as the round trip" (it lasts until the first save that observes the reference); a false claim about what the test-suite reset protects against; and a doc-comment line duplicated verbatim by #104, whose "scoped to one document" claim now sits above a function consulting a global registry — reconciled.
4. `ScratchpadImportTests` calls `addImage` and left registry entries behind; added the matching reset.
5. Noted that the write-then-mark pair is safe only because the one concurrent sweeper always passes `referencedAsOf`; that dependency is now documented at the call site.

**Filed as follow-up rather than fixed here**, on the reviewer's recommendation: the registry is keyed by id alone while sweeps are per-directory. Reachable only through a pre-existing seam (`activeDirectory` is process-global while `ScratchpadStore` is per-pane, so a split-view drop can write into the other pane's document folder) which this PR neither introduces nor worsens — with or without the registry, that misdirected file is collected. Keying the registry by directory is the right long-term shape and would make the mismatch detectable instead of silently absorbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)