### PR TITLE
Disable document commands while a sheet is presented

### DIFF
--- a/Tests/SheetPresenceTests.swift
+++ b/Tests/SheetPresenceTests.swift
@@ -1,0 +1,235 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Vellum
+
+/// The gate behind issue #98: `ContentView` publishes its scene focus value
+/// only while `sheetPresented` is false, so these are the conditions under
+/// which the document menu commands are live.
+///
+/// These drive REAL windows and a REAL hosted SwiftUI `.sheet` rather than
+/// poking the model's setters, because every interesting claim here is a claim
+/// about AppKit: that a SwiftUI sheet is an attached AppKit sheet at all, that
+/// the begin/end notifications name the presenting window, and that
+/// `attachedSheet` is not yet set at begin but already cleared at end. Asserting
+/// those against the real thing is the whole point — a hand-rolled fake would
+/// only re-state what this file assumes.
+///
+/// What is NOT covered: the `.focusedSceneValue` plumbing that consumes this
+/// state, and the AppKit key-equivalent behaviour that follows from it (a
+/// disabled menu item declining ⌘W). Both need a running scene with a real menu
+/// bar and a real key event; neither is reachable from a unit test.
+@MainActor
+final class SheetPresenceTests: XCTestCase {
+    private var windows: [NSWindow] = []
+
+    override func tearDown() async throws {
+        for window in windows { window.orderOut(nil) }
+        windows = []
+    }
+
+    // MARK: - Harness
+
+    /// A real window, positioned far offscreen so a test run never puts
+    /// anything on the developer's desktop, and ordered in — an unordered
+    /// window cannot take a sheet.
+    private func makeWindow(_ content: NSView? = nil) -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        if let content { window.contentView = content }
+        window.setFrameOrigin(NSPoint(x: -30_000, y: -30_000))
+        window.orderFront(nil)
+        windows.append(window)
+        return window
+    }
+
+    private func pump(_ seconds: TimeInterval = 0.6) {
+        RunLoop.current.run(until: Date().addingTimeInterval(seconds))
+    }
+
+    private func pump(until condition: @autoclosure () -> Bool, timeout: TimeInterval = 5) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    // MARK: - The AppKit contract this fix rests on
+
+    /// The load-bearing assumption: SwiftUI's `.sheet` on macOS really does
+    /// attach an AppKit sheet to the presenting window and really does emit the
+    /// begin/end notifications naming that window. If a future SwiftUI ever
+    /// presents sheets some other way, the gate would silently stop working and
+    /// #98 would come back with no other test noticing — so this asserts it
+    /// directly, and asserts the asymmetry the monitor is written around:
+    /// `attachedSheet` is NOT yet set when the begin notification lands, and IS
+    /// already cleared when the end notification lands.
+    func testSwiftUISheetIsAnAttachedAppKitSheetWithTheExpectedNotifications() throws {
+        let box = SheetProbeBox()
+        let host = NSHostingView(rootView: SheetProbeView(box: box))
+        host.frame = NSRect(x: 0, y: 0, width: 400, height: 300)
+        let window = makeWindow(host)
+
+        var beginAttachedStates: [Bool] = []
+        var endAttachedStates: [Bool] = []
+        let began = NotificationCenter.default.addObserver(
+            forName: NSWindow.willBeginSheetNotification, object: window, queue: .main
+        ) { note in
+            beginAttachedStates.append((note.object as? NSWindow)?.attachedSheet != nil)
+        }
+        let ended = NotificationCenter.default.addObserver(
+            forName: NSWindow.didEndSheetNotification, object: window, queue: .main
+        ) { note in
+            endAttachedStates.append((note.object as? NSWindow)?.attachedSheet != nil)
+        }
+        defer {
+            NotificationCenter.default.removeObserver(began)
+            NotificationCenter.default.removeObserver(ended)
+        }
+
+        host.layoutSubtreeIfNeeded()
+        pump()
+        XCTAssertNil(window.attachedSheet, "precondition: nothing attached yet")
+
+        box.presented = true
+        host.layoutSubtreeIfNeeded()
+        pump(until: window.attachedSheet != nil)
+        XCTAssertNotNil(
+            window.attachedSheet,
+            "a SwiftUI .sheet did not attach an AppKit sheet to the presenting window")
+        XCTAssertEqual(
+            beginAttachedStates, [false],
+            "expected exactly one begin notification, with attachedSheet not yet set")
+
+        box.presented = false
+        host.layoutSubtreeIfNeeded()
+        pump(until: window.attachedSheet == nil)
+        XCTAssertNil(window.attachedSheet, "the sheet stayed attached after dismissal")
+        XCTAssertEqual(
+            endAttachedStates, [false],
+            "expected exactly one end notification, with attachedSheet already cleared")
+    }
+
+    // MARK: - The gate
+
+    /// The gate against a real SwiftUI sheet on a real window, fed the calls
+    /// `ContentView`'s two `.onReceive` handlers make. The test above pins that
+    /// those notifications actually arrive, with these objects, at these
+    /// moments; this pins what the monitor does with them — including that the
+    /// end path's re-read of a real `attachedSheet` returns the window to a
+    /// live menu rather than leaving it dead until relaunch.
+    ///
+    /// The `.onReceive` subscription itself is the seam neither test can cross:
+    /// it needs a mounted scene.
+    func testGateClosesWhileARealSheetIsUpAndReopensAfter() throws {
+        let monitor = SheetPresenceMonitor()
+        let box = SheetProbeBox()
+        let host = NSHostingView(rootView: SheetProbeView(box: box))
+        host.frame = NSRect(x: 0, y: 0, width: 400, height: 300)
+        let window = makeWindow(host)
+
+        host.layoutSubtreeIfNeeded()
+        pump()
+        XCTAssertFalse(monitor.sheetPresented, "the gate started closed with no sheet")
+
+        box.presented = true
+        host.layoutSubtreeIfNeeded()
+        pump(until: window.attachedSheet != nil)
+        monitor.noteSheetBegan(on: window, host: window)
+        XCTAssertTrue(
+            monitor.sheetPresented,
+            "the document commands stayed live behind a presented sheet — issue #98")
+
+        box.presented = false
+        host.layoutSubtreeIfNeeded()
+        pump(until: window.attachedSheet == nil)
+        monitor.noteSheetEnded(on: window, host: window)
+        XCTAssertFalse(
+            monitor.sheetPresented,
+            "the gate stayed shut after the sheet closed — the menu would be dead until relaunch")
+    }
+
+    /// A sheet on some OTHER window (Settings, the Help centre, a save panel
+    /// run on a different window) must not disable the main window's commands.
+    /// `object:` filtering in the app's own subscription is on the whole
+    /// notification stream, so the window check has to live in the monitor.
+    func testASheetOnAnotherWindowLeavesTheGateOpen() throws {
+        let monitor = SheetPresenceMonitor()
+        let host = makeWindow()
+        let other = makeWindow()
+
+        monitor.noteSheetBegan(on: other, host: host)
+        XCTAssertFalse(
+            monitor.sheetPresented,
+            "another window's sheet disabled this window's document commands")
+
+        // And the symmetric case: another window's sheet ending must not
+        // re-enable them while this window is genuinely sheeted.
+        monitor.noteSheetBegan(on: host, host: host)
+        monitor.noteSheetEnded(on: other, host: host)
+        XCTAssertTrue(
+            monitor.sheetPresented,
+            "another window's sheet ending re-enabled ⌘W behind a live sheet")
+    }
+
+    /// The end notification re-reads the window rather than assuming "ended
+    /// means nothing left", so a sheet still attached at that moment keeps the
+    /// gate shut. Driven through a real `beginSheet` because the assertion is
+    /// about what `attachedSheet` reports, not about bookkeeping.
+    func testEndRereadsTheWindowSoARemainingSheetKeepsTheGateShut() throws {
+        let monitor = SheetPresenceMonitor()
+        let host = makeWindow()
+        let sheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 120),
+            styleMask: [.titled], backing: .buffered, defer: false)
+
+        host.beginSheet(sheet)
+        pump(until: host.attachedSheet != nil)
+        XCTAssertNotNil(host.attachedSheet, "precondition: the sheet attached")
+
+        // An end notification that arrives while a sheet is still attached (a
+        // stacked presentation) must leave the gate shut.
+        monitor.noteSheetBegan(on: host, host: host)
+        monitor.noteSheetEnded(on: host, host: host)
+        XCTAssertTrue(
+            monitor.sheetPresented,
+            "the gate reopened while a sheet was still attached to the window")
+
+        host.endSheet(sheet)
+        pump(until: host.attachedSheet == nil)
+        monitor.noteSheetEnded(on: host, host: host)
+        XCTAssertFalse(monitor.sheetPresented, "the gate stayed shut with nothing attached")
+    }
+
+    /// Before `WindowAccessor` reports the host window there is nothing to
+    /// compare against, so notifications are ignored rather than guessed at.
+    func testNotificationsBeforeTheHostWindowIsKnownAreIgnored() {
+        let monitor = SheetPresenceMonitor()
+        let some = makeWindow()
+
+        monitor.noteSheetBegan(on: some, host: nil)
+        XCTAssertFalse(monitor.sheetPresented)
+        monitor.noteSheetBegan(on: nil, host: nil)
+        XCTAssertFalse(monitor.sheetPresented)
+    }
+
+}
+
+/// Drives a real SwiftUI sheet from the test body.
+@MainActor
+@Observable
+private final class SheetProbeBox {
+    var presented = false
+}
+
+private struct SheetProbeView: View {
+    @Bindable var box: SheetProbeBox
+
+    var body: some View {
+        Color.gray
+            .sheet(isPresented: $box.presented) {
+                Text("Sheet").frame(width: 200, height: 120)
+            }
+    }
+}

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		B370CC64C56C8E29DC8A4C42 /* WebStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF653B1B8741B61DBE9B55EE /* WebStorage.swift */; };
 		B6535E25C5FC85D2DBE39DC3 /* PdfDocIdRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C33B518BE736FCF7077F63A /* PdfDocIdRegistry.swift */; };
 		B861F8FD72248FD16E1562D4 /* AttachmentDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DFD2EC2ED5A947809EA139F /* AttachmentDrop.swift */; };
+		B8D01DF1656ED81272F4507C /* SheetPresenceMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12408D020F6B22CD99D283AD /* SheetPresenceMonitor.swift */; };
 		BB776BF184FBD5A0469377E2 /* AiPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90963B42EE17356826E8DE90 /* AiPrompts.swift */; };
 		BD31BC1F3FB2299BEC39F054 /* AiToolSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AF0117D296B571E62111BB /* AiToolSummary.swift */; };
 		BF75A2925C8FCE36AD43F41B /* KaTeX_Typewriter-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = E8C9F22335B2DEA99AF5ABF5 /* KaTeX_Typewriter-Regular.woff2 */; };
@@ -171,6 +172,7 @@
 		E4EC8CEAAD8788E622D56A58 /* AiFileAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D76BD9134C505A0D1E0DFEE /* AiFileAttachment.swift */; };
 		E5F120A320C5FC13A9026B70 /* MarkdownMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A774391C8C286453B790F75 /* MarkdownMessage.swift */; };
 		E6B0CB4F9698FD21D03270E1 /* WebContentScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F083E5C02A66A025F06638 /* WebContentScript.swift */; };
+		E8D830B96D822615B4A3AD86 /* SheetPresenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA013D3FF310F0B6AF41E9D /* SheetPresenceTests.swift */; };
 		E902AE322CF4E85CD5937369 /* VellumCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90614A8F48AEDB52A5B7FE1E /* VellumCommands.swift */; };
 		E98C90203E064AA2B272B3A3 /* HomeResultViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F128F9801AD030A1C8DA97 /* HomeResultViews.swift */; };
 		EA8A7AFB3A02F3AD545262CB /* AppIcon.icns in Resources */ = {isa = PBXBuildFile; fileRef = 89E21441131E7C57CE324E83 /* AppIcon.icns */; };
@@ -221,11 +223,13 @@
 		0A7870954383EAE833F32ABF /* FindBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindBar.swift; sourceTree = "<group>"; };
 		0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenRouterCatalog.swift; sourceTree = "<group>"; };
 		102BFBC5EF5B66C15AC2BC86 /* PdfGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfGeometry.swift; sourceTree = "<group>"; };
+		12408D020F6B22CD99D283AD /* SheetPresenceMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetPresenceMonitor.swift; sourceTree = "<group>"; };
 		13F6592FEBC0C0187E0C35A3 /* PageTextCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextCacheTests.swift; sourceTree = "<group>"; };
 		14BA2FED5E906C5D311882E3 /* ChatGPTAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTAuth.swift; sourceTree = "<group>"; };
 		14F128F9801AD030A1C8DA97 /* HomeResultViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeResultViews.swift; sourceTree = "<group>"; };
 		195A20D8270BAD8604C2E641 /* PdfAnnotationCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfAnnotationCodec.swift; sourceTree = "<group>"; };
 		1B7D1E617157C08AD0AB7246 /* HomeSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchStore.swift; sourceTree = "<group>"; };
+		1CA013D3FF310F0B6AF41E9D /* SheetPresenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetPresenceTests.swift; sourceTree = "<group>"; };
 		1DE37DD793875C0DBF92E050 /* KaTeX_Main-BoldItalic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-BoldItalic.woff2"; sourceTree = "<group>"; };
 		20B2D17372EC7164FEB6B7AF /* KaTeX_Math-Italic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Math-Italic.woff2"; sourceTree = "<group>"; };
 		22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabResidencyTests.swift; sourceTree = "<group>"; };
@@ -518,6 +522,7 @@
 				37F7B1CD3853E8F7239B9191 /* ScratchpadMarkdownExporterTests.swift */,
 				709F72C1FA6B697D52FCD5BC /* SelectableMessageTests.swift */,
 				583E0A6988C207365E311AC2 /* SettingsNavigationTests.swift */,
+				1CA013D3FF310F0B6AF41E9D /* SheetPresenceTests.swift */,
 				BF3E4F80AF4A2707D432AF73 /* SidebarDropRoutingTests.swift */,
 				3B76DBD84FB379B34AC58BCE /* StorageManagementTests.swift */,
 				22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */,
@@ -610,6 +615,7 @@
 			isa = PBXGroup;
 			children = (
 				027E09C0BD7A98F4590A5878 /* ContentView.swift */,
+				12408D020F6B22CD99D283AD /* SheetPresenceMonitor.swift */,
 				84875506ADE5E9DDF4F20CC4 /* UITestLaunchConfiguration.swift */,
 				723EC058218A6DF8D994CC26 /* UpdateChecker.swift */,
 				4B19F1048CA6DE0E71C521DB /* VellumApp.swift */,
@@ -1078,6 +1084,7 @@
 				47362B3C5DF753594BDEC3E9 /* SentReferenceChips.swift in Sources */,
 				B1EA8A76FD9FE32930829528 /* SessionService.swift in Sources */,
 				2439956FEFA7E14A045B9289 /* SettingsView.swift in Sources */,
+				B8D01DF1656ED81272F4507C /* SheetPresenceMonitor.swift in Sources */,
 				4F2BA9E78B1F859723D5587C /* SidebarDropCatcher.swift in Sources */,
 				7A22F35E2A3DE9629E53A11D /* StickyNoteOverlay.swift in Sources */,
 				56FC925BB362E1EA594F963B /* StorageHousekeeping.swift in Sources */,
@@ -1156,6 +1163,7 @@
 				F588EF4EEF4D4DA1E50F5D85 /* ScratchpadMarkdownExporterTests.swift in Sources */,
 				FFFCBEA9C2190362FA4B52F5 /* SelectableMessageTests.swift in Sources */,
 				6FF504D4444288CAFA641BF6 /* SettingsNavigationTests.swift in Sources */,
+				E8D830B96D822615B4A3AD86 /* SheetPresenceTests.swift in Sources */,
 				5236947317CC86594F165BD2 /* SidebarDropRoutingTests.swift in Sources */,
 				ACD85838F860C270E27BE7FC /* StorageManagementTests.swift in Sources */,
 				5716E0D875F1A5AD2EC02604 /* TabResidencyTests.swift in Sources */,

--- a/Vellum/App/ContentView.swift
+++ b/Vellum/App/ContentView.swift
@@ -6,6 +6,9 @@ struct ContentView: View {
     @Environment(WorkspaceStore.self) private var workspace
 
     @State private var keyMonitor: Any?
+    /// Whether this window is currently showing a sheet, so the focus value
+    /// below can go away while one is up (issue #98).
+    @State private var sheets = SheetPresenceMonitor()
     @State private var sidebarHovering = false
     @State private var addWebpagePresented = false
     @State private var hostWindow: NSWindow?
@@ -31,11 +34,35 @@ struct ContentView: View {
             .sheet(isPresented: $addWebpagePresented) {
                 AddWebpageSheet()
             }
+            // Every sheet on this window, whoever presents it — the two
+            // first-run sheets in `VellumApp`, this one, the rename and export
+            // sheets deeper in the tree, and the ones Vellum does not own at
+            // all (`.fileImporter`'s open panel, PDFKit's print panel).
+            // `SheetPresenceMonitor` explains why this asks AppKit rather than
+            // watching presentation flags.
+            .onReceive(
+                NotificationCenter.default.publisher(for: NSWindow.willBeginSheetNotification)
+            ) { notification in
+                sheets.noteSheetBegan(on: notification.object as? NSWindow, host: hostWindow)
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(for: NSWindow.didEndSheetNotification)
+            ) { notification in
+                sheets.noteSheetEnded(on: notification.object as? NSWindow, host: hostWindow)
+            }
             // Commands belong to the main window, not whichever nested
             // PDFKit/WebKit/AppKit responder happens to own keyboard focus.
             // A scene-focused value remains available throughout this window
             // and automatically disappears when Settings becomes key.
-            .focusedSceneValue(\.vellumFocus, VellumFocus(workspace: workspace))
+            //
+            // ...and while a sheet is up, because a sheet belongs to the scene
+            // that presents it and so does NOT displace a scene value the way
+            // it displaced the old view-focused one. Publishing nil disables
+            // every document command for as long as the sheet is attached; a
+            // disabled item does not claim its key equivalent, so ⌘W stops
+            // closing the tab behind the sheet (issue #98).
+            .focusedSceneValue(
+                \.vellumFocus, sheets.sheetPresented ? nil : VellumFocus(workspace: workspace))
             .background(WindowAccessor { hostWindow = $0 })
             .onAppear(perform: installKeyMonitor)
             .onDisappear(perform: removeKeyMonitor)

--- a/Vellum/App/SheetPresenceMonitor.swift
+++ b/Vellum/App/SheetPresenceMonitor.swift
@@ -1,0 +1,61 @@
+import AppKit
+import SwiftUI
+
+/// Whether the main window currently has a sheet attached — asked of AppKit,
+/// not inferred from SwiftUI's presentation flags.
+///
+/// #71 moved the document commands' target from `.focusedValue` to
+/// `.focusedSceneValue` so a first-responder PDFView/WKWebView could no longer
+/// grey out the whole menu. A sheet belongs to the scene that presents it, so
+/// unlike the view-focused value it displaced, the scene value stayed published
+/// behind a sheet and every document command stayed live: ⌘W, pressed to get rid
+/// of the sheet, closed the tab underneath (issue #98).
+///
+/// `ContentView` publishes a nil focus value while `sheetPresented`, which
+/// disables those commands. A disabled menu item does not claim its key
+/// equivalent, so the chord no longer reaches "Close Tab" — the pre-#71
+/// behaviour, restored for sheets and nothing else.
+///
+/// WHY APPKIT RATHER THAN A SET OF `isPresented` FLAGS. A presentation flag
+/// records what the app *asked for*, which is not the same as what is on screen:
+///
+///   • macOS will not put a second sheet on a window that already has one. Help
+///     ▸ Vellum Walkthrough is deliberately never disabled (`VellumCommands`),
+///     and the Help centre — a scene of its own, fully live while the main
+///     window is sheeted — posts the same notification. Setting that flag behind
+///     an open sheet latches it true with nothing ever presented, and a gate
+///     built on it would disable the document menu until relaunch. Trading a
+///     mis-enabled ⌘W for a permanently dead File menu is a bad trade.
+///   • It takes one flag per sheet, and Vellum does not present all of its own
+///     sheets. `.fileImporter` (the AI panel's image picker) and PDFKit's print
+///     panel are window-modal sheets too, and ⌘W behind them closed the tab just
+///     the same.
+///
+/// `NSWindow.attachedSheet` has neither problem: it is AppKit's own answer, it
+/// covers every sheet whoever presented it, and it cannot describe a sheet that
+/// is not there.
+///
+/// The two notifications are not symmetric, which is why they get separate
+/// entry points. Both were measured against a real hosted SwiftUI `.sheet` (see
+/// `SheetPresenceTests`): `willBeginSheet` arrives BEFORE `attachedSheet` is
+/// set, so a begin is taken at its word; `didEndSheet` arrives AFTER it is
+/// cleared, so an end re-reads the window instead — which also keeps the gate
+/// closed if some other sheet is still attached.
+@MainActor
+@Observable
+final class SheetPresenceMonitor {
+    private(set) var sheetPresented = false
+
+    /// `NSWindow.willBeginSheetNotification`. The notification's object is the
+    /// window the sheet is being attached TO, not the sheet.
+    func noteSheetBegan(on window: NSWindow?, host: NSWindow?) {
+        guard let host, window === host else { return }
+        sheetPresented = true
+    }
+
+    /// `NSWindow.didEndSheetNotification`, same object convention.
+    func noteSheetEnded(on window: NSWindow?, host: NSWindow?) {
+        guard let host, window === host else { return }
+        sheetPresented = host.attachedSheet != nil
+    }
+}


### PR DESCRIPTION
Closes #98

## Root cause

#71 switched `ContentView` from `.focusedValue` to `.focusedSceneValue`, which fixed the real bug (every menu item greyed out exactly while reading a document, because a first-responder `PDFView`/`WKWebView` displaced the view-focused value). A sheet, though, belongs to the scene that presents it — so unlike the view-focused value it displaced, the scene value stayed published behind a sheet. Every document command stayed enabled, and ⌘W, pressed to get rid of the sheet, closed the tab underneath it.

## Fix

Gate the published value on whether the window actually has a sheet attached. `SheetPresenceMonitor` (new, `Vellum/App/SheetPresenceMonitor.swift`) tracks `NSWindow.attachedSheet` via the window's `willBeginSheet`/`didEndSheet` notifications; `ContentView` publishes `nil` for `\.vellumFocus` while one is up, which disables every document command. A disabled menu item does not claim its key equivalent, so ⌘W no longer reaches "Close Tab".

**Why AppKit rather than a set of `isPresented` flags** — the first thing I built, and the reviewer killed it:

- macOS will not put a second sheet on a window that already has one. Help ▸ Vellum Walkthrough is deliberately never disabled, and the Help centre is a separate scene that stays fully live while the main window is sheeted, so its flag can be set behind an open sheet. It then latches `true` with nothing ever presented — and a gate built on that flag would leave the document menu **dead until relaunch**. Trading a mis-enabled ⌘W for a permanently dead File menu is a bad trade.
- Flags need one per sheet, and Vellum does not present all of its own sheets. `.fileImporter` (the AI panel's image picker) and PDFKit's print panel are window-modal sheets too, with the same defect. AppKit's answer covers them for free.

**Scope note:** the issue named two sheets. There are **six** `.sheet` sites in the main window scene — the two first-run sheets, add-webpage, both rename presenters (tab bar and Home), and the scratchpad export sheet — all with the identical defect, plus the two non-Vellum sheets above. One window-level gate covers all of them uniformly, which is why this ended up smaller than the per-sheet version. Alerts and confirmation dialogs are all in the Settings scene, which never published the value.

## Reviewer findings (fresh-context adversarial review)

Two blockers, both against the original per-sheet-flag approach, both fatal and both fixed by the rewrite above:

1. **Permanent menu lock** via the never-disabled Walkthrough command (described above).
2. **False clear** — `TabBarView` exists per split pane and `WelcomeScreen` per start tab, several instances reporting into one shared enum case; any sibling mounting or unmounting cleared the slot while another instance's sheet was genuinely up, restoring the original bug.

Also raised and acted on: the justifying comment claiming `.fileImporter` is app-modal was factually wrong (it is a sheet); and the original tests were tautological re-assertions of `Set` semantics. Confirmed correct and left alone: the `focusedSceneValue` Optional overload does exist and unpublishes; the key monitor's `event.window === hostWindow` guard already excludes sheet key events; ⌘Q/⌘,/Help/update commands correctly stay live.

One reviewer point I did **not** adopt: it suggested tracking the sheet's content lifecycle (`onAppear`/`onDisappear` on the sheet body). That fixes both blockers too, but still misses `.fileImporter`/print sheets and still depends on the environment crossing the sheet presentation boundary — something this codebase already works around by re-injecting `\.palette` into sheet content.

## Measured

- Full suite green: **476 XCTest + 147 Swift Testing**, zero compiler warnings (warnings-as-errors on).
- 5 new tests, all against real windows and a real hosted SwiftUI sheet.
- The load-bearing AppKit assumptions were **measured, not assumed**, and are now pinned by `testSwiftUISheetIsAnAttachedAppKitSheetWithTheExpectedNotifications`: a SwiftUI `.sheet` really does attach an AppKit sheet to the presenting window; `willBeginSheet` fires with `attachedSheet` **not yet** set; `didEndSheet` fires with it **already** cleared. The monitor is written around exactly that asymmetry.
- Flake watch: one full-suite run failed 4 asserts in `DocumentDataStoreTests.testLazyMigrationCopiesSharedAttachmentForSecondNote`. Re-run green (476/476) and that suite alone green (25/25). Same suite and same "attachment missing when the assert ran" symptom as the known flake #100, and it runs alphabetically before anything added here.

## Explicitly unverified

- **No runtime confirmation of the actual key press.** The `.focusedSceneValue` plumbing and AppKit's "a disabled item declines its key equivalent" behaviour both need a running scene with a real menu bar and a real key event. The AppKit rule is documented and the notification half is now tested, but nobody pressed ⌘W.
- **⌘W does not *dismiss* the sheet** — it does nothing (beep). SwiftUI sheets have no ⌘W handler and `File ▸ Close` is fully replaced by the custom "Close Tab" command, so there is no `performClose:` path. Escape is what dismisses these sheets. This fixes the destructive half of #98 (⌘W closing the tab behind the sheet); it does not add sheet dismissal.
- The `.onReceive` subscription itself (notification → monitor call) is the one seam no unit test can cross; both sides of it are tested separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)