### PR TITLE
Fix inspector switcher styling, drop zone, and shortcuts

### DIFF
--- a/Tests/InspectorPresentationTests.swift
+++ b/Tests/InspectorPresentationTests.swift
@@ -134,6 +134,43 @@ struct InspectorPresentationTests {
         #expect(workspace.inspectorPresented)
     }
 
+    /// What ⌥⌘1/2/3 do (issue #101). The commands are disabled without a
+    /// document, so the interesting half is the reveal: selecting a panel while
+    /// the inspector is closed has to open it, or the shortcut appears to do
+    /// nothing at all.
+    @Test("Revealing a panel selects it and opens a closed inspector")
+    func revealSidebarTabOpensTheInspector() async {
+        let workspace = WorkspaceStore(sessions: InspectorSessionService())
+        await workspace.focusedPane.app.openFile(path: "/tmp/inspector-test.pdf")
+        workspace.setInspectorPresented(false)
+        #expect(workspace.inspectorPresented == false)
+
+        workspace.revealSidebarTab(.scratchpad)
+        #expect(workspace.sidebarTab == .scratchpad)
+        #expect(workspace.sidebarOpen)
+        #expect(workspace.inspectorPresented)
+
+        // Reveal, never toggle: pressing the same shortcut again must not close
+        // the panel it just opened. ⌥⌘S is the toggle.
+        workspace.revealSidebarTab(.scratchpad)
+        #expect(workspace.inspectorPresented)
+        #expect(workspace.sidebarTab == .scratchpad)
+    }
+
+    /// The belt-and-braces half of the gate. The menu items are disabled with
+    /// no document; if one ever fired anyway it must not flip `sidebarOpen`,
+    /// which is the preference the *next* document would open with.
+    @Test("Revealing a panel does nothing without a document")
+    func revealSidebarTabIsInertWithoutADocument() {
+        let workspace = WorkspaceStore(sessions: InspectorSessionService())
+        workspace.sidebarOpen = false
+        #expect(workspace.focusedPane.app.document == nil)
+
+        workspace.revealSidebarTab(.ai)
+        #expect(workspace.sidebarOpen == false)
+        #expect(workspace.sidebarTab == .annotations)
+    }
+
     @Test("Remembered inspector width ignores out-of-range and suppressed geometry")
     func rememberSidebarWidthRejectsUnusableMeasurements() async throws {
         let workspace = WorkspaceStore(sessions: InspectorSessionService())

--- a/Tests/InspectorTabSwitcherTests.swift
+++ b/Tests/InspectorTabSwitcherTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 @testable import Vellum
 
@@ -49,6 +50,16 @@ final class InspectorTabSwitcherTests: XCTestCase {
         }
     }
 
+    /// The header's height is a drop-routing fact as much as a layout one: it
+    /// is the strip issue #101 found was not a drag target, and
+    /// `SidebarDropRoutingTests` aims at its midpoint. Pinned with a literal so
+    /// the drop test cannot start aiming somewhere else by accident.
+    func testHeaderHeightIsTheStripTheCatcherMustCover() {
+        XCTAssertEqual(InspectorLayout.switcherHeight, 30)
+        XCTAssertEqual(InspectorLayout.switcherVerticalPadding, 8)
+        XCTAssertEqual(InspectorLayout.headerHeight, 46)
+    }
+
     func testPresentationRespondsAtEachWidthClass() {
         XCTAssertEqual(
             InspectorLayout.presentation(for: InspectorLayout.idealWidth),
@@ -69,6 +80,44 @@ final class InspectorTabSwitcherTests: XCTestCase {
         XCTAssertEqual(
             Set(WorkspaceStore.SidebarTab.allCases.map(\.systemImage)).count,
             WorkspaceStore.SidebarTab.allCases.count)
+    }
+
+    /// The panel shortcuts follow the switcher's own left-to-right order, so
+    /// ⌥⌘2 always means "the middle one". Written out rather than derived from
+    /// `allCases` so reordering the panels has to be a deliberate decision here.
+    func testPanelShortcutDigitsFollowTheSwitcherOrder() {
+        XCTAssertEqual(
+            WorkspaceStore.SidebarTab.allCases.map(\.shortcutDigit),
+            ["1", "2", "3"])
+        XCTAssertEqual(WorkspaceStore.SidebarTab.annotations.shortcutDigit, "1")
+        XCTAssertEqual(WorkspaceStore.SidebarTab.ai.shortcutDigit, "2")
+        XCTAssertEqual(WorkspaceStore.SidebarTab.scratchpad.shortcutDigit, "3")
+    }
+
+    /// The collision guard, comparing the two real constants rather than a
+    /// remembered value. Plain ⌘1…⌘9 already activate TABS (`VellumCommands`
+    /// ▸ Navigate, from #83); binding the panels to the same chord would give
+    /// two enabled menu items one key equivalent, and AppKit would hand it to
+    /// whichever menu it walked first. The digits deliberately DO overlap —
+    /// that is what the different modifier is for — so the modifier is the
+    /// entire separation, and changing EITHER side to match the other fails
+    /// here.
+    func testPanelShortcutsDoNotCollideWithTabSwitching() {
+        let panel = WorkspaceStore.SidebarTab.shortcutModifiers
+        let tabs = VellumCommands.tabShortcutModifiers
+        XCTAssertNotEqual(
+            panel, tabs,
+            "the inspector panels and the tab switcher claim the same chord for ⌘1/2/3")
+        XCTAssertEqual(panel, [.command, .option])
+        XCTAssertEqual(tabs, .command)
+
+        // Every panel digit is inside the range the Navigate menu claims, which
+        // is exactly why the modifiers have to differ.
+        for tab in WorkspaceStore.SidebarTab.allCases {
+            XCTAssertTrue(
+                ("1"..."9").contains(tab.shortcutDigit),
+                "\(tab.shortcutDigit) is not a digit the switcher can reach")
+        }
     }
 
     func testCollapsedControlValueReflectsEverySelection() {

--- a/Tests/SidebarDropRoutingTests.swift
+++ b/Tests/SidebarDropRoutingTests.swift
@@ -175,6 +175,31 @@ final class SidebarDropRoutingTests: XCTestCase {
         host.convert(NSPoint(x: host.bounds.midX, y: host.bounds.midY), to: nil)
     }
 
+    /// The window point at the middle of the inspector's switcher header — the
+    /// strip that used to sit above the catcher and take no drops (issue #101).
+    /// `NSHostingView` is flipped, so the header is at LOW y.
+    private func headerPoint(of host: NSView) -> NSPoint {
+        XCTAssertTrue(host.isFlipped, "an unflipped host would put the header at the other end")
+        return host.convert(
+            NSPoint(x: host.bounds.midX, y: host.bounds.minY + InspectorLayout.headerHeight / 2),
+            to: nil)
+    }
+
+    /// How far down the column the visible panel's own content begins, measured
+    /// off a real AppKit view the panel owns (the scratchpad's editor WebView).
+    /// The header, if this stack builds it, is what pushes it down.
+    ///
+    /// Measured values, so the next reader knows the margin this discriminates
+    /// on: 44pt with the header built by the caller (the panel's own inset
+    /// alone), 91pt with the header inside the stack (44 + the 46pt header and
+    /// its 1pt divider). The `>= headerHeight` assertion sits between them.
+    private func panelContentTop(in host: NSView) throws -> CGFloat {
+        let editor = try XCTUnwrap(
+            firstSubview(of: ScratchpadWebView.self, in: host),
+            "the scratchpad editor is not mounted, so the panels' top cannot be measured")
+        return editor.convert(editor.bounds, to: host).minY
+    }
+
     // MARK: - Tests
 
     /// The destination AppKit would pick over the AI panel must be our AppKit
@@ -198,6 +223,77 @@ final class SidebarDropRoutingTests: XCTestCase {
             String(describing: type(of: dest)).contains("PlatformDraggingDestination"),
             "a SwiftUI _PlatformDraggingDestinationView is frontmost again — it will " +
             "steal and refuse the drag exactly like the original bug")
+    }
+
+    /// The switcher header is part of the drop target (issue #101). Until the
+    /// header moved inside `SidebarPanelStack`, the catcher's NSView started
+    /// below it, so the inspector's top ~46pt silently refused every drag — the
+    /// user aims at the panel they can see, hits the header, and nothing
+    /// happens. Same destination, same routing, same attachment as the middle
+    /// of the panel.
+    ///
+    /// The limit of the harness: it mounts `SidebarPanelStack`, so it proves the
+    /// catcher covers the header THAT STACK BUILDS. That the header is built
+    /// there at all — rather than by the caller, above the stack, as it was
+    /// before #101 — is structural and is the reason this test's coordinate
+    /// means anything.
+    func testSwitcherHeaderIsPartOfTheSidebarDropTarget() throws {
+        let file = try writeFixture("header-drop.png", try pngFixtureData())
+        let (host, workspace, pane) = hostSidebar(initialTab: .annotations)
+        flip(workspace, to: .ai, host: host)
+
+        // The structural half, and the one that fails on the old arrangement:
+        // the panels start BELOW the header, which is only true when the stack
+        // builds the header itself. Built by the caller above the stack, as it
+        // was before #101, the panel content starts at the top of the stack and
+        // the drop point below lands on the panel rather than on the header —
+        // which is exactly how the header could look covered while the live app
+        // refused drags there.
+        let panelTop = try panelContentTop(in: host)
+        XCTAssertGreaterThanOrEqual(
+            panelTop, InspectorLayout.headerHeight,
+            "the sidebar's panel content starts \(panelTop)pt down; the " +
+            "\(InspectorLayout.headerHeight)pt switcher header is not above it, so this " +
+            "stack is not the one that owns the header")
+
+        let point = headerPoint(of: host)
+        let dest = try XCTUnwrap(
+            dragDestination(in: host, windowPoint: point),
+            "no registered drag destination over the switcher header")
+        XCTAssertTrue(
+            dest is SidebarDropView,
+            "the frontmost drag destination over the header is \(type(of: dest)), " +
+            "not the AppKit SidebarDropView — the header is outside the catcher again")
+
+        let drag = finderDrag(of: [file], at: point)
+        XCTAssertEqual(
+            dest.draggingEntered(drag), .copy,
+            "a drag over the header did not light up while the AI panel was visible")
+        XCTAssertTrue(dest.performDragOperation(drag), "the header drop was not accepted")
+
+        pump(until: !pane.ai.composerReferences.isEmpty)
+        XCTAssertEqual(
+            pane.ai.composerReferences.count, 1,
+            "a drop on the header did not route to the visible panel's store")
+    }
+
+    /// The header follows the visible tab like the rest of the sidebar: over
+    /// annotations there is nothing to attach to, so the same point refuses.
+    /// Without this, a catcher that blanket-accepted everything would pass the
+    /// test above.
+    func testSwitcherHeaderRefusesWhileAnnotationsIsVisible() throws {
+        let file = try writeFixture("header-refused.png", try pngFixtureData())
+        let (host, _, _) = hostSidebar(initialTab: .annotations)
+
+        let point = headerPoint(of: host)
+        let dest = try XCTUnwrap(
+            dragDestination(in: host, windowPoint: point),
+            "no registered drag destination over the switcher header")
+
+        let drag = finderDrag(of: [file], at: point)
+        XCTAssertEqual(
+            dest.draggingEntered(drag), [],
+            "the header accepted a drag while the annotations panel was visible")
     }
 
     /// "Add to AI Chat" must not leave a keyboard user stranded in the document.

--- a/Vellum/App/ContentView.swift
+++ b/Vellum/App/ContentView.swift
@@ -216,31 +216,24 @@ private struct WindowChrome: View {
             VellumToolbar()
         }
         .inspector(isPresented: inspectorPresented) {
-            // The tab switcher lives INSIDE the inspector, not in its window
-            // toolbar: AppKit collapses toolbar items into an overflow menu at
-            // narrow window widths, and that synthesized overflow exposed only
-            // one of the three sections — so a narrow window could strand the
-            // user on whichever panel was already selected. Here every
-            // destination stays reachable at every width.
-            VStack(spacing: 0) {
-                InspectorTabSwitcher(selection: sidebarTabBinding)
-                    .padding(.horizontal, InspectorLayout.switcherHorizontalPadding)
-                    .padding(.vertical, 8)
-                Divider()
-                sidebar
-            }
-            .inspectorColumnWidth(
-                min: InspectorLayout.minimumWidth,
-                ideal: workspace.sidebarWidth,
-                max: InspectorLayout.maximumWidth)
-            // Feeds the user's splitter drag back to the store so the next
-            // document reopens the column where they left it. The store
-            // rejects the collapsed measurements a start tab produces.
-            .onGeometryChange(for: CGFloat.self) { proxy in
-                proxy.size.width
-            } action: { width in
-                workspace.rememberSidebarWidth(width)
-            }
+            // The whole column, switcher header included, is one view: the
+            // header used to be assembled here, above `SidebarPanelStack`, which
+            // left it outside the stack's AppKit drop catcher and so made the
+            // inspector's top ~46pt the one strip of the sidebar that refused
+            // drags (issue #101).
+            sidebar
+                .inspectorColumnWidth(
+                    min: InspectorLayout.minimumWidth,
+                    ideal: workspace.sidebarWidth,
+                    max: InspectorLayout.maximumWidth)
+                // Feeds the user's splitter drag back to the store so the next
+                // document reopens the column where they left it. The store
+                // rejects the collapsed measurements a start tab produces.
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.size.width
+                } action: { width in
+                    workspace.rememberSidebarWidth(width)
+                }
         }
     }
 
@@ -251,13 +244,6 @@ private struct WindowChrome: View {
         Binding(
             get: { workspace.inspectorPresented },
             set: { workspace.setInspectorPresented($0) }
-        )
-    }
-
-    private var sidebarTabBinding: Binding<WorkspaceStore.SidebarTab> {
-        Binding(
-            get: { workspace.sidebarTab },
-            set: { workspace.sidebarTab = $0 }
         )
     }
 
@@ -299,7 +285,8 @@ private struct DocumentErrorNotice: View {
     }
 }
 
-/// The three sidebar panels, stacked. All three stay mounted in a ZStack; only
+/// The whole inspector column: the tab switcher header, then the three sidebar
+/// panels. All three panels stay mounted in a ZStack; only their
 /// visibility toggles as the tab changes. Keeping them alive (rather than
 /// switching, which destroys the inactive ones) preserves each panel's transient
 /// state across tab flips — the AI panel's scroll position and half-typed
@@ -324,6 +311,17 @@ private struct DocumentErrorNotice: View {
 /// code (composer text views, the scratchpad WebView) stays as belt-and-braces
 /// but is unreachable by design while the frontmost catcher is present.
 ///
+/// The header is assembled HERE rather than by the caller so that it sits under
+/// the same catcher overlay as the panels. Built above it — as it was until
+/// #101 — the switcher row was the one strip of the inspector that would not
+/// take a drop, because the catcher's NSView only ever covered the panels.
+///
+/// Two deliberate consequences of that move: the drop outline now traces the
+/// whole column rather than stopping under the header, and the caller's
+/// `.onHover` (which arms the ⌘+/⌘− sidebar text sizing) now covers the header
+/// too — right, since the header is part of the sidebar, but it does mean ⌘+
+/// over the switcher resizes sidebar text instead of zooming the document.
+///
 /// Internal (not `private`) so `SidebarDropRoutingTests` can drive the real
 /// stacked hierarchy headlessly.
 struct SidebarPanelStack: View {
@@ -342,13 +340,26 @@ struct SidebarPanelStack: View {
     @State private var dropTargeted = false
 
     var body: some View {
-        ZStack {
-            panel(.annotations) { AnnotationSidebar() }
-            panel(.ai) { AiPanel() }
-            panel(.scratchpad) { ScratchpadPanel() }
+        VStack(spacing: 0) {
+            // The tab switcher lives INSIDE the inspector, not in its window
+            // toolbar: AppKit collapses toolbar items into an overflow menu at
+            // narrow window widths, and that synthesized overflow exposed only
+            // one of the three sections — so a narrow window could strand the
+            // user on whichever panel was already selected. Here every
+            // destination stays reachable at every width.
+            InspectorTabSwitcher(selection: sidebarTabBinding)
+                .padding(.horizontal, InspectorLayout.switcherHorizontalPadding)
+                .padding(.vertical, InspectorLayout.switcherVerticalPadding)
+            Divider()
+            ZStack {
+                panel(.annotations) { AnnotationSidebar() }
+                panel(.ai) { AiPanel() }
+                panel(.scratchpad) { ScratchpadPanel() }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .clipped()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .clipped()
         .overlay {
             if dropTargeted {
                 RoundedRectangle(cornerRadius: Radius.md)
@@ -363,12 +374,23 @@ struct SidebarPanelStack: View {
         // target); AI and scratchpad accept an attachment-carrying drag and route
         // the payload to their store. A non-image dropped on the scratchpad still
         // reaches its handler and is explained.
+        //
+        // Overlaid on the VStack, so it spans the switcher header too. The
+        // catcher's `hitTest` returns nil for every point, so the header's
+        // buttons keep receiving clicks exactly as the panels' controls do.
         .overlay {
             SidebarDropCatcher(
                 resolveOperation: resolveDropOperation,
                 onTargeted: { dropTargeted = $0 },
                 onDrop: routeDrop)
         }
+    }
+
+    private var sidebarTabBinding: Binding<WorkspaceStore.SidebarTab> {
+        Binding(
+            get: { workspace.sidebarTab },
+            set: { workspace.sidebarTab = $0 }
+        )
     }
 
     /// The drag operation to report for the current tab, evaluated live when

--- a/Vellum/App/VellumCommands.swift
+++ b/Vellum/App/VellumCommands.swift
@@ -44,6 +44,11 @@ struct VellumCommands: Commands {
     /// them go dead whenever Settings or the Help centre is key.
     let appWorkspace: WorkspaceStore
 
+    /// Modifier for the ⌘1…⌘9 tab-switching commands in the Navigate menu.
+    /// Named so the inspector panel commands, which reuse the digits, can be
+    /// checked against it rather than against a remembered value.
+    static let tabShortcutModifiers: EventModifiers = .command
+
     // MARK: Availability (drives menu validation)
 
     private var hasFocus: Bool { focus != nil }
@@ -153,6 +158,35 @@ struct VellumCommands: Commands {
             .keyboardShortcut("s", modifiers: [.command, .option])
             .disabled(!hasDocument)
 
+            // One command per inspector panel, so the switcher is reachable
+            // from the keyboard (issue #101). Each reveals its panel, opening
+            // the inspector if it is closed — see `revealSidebarTab`. Gated on
+            // a document for the same reason the toggle above is: without one
+            // there is no inspector to put a panel in.
+            //
+            // The icon slot carries a checkmark for the current panel, the way
+            // the switcher's own compact menu marks it: these three are a
+            // mutually exclusive choice, and a menu that offers one without
+            // showing which is already taken makes the user open the inspector
+            // to find out.
+            ForEach(WorkspaceStore.SidebarTab.allCases) { tab in
+                Button {
+                    workspace?.revealSidebarTab(tab)
+                } label: {
+                    Label {
+                        Text("Show \(tab.title)")
+                    } icon: {
+                        Image(
+                            systemName: workspace?.sidebarTab == tab
+                                ? "checkmark" : tab.systemImage)
+                    }
+                }
+                .keyboardShortcut(
+                    KeyEquivalent(tab.shortcutDigit),
+                    modifiers: WorkspaceStore.SidebarTab.shortcutModifiers)
+                .disabled(!hasDocument)
+            }
+
             Divider()
 
             // Split shortcuts avoid the arrow keys, which ⌘⌥↑/↓ already use for
@@ -218,11 +252,14 @@ struct VellumCommands: Commands {
 
             Divider()
 
-            // Tab switching ⌘1…⌘9.
+            // Tab switching ⌘1…⌘9. The modifier is named because the inspector
+            // panel commands (View menu) use the same digits and must not
+            // collide with it — `InspectorTabSwitcherTests` compares the two.
             ForEach(1...9, id: \.self) { number in
                 Button(tabTitle(index: number - 1)) { activateTab(index: number - 1) }
                     .keyboardShortcut(
-                        KeyEquivalent(Character("\(number)")), modifiers: .command)
+                        KeyEquivalent(Character("\(number)")),
+                        modifiers: VellumCommands.tabShortcutModifiers)
                     .disabled(!tabExists(index: number - 1))
             }
         }

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -78,6 +78,27 @@ final class WorkspaceStore {
         sidebarOpen = isPresented
     }
 
+    /// Selects an inspector panel and makes sure it is actually on screen.
+    ///
+    /// The ⌥⌘1/2/3 menu commands route here rather than assigning `sidebarTab`
+    /// directly: selecting a panel in a closed inspector would change nothing
+    /// the user can see, so choosing one from the menu has to open the column
+    /// too. Reveal only — it never closes an inspector that is already open,
+    /// because ⌥⌘S is the toggle and a panel command that sometimes hid the
+    /// panel would be a trap.
+    ///
+    /// Nothing is done without a document: the inspector cannot be presented
+    /// then (`inspectorPresented`), so opening it would silently flip the user's
+    /// preference for whenever they next open one. The menu items are already
+    /// disabled in that state, so this guard is belt-and-braces — note it is
+    /// stricter than the ⌥⌘S toggle beside them, which writes `sidebarOpen`
+    /// directly and leans entirely on `.disabled`.
+    func revealSidebarTab(_ tab: SidebarTab) {
+        guard focusedPane.app.document != nil else { return }
+        sidebarTab = tab
+        sidebarOpen = true
+    }
+
     /// Remembers user resizing while the inspector is genuinely visible.
     /// Geometry briefly collapses when a start tab suppresses the inspector;
     /// rejecting that transient measurement lets the next document reopen at

--- a/Vellum/Views/Shared/InspectorTabSwitcher.swift
+++ b/Vellum/Views/Shared/InspectorTabSwitcher.swift
@@ -25,6 +25,15 @@ enum InspectorLayout {
 
     /// Inset applied to the switcher inside the inspector column.
     static let switcherHorizontalPadding: CGFloat = 12
+    static let switcherVerticalPadding: CGFloat = 8
+    static let switcherHeight: CGFloat = 30
+
+    /// Height of the inspector's header row — the control plus its inset,
+    /// stopping above the divider. Named because it is a drop-routing fact, not
+    /// only a layout one: this row (plus the 1pt divider below it, so 47pt of
+    /// dead strip in all) was NOT a drag target until `SidebarPanelStack` took
+    /// ownership of the header and brought it under the catcher (issue #101).
+    static var headerHeight: CGFloat { switcherHeight + switcherVerticalPadding * 2 }
 
     /// The narrowest width the switcher can actually be handed: the column
     /// cannot go below `minimumWidth`, and the switcher is inset inside it.
@@ -87,6 +96,25 @@ extension WorkspaceStore.SidebarTab: Identifiable {
 
     /// The full identifier each destination control carries, in every layout.
     var accessibilityIdentifier: String { "sidebarTab.\(accessibilityIdentifierStem)" }
+
+    /// Digit of the shortcut that reveals this panel from the View menu.
+    ///
+    /// Numbered in `allCases` order, so the shortcut matches the left-to-right
+    /// order of the switcher itself rather than an independent list that could
+    /// drift from it.
+    var shortcutDigit: Character {
+        switch self {
+        case .annotations: "1"
+        case .ai: "2"
+        case .scratchpad: "3"
+        }
+    }
+
+    /// ⌥⌘, not plain ⌘: ⌘1…⌘9 already switch TABS from the Navigate menu (#83),
+    /// and a tab is the thing most users reach for first. ⌥⌘ is also the prefix
+    /// the neighbouring inspector commands already use — ⌥⌘S toggles the
+    /// inspector, ⌥⌘\ and ⌥⌘J drive the splits.
+    static let shortcutModifiers: EventModifiers = [.command, .option]
 }
 
 /// Responsive navigation for the inspector's three persistent panels.
@@ -97,6 +125,11 @@ extension WorkspaceStore.SidebarTab: Identifiable {
 /// Keeping the control here guarantees that all destinations remain reachable.
 struct InspectorTabSwitcher: View {
     @Binding var selection: WorkspaceStore.SidebarTab
+
+    @Environment(\.palette) private var palette
+    /// Hovered segment, so an unselected one can preview the selection surface
+    /// the way the annotation filter chips and Home rows do.
+    @State private var hovering: WorkspaceStore.SidebarTab?
 
     var body: some View {
         GeometryReader { proxy in
@@ -109,7 +142,7 @@ struct InspectorTabSwitcher: View {
                 compactMenu
             }
         }
-        .frame(height: 30)
+        .frame(height: InspectorLayout.switcherHeight)
         .accessibilityElement(children: .contain)
     }
 
@@ -117,6 +150,7 @@ struct InspectorTabSwitcher: View {
         HStack(spacing: 0) {
             ForEach(WorkspaceStore.SidebarTab.allCases) { tab in
                 let isSelected = selection == tab
+                let isHovering = hovering == tab
                 Button {
                     withAnimation(.snappy) {
                         selection = tab
@@ -133,18 +167,31 @@ struct InspectorTabSwitcher: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(isSelected ? .primary : .secondary)
+                // All three parts of the shared selection language — tinted
+                // label, tinted fill, hairline edge — exactly as the annotation
+                // filter chips and the Home result rows use it, and as the
+                // picker this control replaced used the fill and edge.
+                //
+                // NOT `.quaternary` / `.separator`: those resolve from the color
+                // scheme rather than from our palette, which is what sent
+                // `Keycap` to `palette.muted`/`borderStrong` in #70. Being
+                // precise about what that buys here, because the fill alone
+                // does not carry it: `SelectionStyle.fill` is only
+                // `primary.opacity(0.16)`, which against this track measures
+                // ~1.28:1 in light — no better than the quaternary it replaces.
+                // The signal comes from the other two. The label goes from
+                // near-black to `palette.primary` (7.35:1 on `muted` in light,
+                // 3.86:1 in dark) and the edge from `.separator` to a 45%
+                // primary stroke (1.56:1 → 2.15:1). Selected now reads as
+                // *indigo*, in both schemes, rather than as a slightly
+                // different shade of the surrounding grey.
+                .foregroundStyle(
+                    SelectionStyle.foreground(palette, selected: isSelected, hovering: isHovering))
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
-                .background {
-                    if isSelected {
-                        Capsule()
-                            .fill(.quaternary)
-                            .overlay {
-                                Capsule().strokeBorder(.separator, lineWidth: 1)
-                            }
-                    }
-                }
+                .selectionSurface(
+                    selected: isSelected, hovering: isHovering, in: Capsule(), palette: palette)
+                .onHover { hovering = $0 ? tab : nil }
                 .accessibilityLabel(tab.title)
                 .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
                 .accessibilityIdentifier(tab.accessibilityIdentifier)
@@ -152,7 +199,10 @@ struct InspectorTabSwitcher: View {
         }
         .font(.callout)
         .padding(2)
-        .background(.quaternary.opacity(0.35), in: Capsule())
+        // The recessed track behind the thumb, from the palette for the same
+        // reason: `muted` is defined for both schemes and stays visible against
+        // parchment, where a scheme-derived quaternary wash does not.
+        .background(palette.muted, in: Capsule())
     }
 
     private var compactMenu: some View {


### PR DESCRIPTION
Closes #101

Three follow-ups from #73, all in and around `InspectorTabSwitcher`.

## 1. Light-mode washout

**Root cause.** The switcher drew its selected thumb with `.quaternary` inside a `.quaternary` track and edged it with `.separator`. Those resolve from the system color scheme rather than from `ThemePalette` — the same defect that sent `Keycap` to palette colors in #70.

**Fix.** Route all three parts through the app's selection language, as the annotation filter chips and Home result rows already do: `SelectionStyle.foreground` for the label, `selectionSurface` (`SelectionStyle.fill`/`edge`) for the thumb, `palette.muted` for the track. Hover state added so an unselected segment previews the surface, matching the other call sites.

**Numbers, because the reviewer's contrast math changed the fix.** My first pass swapped only the fill and edge and claimed that cured the washout. It does not: `SelectionStyle.fill` is `primary.opacity(0.16)`, which against this track measures **1.28:1** in light — no better than the `.quaternary` it replaces, and slightly *worse* in dark (1.36 → 1.22). The signal actually comes from the other two: the label goes to `palette.primary` at **7.35:1** (light) / **3.86:1** (dark), and the edge from `.separator` to a 45% primary stroke, 1.56:1 → **2.15:1**. Selected now reads as *indigo* in both schemes rather than as a slightly different grey. The comment in the code states this rather than over-claiming.

## 2. Lost drop zone

**Root cause.** The header was assembled by the caller (`WindowChrome`) *above* `SidebarPanelStack`, while `SidebarDropCatcher` is overlaid *inside* that stack. The catcher's NSView therefore started below the header, and the inspector's top 47pt (46pt header + 1pt divider) silently refused every drag.

**Fix.** `SidebarPanelStack` now owns the header, which puts it under the same catcher overlay. **No `.onDrop` was added** — the hard rule holds; the existing AppKit catcher simply covers more. Verified by grep that the sidebar subtree still has zero SwiftUI drop handling.

Two deliberate consequences, both documented in the code: the drop outline now traces the whole column, and the caller's `.onHover` (which arms ⌘+/⌘− sidebar text sizing) now includes the header — correct, since the header is part of the sidebar, but it is a behavior change.

## 3. Missing shortcuts

⌘1–9 **are** already taken by tab switching (#83), so panels take **⌥⌘1/2/3** — the prefix the neighbouring inspector toggle (⌥⌘S) and split commands already use, and incidentally Xcode's own convention (⌘1-9 navigator / ⌥⌘1-9 inspector). Each reveals its panel and opens the inspector if closed (`WorkspaceStore.revealSidebarTab`), gated on a document like the ⌥⌘S toggle beside it, with a checkmark marking the current panel the way the switcher's own compact menu does.

## Reviewer findings (fresh-context adversarial review)

**Blocker — my first drop tests passed against the unfixed code.** The catcher is a SwiftUI `.overlay`, which always matches its parent's frame, so "catcher spans the full column" was 700 == 700 before *and* after the fix; and the harness mounts `SidebarPanelStack` alone, so pre-fix the header point simply landed on the panel and routed fine. My own mutation check had missed it because I mutated the overlay's position rather than the header's ownership. Replaced with the structural fact the coordinate depends on: the panels start below the header, measured off the scratchpad's real editor WebView. **Verified by mutation** — reverting the header to the caller now fails with `panel content starts 44.0pt down; the 46.0pt switcher header is not above it`.

Also acted on: the contrast math above (the fix would have shipped a 1.28:1 fill); menu items showed no current-panel state; the collision test was tautological (both modifier sets are now named constants the test compares directly, so changing *either* side fails); plus nits on comment accuracy (46 vs 47pt, the unreachable `isFlipped` branch, a `revealSidebarTab` comment citing a precedent that does not hold).

Confirmed correct and left alone: no `.onDrop` leaked in; `hitTest → nil` keeps the switcher's buttons clickable under the catcher; no shortcut collisions anywhere in the app; `.disabled(!hasDocument)` is the right gate; `ForEach` in a `CommandGroup` is fine; the column geometry plumbing and both UI-test `sidebarTab.*` lookups are unaffected by the extra nesting.

## Measured

- Full suite green: **476 XCTest + 149 Swift Testing**, zero compiler warnings (warnings-as-errors on).
- 7 new tests. All four mutants caught: catcher moved below the header, header moved back to the caller, panel shortcut modifiers changed to plain ⌘, and `revealSidebarTab` not opening a closed inspector.
- `sidebarTab.*` identifier tests from #73 kept green and untouched.
- Flake watch: one run failed `StorageManagementTests.testAiLegacyListAndRemove` on cross-test state (a `/tmp/ai-conv-*.pdf` where the fixture expected `/tmp/a.pdf`); re-run green 476/476. Same shared-state isolation family as known flake #100, unrelated to anything here.

## Explicitly unverified

- **The visual result. Nobody looked at it.** The contrast figures above are computed from the hex values in `ThemePalette`, not observed. The code matches the established pattern exactly; one glance in light mode is still what settles #101 part 1.
- **No real drag was performed.** The drop tests drive AppKit's destination search and the catcher's overrides with a fake `NSDraggingInfo`, which is the harness this repo mandates — but AppKit routing a live drag to the view under the cursor is the one thing it cannot cover.
- **No real key press.** ⌥⌘1/2/3 are asserted at the level of the constants and the store method; nothing tests that `VellumCommands` binds them, so a mis-wire (all three on "1", or the action calling `sidebarTab =` directly) would pass the suite. The existing `UITests` scheme drives menu items by title and could close this, but it launches the real app and is outside the unit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)