### PR TITLE
Stop the tool loop after an output-token cutoff

### DIFF
--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -496,22 +496,41 @@ final class AiPipelineTests: XCTestCase {
 
     /// An OpenAI Responses stream that completes a `function_call` item and THEN
     /// reports a `max_output_tokens` cutoff — the exact ordering issue #107 is
-    /// about. `incomplete` is omitted when `truncated` is false.
-    private func truncatedToolCallFixture(truncated: Bool) -> FixtureBytes {
-        var lines = """
-        data: {"type":"response.output_text.delta","delta":"Let me check page 4"}
+    /// about. When `truncated` is false the stream ends the way a real completed
+    /// one does, with `response.completed`. The intermediate
+    /// `function_call_arguments.delta` is there because the real API sends it and
+    /// the client must ignore it (the completed item is the source of truth).
+    private func toolCallFixture(truncated: Bool, text: String = "Let me check page 4") -> FixtureBytes {
+        var lines = ""
+        if !text.isEmpty {
+            lines += """
+            event: response.output_text.delta
+            data: {"type":"response.output_text.delta","delta":"\(text)"}
 
+
+            """
+        }
+        lines += """
+        event: response.function_call_arguments.delta
+        data: {"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\\"pageNu"}
+
+        event: response.output_item.done
         data: {"type":"response.output_item.done","item":{"type":"function_call","name":"goToPage","call_id":"call_1","arguments":"{\\"pageNumber\\":4}"}}
 
         """
         if truncated {
             lines += """
 
+            event: response.incomplete
             data: {"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}
+            """
+        } else {
+            lines += """
 
+            event: response.completed
+            data: {"type":"response.completed","response":{"status":"completed"}}
             """
         }
-        lines += "\ndata: [DONE]"
         return FixtureBytes(bytes: Array(lines.utf8))
     }
 
@@ -520,13 +539,18 @@ final class AiPipelineTests: XCTestCase {
     /// Before the gate, a non-empty `calls` sent the loop straight into
     /// `toolEngine.run` — spending more tokens right after the budget said stop.
     func testTokenLimitDropsQueuedFunctionCallsInsteadOfRunningThem() async throws {
+        var deltas: [String] = []
         let turn = try await OpenAIClient.consumeTurn(
-            truncatedToolCallFixture(truncated: true), onEvent: { _ in })
-        // Fixture sanity: the model really did queue a call before the cutoff.
+            toolCallFixture(truncated: true), provider: "OpenAI",
+            throwsOnUnexpectedIncomplete: true,
+            onEvent: { if case .textDelta(let delta) = $0 { deltas.append(delta) } })
+        // Fixture sanity: the model really did queue a call before the cutoff,
+        // and the text it streamed was forwarded live on the way through.
         XCTAssertEqual(turn.calls.count, 1)
         XCTAssertTrue(turn.hitTokenLimit)
+        XCTAssertEqual(deltas, ["Let me check page 4"])
 
-        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI") {
+        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI", hasPriorActions: false) {
         case .runTools:
             XCTFail("a truncated response must not run its queued function calls")
         case .finish(let reply):
@@ -540,31 +564,87 @@ final class AiPipelineTests: XCTestCase {
     /// the same call still runs it, so the tool loop keeps working.
     func testQueuedFunctionCallsStillRunWhenTheResponseWasNotTruncated() async throws {
         let turn = try await OpenAIClient.consumeTurn(
-            truncatedToolCallFixture(truncated: false), onEvent: { _ in })
+            toolCallFixture(truncated: false), provider: "OpenAI",
+            throwsOnUnexpectedIncomplete: true, onEvent: { _ in })
         XCTAssertFalse(turn.hitTokenLimit)
 
-        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI") {
+        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI", hasPriorActions: false) {
         case .finish:
             XCTFail("a completed response must still run its queued function calls")
         case .runTools(let queued):
             XCTAssertEqual(queued.count, 1)
             XCTAssertEqual(queued.first?["name"] as? String, "goToPage")
+            // The streamed argument fragment must not be mistaken for a call.
+            XCTAssertEqual(queued.first?["arguments"] as? String, #"{"pageNumber":4}"#)
         }
     }
 
-    /// A cutoff that queued a call but streamed no text reaches the same error
-    /// the no-calls path has always produced, named for the calling provider.
-    func testTokenLimitWithNoTextErrorsRatherThanRunningTools() throws {
-        var turn = OpenAIClient.StreamedTurn()
-        turn.calls = [["type": "function_call", "name": "goToPage", "call_id": "call_1"]]
-        turn.hitTokenLimit = true
+    /// A cutoff that streamed no text at all, on the FIRST turn, still reaches
+    /// the error the no-calls path has always produced — named for the calling
+    /// provider, since the two Responses clients share this decision.
+    func testTokenLimitWithNoTextAndNoPriorWorkErrorsRatherThanRunningTools() async throws {
+        let turn = try await OpenAIClient.consumeTurn(
+            toolCallFixture(truncated: true, text: ""), provider: "ChatGPT",
+            throwsOnUnexpectedIncomplete: false, onEvent: { _ in })
+        XCTAssertEqual(turn.calls.count, 1)
+        XCTAssertTrue(turn.text.isEmpty)
 
-        XCTAssertThrowsError(try OpenAIClient.turnOutcome(turn, provider: "ChatGPT")) { error in
+        XCTAssertThrowsError(
+            try OpenAIClient.turnOutcome(turn, provider: "ChatGPT", hasPriorActions: false)
+        ) { error in
             guard case AiClientError.message(let message) = error else {
                 return XCTFail("expected an AiClientError.message, got \(error)")
             }
             XCTAssertTrue(message.hasPrefix("ChatGPT hit the output-token limit"))
         }
+    }
+
+    /// Stopping must not mean erasing. A reasoning model can spend its whole
+    /// budget thinking and emit one function call with no visible text — so when
+    /// EARLIER turns of the same request already ran tools (which have already
+    /// changed the document), the request ends with the cutoff named and their
+    /// results kept, instead of throwing them away with an error.
+    func testTokenLimitKeepsWorkDoneByEarlierTurnsInsteadOfThrowing() async throws {
+        let turn = try await OpenAIClient.consumeTurn(
+            toolCallFixture(truncated: true, text: ""), provider: "OpenAI",
+            throwsOnUnexpectedIncomplete: true, onEvent: { _ in })
+
+        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI", hasPriorActions: true) {
+        case .runTools:
+            XCTFail("a truncated response must not run its queued function calls")
+        case .finish(let reply):
+            XCTAssertTrue(reply.contains("output-token limit"),
+                          "the cutoff must still be named for the user")
+        }
+    }
+
+    /// The one behavioural difference between the two Responses clients is now a
+    /// parameter, not a second copy of the loop. The direct client surfaces a
+    /// non-token cutoff (the `content_filter` path that was dead code before
+    /// #86); the Codex-backed one finalizes silently, as it always has.
+    func testNonTokenIncompleteReasonSurfacesOnlyWhereTheClientAsksForIt() async throws {
+        let filtered = """
+        event: response.incomplete
+        data: {"type":"response.incomplete","response":{"incomplete_details":{"reason":"content_filter"}}}
+        """
+        func fixture() -> FixtureBytes { FixtureBytes(bytes: Array(filtered.utf8)) }
+
+        do {
+            _ = try await OpenAIClient.consumeTurn(
+                fixture(), provider: "OpenAI", throwsOnUnexpectedIncomplete: true,
+                onEvent: { _ in })
+            XCTFail("the direct client must surface a non-token cutoff")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains("content_filter"),
+                "the direct client must name the reason it stopped for")
+        }
+
+        let tolerated = try await OpenAIClient.consumeTurn(
+            fixture(), provider: "ChatGPT", throwsOnUnexpectedIncomplete: false,
+            onEvent: { _ in })
+        XCTAssertFalse(tolerated.hitTokenLimit)
+        XCTAssertTrue(tolerated.calls.isEmpty)
     }
 
     // MARK: - §4 Usage parsing

--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -492,6 +492,81 @@ final class AiPipelineTests: XCTestCase {
         XCTAssertTrue(payloads[1].contains("lo"))
     }
 
+    // MARK: - Tool loop vs. the output-token limit (#107)
+
+    /// An OpenAI Responses stream that completes a `function_call` item and THEN
+    /// reports a `max_output_tokens` cutoff — the exact ordering issue #107 is
+    /// about. `incomplete` is omitted when `truncated` is false.
+    private func truncatedToolCallFixture(truncated: Bool) -> FixtureBytes {
+        var lines = """
+        data: {"type":"response.output_text.delta","delta":"Let me check page 4"}
+
+        data: {"type":"response.output_item.done","item":{"type":"function_call","name":"goToPage","call_id":"call_1","arguments":"{\\"pageNumber\\":4}"}}
+
+        """
+        if truncated {
+            lines += """
+
+            data: {"type":"response.incomplete","response":{"incomplete_details":{"reason":"max_output_tokens"}}}
+
+            """
+        }
+        lines += "\ndata: [DONE]"
+        return FixtureBytes(bytes: Array(lines.utf8))
+    }
+
+    /// The regression: a response cut off at its token budget must NOT run the
+    /// function call it had already queued, and must not start another turn.
+    /// Before the gate, a non-empty `calls` sent the loop straight into
+    /// `toolEngine.run` — spending more tokens right after the budget said stop.
+    func testTokenLimitDropsQueuedFunctionCallsInsteadOfRunningThem() async throws {
+        let turn = try await OpenAIClient.consumeTurn(
+            truncatedToolCallFixture(truncated: true), onEvent: { _ in })
+        // Fixture sanity: the model really did queue a call before the cutoff.
+        XCTAssertEqual(turn.calls.count, 1)
+        XCTAssertTrue(turn.hitTokenLimit)
+
+        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI") {
+        case .runTools:
+            XCTFail("a truncated response must not run its queued function calls")
+        case .finish(let reply):
+            // The truncation still surfaces exactly as it does with no calls.
+            XCTAssertTrue(reply.hasPrefix("Let me check page 4"))
+            XCTAssertTrue(reply.hasSuffix("_(reply truncated at the output-token limit)_"))
+        }
+    }
+
+    /// The gate must be scoped to the cutoff: an ordinary response that queued
+    /// the same call still runs it, so the tool loop keeps working.
+    func testQueuedFunctionCallsStillRunWhenTheResponseWasNotTruncated() async throws {
+        let turn = try await OpenAIClient.consumeTurn(
+            truncatedToolCallFixture(truncated: false), onEvent: { _ in })
+        XCTAssertFalse(turn.hitTokenLimit)
+
+        switch try OpenAIClient.turnOutcome(turn, provider: "OpenAI") {
+        case .finish:
+            XCTFail("a completed response must still run its queued function calls")
+        case .runTools(let queued):
+            XCTAssertEqual(queued.count, 1)
+            XCTAssertEqual(queued.first?["name"] as? String, "goToPage")
+        }
+    }
+
+    /// A cutoff that queued a call but streamed no text reaches the same error
+    /// the no-calls path has always produced, named for the calling provider.
+    func testTokenLimitWithNoTextErrorsRatherThanRunningTools() throws {
+        var turn = OpenAIClient.StreamedTurn()
+        turn.calls = [["type": "function_call", "name": "goToPage", "call_id": "call_1"]]
+        turn.hitTokenLimit = true
+
+        XCTAssertThrowsError(try OpenAIClient.turnOutcome(turn, provider: "ChatGPT")) { error in
+            guard case AiClientError.message(let message) = error else {
+                return XCTFail("expected an AiClientError.message, got \(error)")
+            }
+            XCTAssertTrue(message.hasPrefix("ChatGPT hit the output-token limit"))
+        }
+    }
+
     // MARK: - §4 Usage parsing
 
     func testUsageParsingAcrossProviderShapes() {

--- a/Vellum/Services/Ai/ChatGPTClient.swift
+++ b/Vellum/Services/Ai/ChatGPTClient.swift
@@ -77,40 +77,17 @@ final class ChatGPTClient {
             let request = try await makeRequest(url: url, body: body)
             let bytes = try await openStream(request)
 
-            // Kept as its own loop rather than reusing `OpenAIClient.consumeTurn`:
-            // the Codex backend's `response.incomplete` carries reasons this
-            // client deliberately does not turn into errors, and its stream
-            // failure text names ChatGPT.
-            var turn = OpenAIClient.StreamedTurn()
-            for try await payload in SSE.dataPayloads(bytes) {
-                guard let object = Self.jsonObjectOrNil(payload),
-                      let type = object["type"] as? String else { continue }
-                switch type {
-                case "response.output_text.delta":
-                    if let delta = object["delta"] as? String, !delta.isEmpty {
-                        turn.text += delta
-                        onEvent(.textDelta(delta))
-                    }
-                case "response.output_item.done":
-                    if let item = object["item"] as? [String: Any],
-                       item["type"] as? String == "function_call" {
-                        turn.calls.append(item)
-                    }
-                case "response.incomplete":
-                    let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
-                    if reason == "max_output_tokens" { turn.hitTokenLimit = true }
-                case "response.failed", "error":
-                    let message = ((object["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
-                        ?? (object["message"] as? String)
-                    throw AiClientError.message(message ?? "ChatGPT streaming failed.")
-                default:
-                    break
-                }
-            }
+            // Same parse AND same gate as the direct client. This loop used to be
+            // a second copy of both, which is how #107 came to be fixed in one
+            // client and not the other; the one remaining behavioural difference
+            // is now the `throwsOnUnexpectedIncomplete` argument rather than a
+            // divergent body. A turn cut off at the token limit never runs its
+            // queued calls or starts another turn.
+            let turn = try await OpenAIClient.consumeTurn(
+                bytes, provider: "ChatGPT", throwsOnUnexpectedIncomplete: false, onEvent: onEvent)
 
-            // Same gate as the direct client: a turn cut off at the token limit
-            // never runs its queued calls or starts another turn (#107).
-            switch try OpenAIClient.turnOutcome(turn, provider: "ChatGPT") {
+            switch try OpenAIClient.turnOutcome(
+                turn, provider: "ChatGPT", hasPriorActions: !actionResults.isEmpty) {
             case .finish(let reply):
                 return AiProviderResult(reply: Self.finalize(reply, actions: actionResults), actionResults: actionResults)
             case .runTools(let queued):

--- a/Vellum/Services/Ai/ChatGPTClient.swift
+++ b/Vellum/Services/Ai/ChatGPTClient.swift
@@ -77,26 +77,28 @@ final class ChatGPTClient {
             let request = try await makeRequest(url: url, body: body)
             let bytes = try await openStream(request)
 
-            var text = ""
-            var calls: [[String: Any]] = []
-            var hitTokenLimit = false
+            // Kept as its own loop rather than reusing `OpenAIClient.consumeTurn`:
+            // the Codex backend's `response.incomplete` carries reasons this
+            // client deliberately does not turn into errors, and its stream
+            // failure text names ChatGPT.
+            var turn = OpenAIClient.StreamedTurn()
             for try await payload in SSE.dataPayloads(bytes) {
                 guard let object = Self.jsonObjectOrNil(payload),
                       let type = object["type"] as? String else { continue }
                 switch type {
                 case "response.output_text.delta":
                     if let delta = object["delta"] as? String, !delta.isEmpty {
-                        text += delta
+                        turn.text += delta
                         onEvent(.textDelta(delta))
                     }
                 case "response.output_item.done":
                     if let item = object["item"] as? [String: Any],
                        item["type"] as? String == "function_call" {
-                        calls.append(item)
+                        turn.calls.append(item)
                     }
                 case "response.incomplete":
                     let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
-                    if reason == "max_output_tokens" { hitTokenLimit = true }
+                    if reason == "max_output_tokens" { turn.hitTokenLimit = true }
                 case "response.failed", "error":
                     let message = ((object["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
                         ?? (object["message"] as? String)
@@ -106,38 +108,34 @@ final class ChatGPTClient {
                 }
             }
 
-            if calls.isEmpty {
-                var reply = text
-                if hitTokenLimit {
-                    guard !reply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                        throw AiClientError.message("ChatGPT hit the output-token limit before producing any text. Try a lower thinking mode.")
-                    }
-                    reply += "\n\n_(reply truncated at the output-token limit)_"
-                }
+            // Same gate as the direct client: a turn cut off at the token limit
+            // never runs its queued calls or starts another turn (#107).
+            switch try OpenAIClient.turnOutcome(turn, provider: "ChatGPT") {
+            case .finish(let reply):
                 return AiProviderResult(reply: Self.finalize(reply, actions: actionResults), actionResults: actionResults)
-            }
-
-            for call in calls {
-                guard let name = call["name"] as? String,
-                      let callId = call["call_id"] as? String else { continue }
-                let argumentsText = call["arguments"] as? String ?? "{}"
-                let values = (try? JSONSerialization.jsonObject(with: Data(argumentsText.utf8))) as? [String: Any] ?? [:]
-                let action = AiToolAction(tool: name, args: Self.toolArguments(from: values))
-                input.append([
-                    "type": "function_call",
-                    "call_id": callId,
-                    "name": name,
-                    "arguments": argumentsText,
-                ])
-                onEvent(.toolStarted(summary: GeminiClient.toolSummary(action)))
-                let result = await toolEngine.run(
-                    action,
-                    sessionIdAtStart: sessionIdAtStart,
-                    actionCount: actionResults.count
-                )
-                actionResults.append(result)
-                onEvent(.toolFinished(result: result))
-                input.append(["type": "function_call_output", "call_id": callId, "output": result])
+            case .runTools(let queued):
+                for call in queued {
+                    guard let name = call["name"] as? String,
+                          let callId = call["call_id"] as? String else { continue }
+                    let argumentsText = call["arguments"] as? String ?? "{}"
+                    let values = (try? JSONSerialization.jsonObject(with: Data(argumentsText.utf8))) as? [String: Any] ?? [:]
+                    let action = AiToolAction(tool: name, args: Self.toolArguments(from: values))
+                    input.append([
+                        "type": "function_call",
+                        "call_id": callId,
+                        "name": name,
+                        "arguments": argumentsText,
+                    ])
+                    onEvent(.toolStarted(summary: GeminiClient.toolSummary(action)))
+                    let result = await toolEngine.run(
+                        action,
+                        sessionIdAtStart: sessionIdAtStart,
+                        actionCount: actionResults.count
+                    )
+                    actionResults.append(result)
+                    onEvent(.toolFinished(result: result))
+                    input.append(["type": "function_call_output", "call_id": callId, "output": result])
+                }
             }
             onEvent(.status("Thinking"))
         }

--- a/Vellum/Services/Ai/OpenAIClient.swift
+++ b/Vellum/Services/Ai/OpenAIClient.swift
@@ -68,88 +68,134 @@ final class OpenAIClient {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
             let bytes = try await openStream(request)
+            let turn = try await Self.consumeTurn(bytes, onEvent: onEvent)
 
-            var text = ""
-            var calls: [[String: Any]] = []
-            var hitTokenLimit = false
-            for try await payload in SSE.dataPayloads(bytes) {
-                guard let object = Self.jsonObjectOrNil(payload),
-                      let type = object["type"] as? String else { continue }
-                switch type {
-                case "response.output_text.delta":
-                    if let delta = object["delta"] as? String, !delta.isEmpty {
-                        text += delta
-                        onEvent(.textDelta(delta))
-                    }
-                case "response.output_item.done":
-                    if let item = object["item"] as? [String: Any],
-                       item["type"] as? String == "function_call" {
-                        calls.append(item)
-                    }
-                // Terminal event when the response was cut off. There were two
-                // identical `case "response.incomplete"` arms here, so the second
-                // was dead — which is why `incompleteMessage(reason:)` could
-                // never actually reach a user despite being covered by a test,
-                // and why a cutoff for any reason other than the token limit
-                // finalized silently as if the reply had completed normally.
-                //
-                // Merged into one arm that keeps the better behaviour for each
-                // case: a token-limit cutoff returns the partial text with a
-                // truncation note (throwing away a long, nearly-complete answer
-                // is worse than flagging it), while anything else — a content
-                // filter, say — surfaces the reason.
-                case "response.incomplete":
-                    let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
-                    if reason == "max_output_tokens" {
-                        hitTokenLimit = true
-                    } else {
-                        throw AiClientError.message(Self.incompleteMessage(reason: reason ?? "unknown"))
-                    }
-                case "response.failed", "error":
-                    let message = ((object["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
-                        ?? (object["message"] as? String)
-                    throw AiClientError.message(message ?? "OpenAI streaming failed.")
-                default:
-                    break
-                }
-            }
-
-            if calls.isEmpty {
-                var reply = text
-                if hitTokenLimit {
-                    guard !reply.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                        throw AiClientError.message("OpenAI hit the output-token limit before producing any text. Try a lower thinking mode.")
-                    }
-                    reply += "\n\n_(reply truncated at the output-token limit)_"
-                }
+            // The gate is the only route from a streamed turn into the tool
+            // loop, so a truncated response cannot reach `toolEngine.run` (#107).
+            switch try Self.turnOutcome(turn, provider: "OpenAI") {
+            case .finish(let reply):
                 return AiProviderResult(reply: Self.finalize(reply, actions: actionResults), actionResults: actionResults)
-            }
-
-            for call in calls {
-                guard let name = call["name"] as? String,
-                      let callId = call["call_id"] as? String else { continue }
-                let argumentsText = call["arguments"] as? String ?? "{}"
-                let values = (try? JSONSerialization.jsonObject(with: Data(argumentsText.utf8))) as? [String: Any] ?? [:]
-                let action = AiToolAction(tool: name, args: Self.toolArguments(from: values))
-                input.append([
-                    "type": "function_call",
-                    "call_id": callId,
-                    "name": name,
-                    "arguments": argumentsText,
-                ])
-                onEvent(.toolStarted(summary: GeminiClient.toolSummary(action)))
-                let result = await toolEngine.run(
-                    action,
-                    sessionIdAtStart: sessionIdAtStart,
-                    actionCount: actionResults.count
-                )
-                actionResults.append(result)
-                onEvent(.toolFinished(result: result))
-                input.append(["type": "function_call_output", "call_id": callId, "output": result])
+            case .runTools(let queued):
+                for call in queued {
+                    guard let name = call["name"] as? String,
+                          let callId = call["call_id"] as? String else { continue }
+                    let argumentsText = call["arguments"] as? String ?? "{}"
+                    let values = (try? JSONSerialization.jsonObject(with: Data(argumentsText.utf8))) as? [String: Any] ?? [:]
+                    let action = AiToolAction(tool: name, args: Self.toolArguments(from: values))
+                    input.append([
+                        "type": "function_call",
+                        "call_id": callId,
+                        "name": name,
+                        "arguments": argumentsText,
+                    ])
+                    onEvent(.toolStarted(summary: GeminiClient.toolSummary(action)))
+                    let result = await toolEngine.run(
+                        action,
+                        sessionIdAtStart: sessionIdAtStart,
+                        actionCount: actionResults.count
+                    )
+                    actionResults.append(result)
+                    onEvent(.toolFinished(result: result))
+                    input.append(["type": "function_call_output", "call_id": callId, "output": result])
+                }
             }
             onEvent(.status("Thinking"))
         }
         return AiProviderResult(reply: Self.finalize("", actions: actionResults), actionResults: actionResults)
+    }
+
+    /// One streamed Responses turn: the visible text, the function calls the
+    /// model queued, and whether the response was cut off at its output-token
+    /// budget. Those three are decided together — `hitTokenLimit` says nothing
+    /// about whether `calls` is empty, which is the whole point of #107.
+    struct StreamedTurn {
+        var text = ""
+        var calls: [[String: Any]] = []
+        var hitTokenLimit = false
+    }
+
+    /// Consume one Responses SSE stream into a `StreamedTurn`, forwarding text
+    /// deltas live. Generic over the byte source so the loop can be driven from
+    /// an SSE fixture in tests instead of a network response.
+    static func consumeTurn<Bytes: AsyncSequence>(
+        _ bytes: Bytes,
+        onEvent: @escaping @MainActor (AiStreamEvent) -> Void
+    ) async throws -> StreamedTurn where Bytes.Element == UInt8 {
+        var turn = StreamedTurn()
+        for try await payload in SSE.dataPayloads(bytes) {
+            guard let object = jsonObjectOrNil(payload),
+                  let type = object["type"] as? String else { continue }
+            switch type {
+            case "response.output_text.delta":
+                if let delta = object["delta"] as? String, !delta.isEmpty {
+                    turn.text += delta
+                    onEvent(.textDelta(delta))
+                }
+            case "response.output_item.done":
+                if let item = object["item"] as? [String: Any],
+                   item["type"] as? String == "function_call" {
+                    turn.calls.append(item)
+                }
+            // Terminal event when the response was cut off. There were two
+            // identical `case "response.incomplete"` arms here, so the second
+            // was dead — which is why `incompleteMessage(reason:)` could
+            // never actually reach a user despite being covered by a test,
+            // and why a cutoff for any reason other than the token limit
+            // finalized silently as if the reply had completed normally.
+            //
+            // Merged into one arm that keeps the better behaviour for each
+            // case: a token-limit cutoff returns the partial text with a
+            // truncation note (throwing away a long, nearly-complete answer
+            // is worse than flagging it), while anything else — a content
+            // filter, say — surfaces the reason.
+            case "response.incomplete":
+                let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
+                if reason == "max_output_tokens" {
+                    turn.hitTokenLimit = true
+                } else {
+                    throw AiClientError.message(incompleteMessage(reason: reason ?? "unknown"))
+                }
+            case "response.failed", "error":
+                let message = ((object["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
+                    ?? (object["message"] as? String)
+                throw AiClientError.message(message ?? "OpenAI streaming failed.")
+            default:
+                break
+            }
+        }
+        return turn
+    }
+
+    /// What a streamed turn leads to: end the request with this reply, or run
+    /// these queued calls and take another turn.
+    enum TurnOutcome {
+        case finish(reply: String)
+        case runTools([[String: Any]])
+    }
+
+    /// The one decision point between a streamed turn and the tool loop, shared
+    /// by the two Responses-API clients (OpenAI-direct and ChatGPT OAuth).
+    ///
+    /// A `max_output_tokens` cutoff can arrive *after* a `function_call` item
+    /// completed in the same response, so a non-empty `calls` does NOT mean the
+    /// model was allowed to finish. Running that queue would execute a tool and
+    /// fire a whole further request off the back of a response the budget
+    /// already stopped — spending more tokens at exactly the moment the cap said
+    /// to stop (#107). So once the limit is hit the queue is dropped unrun and
+    /// the turn ends through the same truncation surface the no-calls path has
+    /// always used: partial text plus a visible note, or — when nothing streamed
+    /// at all — the "try a lower thinking mode" error. That error now also
+    /// reaches a truncated turn that queued calls, which is deliberate: the
+    /// alternative is silently spending the budget the user just exceeded.
+    static func turnOutcome(_ turn: StreamedTurn, provider: String) throws -> TurnOutcome {
+        guard turn.hitTokenLimit else {
+            return turn.calls.isEmpty ? .finish(reply: turn.text) : .runTools(turn.calls)
+        }
+        guard !turn.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AiClientError.message(
+                "\(provider) hit the output-token limit before producing any text. Try a lower thinking mode.")
+        }
+        return .finish(reply: turn.text + "\n\n_(reply truncated at the output-token limit)_")
     }
 
     /// Whether `model` takes a `reasoning` field at all. Everything else rejects

--- a/Vellum/Services/Ai/OpenAIClient.swift
+++ b/Vellum/Services/Ai/OpenAIClient.swift
@@ -68,11 +68,13 @@ final class OpenAIClient {
             request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
             let bytes = try await openStream(request)
-            let turn = try await Self.consumeTurn(bytes, onEvent: onEvent)
+            let turn = try await Self.consumeTurn(
+                bytes, provider: "OpenAI", throwsOnUnexpectedIncomplete: true, onEvent: onEvent)
 
             // The gate is the only route from a streamed turn into the tool
             // loop, so a truncated response cannot reach `toolEngine.run` (#107).
-            switch try Self.turnOutcome(turn, provider: "OpenAI") {
+            switch try Self.turnOutcome(
+                turn, provider: "OpenAI", hasPriorActions: !actionResults.isEmpty) {
             case .finish(let reply):
                 return AiProviderResult(reply: Self.finalize(reply, actions: actionResults), actionResults: actionResults)
             case .runTools(let queued):
@@ -117,8 +119,21 @@ final class OpenAIClient {
     /// Consume one Responses SSE stream into a `StreamedTurn`, forwarding text
     /// deltas live. Generic over the byte source so the loop can be driven from
     /// an SSE fixture in tests instead of a network response.
+    ///
+    /// Shared by both Responses-API clients rather than copied into each. #107
+    /// existed because this logic lived in two places and one copy was wrong, so
+    /// the two remaining differences are parameters — a visible argument at the
+    /// call site — instead of a divergent second copy that can drift again.
+    ///
+    /// `throwsOnUnexpectedIncomplete` is the ChatGPT/Codex difference: that
+    /// backend's `response.incomplete` reasons are left to finalize silently,
+    /// which is the behaviour that client has always had. Preserved as-is here,
+    /// not endorsed — whether Codex should surface a content-filter cutoff the
+    /// way the direct client does is its own question, not this change's.
     static func consumeTurn<Bytes: AsyncSequence>(
         _ bytes: Bytes,
+        provider: String,
+        throwsOnUnexpectedIncomplete: Bool,
         onEvent: @escaping @MainActor (AiStreamEvent) -> Void
     ) async throws -> StreamedTurn where Bytes.Element == UInt8 {
         var turn = StreamedTurn()
@@ -152,13 +167,13 @@ final class OpenAIClient {
                 let reason = ((object["response"] as? [String: Any])?["incomplete_details"] as? [String: Any])?["reason"] as? String
                 if reason == "max_output_tokens" {
                     turn.hitTokenLimit = true
-                } else {
+                } else if throwsOnUnexpectedIncomplete {
                     throw AiClientError.message(incompleteMessage(reason: reason ?? "unknown"))
                 }
             case "response.failed", "error":
                 let message = ((object["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
                     ?? (object["message"] as? String)
-                throw AiClientError.message(message ?? "OpenAI streaming failed.")
+                throw AiClientError.message(message ?? "\(provider) streaming failed.")
             default:
                 break
             }
@@ -182,20 +197,35 @@ final class OpenAIClient {
     /// fire a whole further request off the back of a response the budget
     /// already stopped — spending more tokens at exactly the moment the cap said
     /// to stop (#107). So once the limit is hit the queue is dropped unrun and
-    /// the turn ends through the same truncation surface the no-calls path has
-    /// always used: partial text plus a visible note, or — when nothing streamed
-    /// at all — the "try a lower thinking mode" error. That error now also
-    /// reaches a truncated turn that queued calls, which is deliberate: the
-    /// alternative is silently spending the budget the user just exceeded.
-    static func turnOutcome(_ turn: StreamedTurn, provider: String) throws -> TurnOutcome {
+    /// the turn ends through the truncation surface the no-calls path has always
+    /// used: the partial text plus a visible note.
+    ///
+    /// `hasPriorActions` is what keeps stopping from becoming erasing. When the
+    /// cutoff leaves no text at all there is nothing to show, and the no-calls
+    /// path has always thrown — but throwing discards `actionResults` from
+    /// EARLIER turns of the same request, and the store's failure path drops the
+    /// tool trace with them. Tools that already navigated the document or added
+    /// a note would keep their effects while vanishing from the transcript. A
+    /// reasoning model that spends its whole budget thinking and emits one
+    /// function call is exactly this shape, so it is not an edge case. When
+    /// earlier turns did real work the request therefore ends with a note naming
+    /// the cutoff and keeps their results; only a request that produced nothing
+    /// at all is worth failing outright, where "try a lower thinking mode" is
+    /// the actionable thing to say.
+    static func turnOutcome(
+        _ turn: StreamedTurn, provider: String, hasPriorActions: Bool
+    ) throws -> TurnOutcome {
         guard turn.hitTokenLimit else {
             return turn.calls.isEmpty ? .finish(reply: turn.text) : .runTools(turn.calls)
         }
-        guard !turn.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw AiClientError.message(
-                "\(provider) hit the output-token limit before producing any text. Try a lower thinking mode.")
+        guard turn.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .finish(reply: turn.text + "\n\n_(reply truncated at the output-token limit)_")
         }
-        return .finish(reply: turn.text + "\n\n_(reply truncated at the output-token limit)_")
+        guard !hasPriorActions else {
+            return .finish(reply: "_(stopped at the output-token limit before answering — try a lower thinking mode)_")
+        }
+        throw AiClientError.message(
+            "\(provider) hit the output-token limit before producing any text. Try a lower thinking mode.")
     }
 
     /// Whether `model` takes a `reasoning` field at all. Everything else rejects


### PR DESCRIPTION
Closes #107

## Root cause

Both Responses-API clients only consulted `hitTokenLimit` from inside `if calls.isEmpty`:

```swift
if calls.isEmpty {
    // ...surface the truncation...
    return AiProviderResult(...)
}
for call in calls { await toolEngine.run(...) }   // ← reached even when truncated
```

A `max_output_tokens` cutoff can arrive *after* a `function_call` item completed in the same response, so a non-empty `calls` does not mean the model was allowed to finish. Such a response fell straight past the truncation handling, executed the queued tool, and started a whole further request — spending more tokens at exactly the moment the budget said stop.

## The fix

Every streamed turn now goes through one decision point, `OpenAIClient.turnOutcome`, returning `.finish(reply:)` or `.runTools(_:)`. Once `hitTokenLimit` is set the queue is dropped unrun and the turn ends through the same truncation surface the no-calls path has always used. Both `OpenAIClient` and `ChatGPTClient` share it, and because each call site `switch`es exhaustively over a two-case enum, the gate is the only route from a streamed turn into `toolEngine.run`.

The per-turn SSE consumption moved into `OpenAIClient.consumeTurn`, generic over the byte source (behaviour unchanged, diffed line-for-line), so the loop is drivable from an SSE fixture with no network — which is what the tests do.

**One deliberate behaviour change beyond a pure gate**, from review: `turnOutcome` takes `hasPriorActions`. See below.

## Scope

Left as filed follow-up **#110**: `GeminiClient`, `OpenRouterClient` and `OpenCodeZenClient` have the structurally identical hole, but signal truncation via `finishReason == "MAX_TOKENS"` / `"length"` rather than `hitTokenLimit`, so this gate doesn't cover them. One issue, one PR — #110 suggests reusing `turnOutcome` and notes that for the two chat-completions clients it may be worse than the OpenAI case (a cutoff mid-`tool_calls` leaves truncated JSON arguments that parse to all-nil and the tool then runs with defaults).

## Reviewer findings

A fresh-context reviewer went at `git diff origin/main` adversarially.

**Applied — HIGH: the gate's throw path erased work already done in the same request.** My first cut turned "truncated + queued calls + no text" into a throw. On a *later* turn that discards every `actionResult` earlier turns produced, and `AiStore`'s failure path never sets `toolSummaries`, so tools that had already navigated the document or added a note kept their side effects while vanishing from the transcript. Reasoning tokens count against `max_output_tokens`, so a model that spends its budget thinking and emits one function call with no visible text is the *common* shape of this bug, not an edge case. `turnOutcome` now takes `hasPriorActions`: with prior work the request ends with the cutoff named and those results kept; only a request that produced nothing at all still fails outright, where "try a lower thinking mode" is the actionable thing to say. This also makes the pre-existing `calls.isEmpty` truncation path stop discarding prior actions.

**Applied — MEDIUM: `ChatGPTClient` still had its own copy of the SSE loop.** #107 exists *because* this logic lived in two places and one copy was wrong; the reviewer verified that deleting `turn.hitTokenLimit = true` from the ChatGPT copy left all tests green. It now shares `consumeTurn`, with the single behavioural difference expressed as the `throwsOnUnexpectedIncomplete` argument. That client's tolerance of non-token `incomplete` reasons is preserved as-is, and the comment no longer implies this change endorsed it.

**Applied — LOW/MEDIUM: test gaps.** The fixture now carries `event:` lines, an intermediate `response.function_call_arguments.delta` the client must ignore, and a real `response.completed` terminator instead of the Chat Completions `[DONE]` sentinel. Text deltas are asserted to be forwarded live. Added coverage for the prior-actions branch and for both settings of the incomplete flag — including the `content_filter` path that was dead code before #86 and had only ever been tested through its string builder.

**Not applied, disclosed instead — MEDIUM: the tests pin `turnOutcome`/`consumeTurn`, not `generate`.** An implementation that reintroduced `if calls.isEmpty` inside `generate` while keeping a correct `turnOutcome` would still pass. Closing that honestly needs an injectable transport (`URLProtocol` stub behind an injected `URLSession`), which the reviewer agreed is larger than this change should carry. What holds it today is structural, not behavioural: `toolEngine.run` appears exactly once per client, inside `case .runTools`, and the exhaustive `switch` forces both call sites to handle any new case. **So: the gate is not end-to-end tested.**

**Declined — nit:** dropping the redundant `@escaping` on `onEvent` (never stored); it matches the surrounding signatures, and the reviewer agreed to leave it. Two genuinely pre-existing issues the reviewer surfaced are out of scope and unchanged: neither Responses client echoes the assistant `message` item back into `input` across tool turns (`OpenRouter`/`OpenCodeZen` do), and a `queued` list whose entries all fail the `name`/`call_id` guard re-sends a byte-identical request up to the 8-iteration cap.

Verified as fine: `consumeTurn` is a faithful extraction (event ordering, `onEvent` timing, error propagation, the non-token `response.incomplete` throw, per-turn state reset all identical); the 8-iteration cap still terminates and now exits *earlier* on truncation; concurrency is sound (main-actor-isolated static, `Bytes` never crosses an isolation boundary, `SSE.dataPayloads` was already generic over the same constraint so the real `URLSession.AsyncBytes` path is unchanged).

## Tests

`xcodebuild test`, macOS, Debug, clean build with warnings-as-errors: **476 XCTest passed** (471 on `main` + 5 new) and **147 Swift Testing passed in 22 suites**. Zero failures, zero new warnings.

One unrelated flake appeared in a single run — `ScratchpadDropRegistrationTests.testAcceptsDropsFlippedFalseAfterLoadStaysUnregistered`, a WebKit-process crash and restart, not #100's `DocumentDataStore` flake. It passed in every other run on this branch, including the final one, and this change touches only AI client code.

Each new test was mutation-checked — it fails when its mechanism is reverted:

| Reverted mechanism | Tests that fail |
|---|---|
| gate removed (queued calls win over the token limit) | all three token-limit tests |
| `hasPriorActions` branch removed | `testTokenLimitKeepsWorkDoneByEarlierTurnsInsteadOfThrowing` |
| `throwsOnUnexpectedIncomplete` ignored | `testNonTokenIncompleteReasonSurfacesOnlyWhereTheClientAsksForIt` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
