### PR TITLE
Serialize PDF page-text extraction to stop Live Text ANE crashes

### DIFF
--- a/Tests/PageTextExtractionGateTests.swift
+++ b/Tests/PageTextExtractionGateTests.swift
@@ -1,0 +1,177 @@
+import XCTest
+@testable import Vellum
+
+// Unit tests for the process-wide page-text extraction gate
+// (Services/Ai/PageTextExtractionGate), which serializes and paces every PDFKit
+// text read that can reach Live Text, so concurrent first-time CoreML/ANE model
+// compiles can't crash the process.
+//
+// Each test builds its own gate instead of touching `.shared`, so ordering state
+// never leaks between tests. A page that reaches Live Text is simulated by
+// returning an empty string — which is exactly what `PDFPage.string` does on an
+// image-only page (measured at ~0.02 ms, i.e. the recognition PDFKit starts is
+// still running after the call returns).
+
+@MainActor
+final class PageTextExtractionGateTests: XCTestCase {
+
+    /// Main-actor scratchpad recording the order bodies actually ran in.
+    private final class Recorder {
+        private(set) var entries: [String] = []
+        func log(_ name: String) -> String {
+            entries.append(name)
+            return name
+        }
+    }
+
+    /// Block the main thread for `duration`. Deliberately a busy-wait: the gate's
+    /// secondary pacing signal is how long the *synchronous* body took, which
+    /// sleeping wouldn't reproduce.
+    private static func spin(for duration: Duration) {
+        let deadline = ContinuousClock.now + duration
+        while ContinuousClock.now < deadline {}
+    }
+
+    /// Run one scanned-page extraction so the gate owes a cooldown. The next
+    /// acquirer then holds the slot across a real suspension, which is the
+    /// window these tests use to queue work behind it.
+    private func primeCooldown(on gate: PageTextExtractionGate) async {
+        _ = await gate.extractText(priority: .background) { "" }
+    }
+
+    // (1) An AI request queued behind the background walk runs first: the walk
+    // only ever costs a chat turn the single page already in flight.
+    func testOnDemandJumpsAheadOfQueuedBackgroundWork() async {
+        let gate = PageTextExtractionGate()
+        await primeCooldown(on: gate)
+        let recorder = Recorder()
+
+        let holder = Task { await gate.extractText(priority: .background) { recorder.log("holder") } }
+        await Task.yield()
+        let queuedBackground = Task {
+            await gate.extractText(priority: .background) { recorder.log("background") }
+        }
+        let queuedOnDemand = Task {
+            await gate.extractText(priority: .onDemand) { recorder.log("onDemand") }
+        }
+
+        _ = await holder.value
+        _ = await queuedBackground.value
+        _ = await queuedOnDemand.value
+        XCTAssertEqual(recorder.entries, ["holder", "onDemand", "background"])
+        XCTAssertEqual(gate.queueDepth, 0)
+    }
+
+    // (2) Background waiters keep FIFO order among themselves.
+    func testBackgroundWaitersStayInQueueOrder() async {
+        let gate = PageTextExtractionGate()
+        await primeCooldown(on: gate)
+        let recorder = Recorder()
+
+        let holder = Task { await gate.extractText(priority: .background) { recorder.log("holder") } }
+        await Task.yield()
+        let first = Task { await gate.extractText(priority: .background) { recorder.log("first") } }
+        await Task.yield()
+        let second = Task { await gate.extractText(priority: .background) { recorder.log("second") } }
+
+        _ = await holder.value
+        _ = await first.value
+        _ = await second.value
+        XCTAssertEqual(recorder.entries, ["holder", "first", "second"])
+    }
+
+    // (3) A walk cancelled on tab deactivation must leave the queue without
+    // running its body and without stranding the slot for everyone behind it.
+    func testCancelledWaiterReleasesTheQueue() async {
+        let gate = PageTextExtractionGate()
+        await primeCooldown(on: gate)
+        let recorder = Recorder()
+
+        let holder = Task { await gate.extractText(priority: .background) { recorder.log("holder") } }
+        await Task.yield()
+        let cancelled = Task {
+            await gate.extractText(priority: .background) { recorder.log("cancelled") }
+        }
+        let follower = Task {
+            await gate.extractText(priority: .background) { recorder.log("follower") }
+        }
+        await Task.yield()
+        XCTAssertEqual(gate.queueDepth, 2, "both waiters should be parked behind the holder")
+
+        cancelled.cancel()
+        let cancelledResult = await cancelled.value
+        XCTAssertNil(cancelledResult, "a cancelled waiter must not run its body")
+
+        _ = await holder.value
+        _ = await follower.value
+        XCTAssertEqual(recorder.entries, ["holder", "follower"])
+        XCTAssertEqual(gate.queueDepth, 0, "the cancelled waiter must not strand the slot")
+    }
+
+    // (4) A task cancelled before it ever reaches the gate does no work.
+    func testAlreadyCancelledCallerSkipsExtraction() async {
+        let gate = PageTextExtractionGate()
+        let recorder = Recorder()
+        let task = Task {
+            // Give the test a chance to cancel before the gate is entered.
+            try? await Task.sleep(for: .milliseconds(20))
+            return await gate.extractText(priority: .background) { recorder.log("body") }
+        }
+        task.cancel()
+        let result = await task.value
+        XCTAssertNil(result)
+        XCTAssertTrue(recorder.entries.isEmpty)
+    }
+
+    // (5) A page that came back with no text — the shape that reaches Live Text
+    // — paces the next extraction, so bursts of scanned pages can't stack ANE
+    // model loads.
+    func testEmptyPageResultPacesTheNextExtraction() async {
+        let gate = PageTextExtractionGate()
+        _ = await gate.extractText(priority: .background) { "" }
+        let started = ContinuousClock.now
+        _ = await gate.extractText(priority: .onDemand) { "page text" }
+        let waited = ContinuousClock.now - started
+        XCTAssertGreaterThanOrEqual(
+            waited, .milliseconds(10), "the page after a scanned one should be paced")
+    }
+
+    // (6) So does a read slow enough to have recognized text synchronously,
+    // in case PDFKit ever makes `page.string` block on Live Text.
+    func testSlowExtractionAlsoPacesTheNextOne() async {
+        let gate = PageTextExtractionGate()
+        _ = await gate.extractText(priority: .background) {
+            Self.spin(for: .milliseconds(30))
+            return "recognized text"
+        }
+        let started = ContinuousClock.now
+        _ = await gate.extractText(priority: .onDemand) { "page text" }
+        XCTAssertGreaterThanOrEqual(ContinuousClock.now - started, .milliseconds(10))
+    }
+
+    // (7) …but a document with a real text layer is not paced at all: those
+    // reads never reach Live Text, so whole-document indexing stays as fast as
+    // it was before the gate existed.
+    func testTextLayerPagesAreNotPaced() async {
+        let gate = PageTextExtractionGate()
+        let started = ContinuousClock.now
+        for page in 0..<40 {
+            _ = await gate.extractText(priority: .background) { "text of page \(page)" }
+        }
+        let elapsed = ContinuousClock.now - started
+        XCTAssertLessThan(
+            elapsed, .milliseconds(200), "text-layer pages must not inherit the OCR cooldown")
+    }
+
+    // (8) A body that declines to read (already cached, wrong document) reports
+    // nil and must not be mistaken for a scanned page.
+    func testSkippedReadDoesNotPaceTheNextExtraction() async {
+        let gate = PageTextExtractionGate()
+        _ = await gate.extractText(priority: .background) { nil }
+        let started = ContinuousClock.now
+        _ = await gate.extractText(priority: .background) { "page text" }
+        XCTAssertLessThan(
+            ContinuousClock.now - started, .milliseconds(10),
+            "skipping a cached page should cost nothing")
+    }
+}

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		0A8D06EC43340A3149052C29 /* AttachmentDropTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F125F1382328217B11BF1DB2 /* AttachmentDropTests.swift */; };
 		0CB718F359EABB9D0B724732 /* AiPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2423823E0BE86C417B6ABBC6 /* AiPanel.swift */; };
 		0F794D4A0D0E512001684D97 /* KaTeX_Math-BoldItalic.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = B313F26C338D071377D89FE9 /* KaTeX_Math-BoldItalic.woff2 */; };
+		114C5F995D5A05DB62C0BF54 /* PageTextExtractionGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2296945CE1660D607D4F253B /* PageTextExtractionGateTests.swift */; };
 		115E39AAB39E90058E9718A7 /* PdfMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21D7E5EC3C32E20B0FDC7DB /* PdfMetadata.swift */; };
 		14218CF999DD463A3DA6A52F /* WalkthroughSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6A0F0FCE599D735A694D605 /* WalkthroughSettings.swift */; };
 		143FFEB4FBB9A94F4F582E96 /* AiToolSourceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E9308A43A15E8D1EAAEC887 /* AiToolSourceRow.swift */; };
@@ -155,6 +156,7 @@
 		CCD31E1E8A71BB0E987EC90B /* SelectionPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D0B4D5702156DFEC64496C9 /* SelectionPopover.swift */; };
 		CE12B2EB31D5767A335D7E04 /* InspectorTabSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A82232CED8811F2320FD91 /* InspectorTabSwitcher.swift */; };
 		CEC1AA6947BD18989D606580 /* VellumConsistencyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA8A917E6A4B1C20FDC7C74 /* VellumConsistencyUITests.swift */; };
+		CF02D8DF508465ACECEC7436 /* PageTextExtractionGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F0E655E1727AA1DA9413F0 /* PageTextExtractionGate.swift */; };
 		D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82487970E20F6628200C4BE /* KeychainStore.swift */; };
 		D3E15D784AC0EF97D1BE22E8 /* purify.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 4B707464546ECFFA1A49EBDE /* purify.min.js */; };
 		D4A79DFDB08A01D35D47933A /* AiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F38132FDC803C6ACEB43CC /* AiStore.swift */; };
@@ -228,6 +230,7 @@
 		1B7D1E617157C08AD0AB7246 /* HomeSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchStore.swift; sourceTree = "<group>"; };
 		1DE37DD793875C0DBF92E050 /* KaTeX_Main-BoldItalic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-BoldItalic.woff2"; sourceTree = "<group>"; };
 		20B2D17372EC7164FEB6B7AF /* KaTeX_Math-Italic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Math-Italic.woff2"; sourceTree = "<group>"; };
+		2296945CE1660D607D4F253B /* PageTextExtractionGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextExtractionGateTests.swift; sourceTree = "<group>"; };
 		22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabResidencyTests.swift; sourceTree = "<group>"; };
 		236D6A7A9EA6BF08E9D6FB10 /* DocumentRenameService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentRenameService.swift; sourceTree = "<group>"; };
 		2423823E0BE86C417B6ABBC6 /* AiPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiPanel.swift; sourceTree = "<group>"; };
@@ -275,6 +278,7 @@
 		5FC3857FDCFA8B1D42B01B73 /* HighlightLayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HighlightLayer.swift; sourceTree = "<group>"; };
 		63D1A270BA1DE40AC978F462 /* HomeSearchRanker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchRanker.swift; sourceTree = "<group>"; };
 		672A0EE8F8913FD534AAF5B2 /* StorageLocationChoiceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageLocationChoiceSheet.swift; sourceTree = "<group>"; };
+		67F0E655E1727AA1DA9413F0 /* PageTextExtractionGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageTextExtractionGate.swift; sourceTree = "<group>"; };
 		6B421C24A86AB0139E135C7D /* UITestLaunchConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestLaunchConfigurationTests.swift; sourceTree = "<group>"; };
 		6E72498058A69F542C2A4CCF /* ScratchpadPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchpadPanel.swift; sourceTree = "<group>"; };
 		6F5F272385E3E99333CFC6C1 /* MarkdownParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParserTests.swift; sourceTree = "<group>"; };
@@ -456,6 +460,7 @@
 				0D0C63462421A1E994C543BB /* OpenRouterCatalog.swift */,
 				96768879872A93B8FD39C342 /* OpenRouterClient.swift */,
 				5513F929B10D107AED515D1E /* PageTextCache.swift */,
+				67F0E655E1727AA1DA9413F0 /* PageTextExtractionGate.swift */,
 				504DC8725E6198531EC21429 /* PageTextPersister.swift */,
 				144717E4B51F7552741BDCE2 /* OAuth */,
 			);
@@ -509,6 +514,7 @@
 				9E7DC69283E8EFA7F1D589A3 /* InspectorTabSwitcherTests.swift */,
 				6F5F272385E3E99333CFC6C1 /* MarkdownParserTests.swift */,
 				13F6592FEBC0C0187E0C35A3 /* PageTextCacheTests.swift */,
+				2296945CE1660D607D4F253B /* PageTextExtractionGateTests.swift */,
 				524641B76B46DE4D791F4E6A /* PaneTreeTests.swift */,
 				A5003641A54B311693588C6C /* PdfPersistenceTests.swift */,
 				BB2C2905E4A08861E42C2EED /* RecentsResolveTests.swift */,
@@ -1051,6 +1057,7 @@
 				FE7D8E1CF0734B927687D5AF /* OpenRouterClient.swift in Sources */,
 				309920512501052A787792CF /* PKCE.swift in Sources */,
 				249CCA82E8B519D78426C055 /* PageTextCache.swift in Sources */,
+				CF02D8DF508465ACECEC7436 /* PageTextExtractionGate.swift in Sources */,
 				D529B1BD4F7B9FA1E791246F /* PageTextPersister.swift in Sources */,
 				4E8BAA1F3AEC100D4C768AFA /* PaneTree.swift in Sources */,
 				74F87D19B20B4A7A23919B5F /* PaneTreeView.swift in Sources */,
@@ -1147,6 +1154,7 @@
 				3134DD9F8B448D0A1DC4BB69 /* InspectorTabSwitcherTests.swift in Sources */,
 				8E2B30ED60C29E54F33081F7 /* MarkdownParserTests.swift in Sources */,
 				91ACF610BE2A44480DD31843 /* PageTextCacheTests.swift in Sources */,
+				114C5F995D5A05DB62C0BF54 /* PageTextExtractionGateTests.swift in Sources */,
 				2E35DAA98C4A45A551382874 /* PaneTreeTests.swift in Sources */,
 				806EDA3BB34A3680F7B39E1B /* PdfPersistenceTests.swift in Sources */,
 				17CEDFD80E708ADD26650928 /* RecentsResolveTests.swift in Sources */,

--- a/Vellum/Services/Ai/PageTextExtractionGate.swift
+++ b/Vellum/Services/Ai/PageTextExtractionGate.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+// Process-wide serialization for PDFKit page-text extraction.
+//
+// `PDFPage.string` reads like a cheap property, but on a page with no text layer
+// PDFKit falls back to Live Text: it loads — and, the first time, *compiles* — a
+// CoreML model for the Apple Neural Engine. Vellum never imports Vision or
+// CoreML, which is why the SIGSEGV crash reports (inside ANECompiler/Espresso,
+// on com.apple.coreml.MLModelAssetResourceFactory's modelLoadQueue, with
+// TextRecognition on the stack) contain no Vellum frame doing anything
+// ML-shaped. The trigger is asking for several scanned pages at once:
+// overlapping first-time compiles race on shared compiler state and take the
+// whole process down.
+//
+// Vellum had four independent producers of `page.string` bursts — the background
+// 1→N walk (one per activated tab, so two in a split), the per-turn AI context
+// fill, the `getPageText` tool, and `searchDocument`'s whole-document pass —
+// each running as its own Task against the same document, interleaving at their
+// suspension points. They all funnel through this gate now.
+//
+// Measured on macOS 26: `page.string` on an image-only page returns an empty
+// string in ~0.02 ms, versus ~1.5 ms for a page with a real text layer. It does
+// *not* block on recognition, so the recognition PDFKit kicks off is still
+// running after the call returns — which is precisely how our requests end up
+// overlapping even though every one of them is issued from the main actor. That
+// measurement is why pacing keys off an *empty* result rather than off how long
+// the call took: an empty read is the page shape that sends PDFKit to Live Text.
+//
+// Not covered: `PDFDocument.findString` (⌘F), which scans the whole document in
+// one synchronous main-thread call and so can also drive Live Text. Gating it
+// would mean making the find handler async all the way up through AppStore, so
+// it is left alone for now — it is user-initiated and never concurrent with
+// itself, unlike the four extraction loops.
+
+/// Serializes and paces every PDFKit text read that can reach Live Text.
+///
+/// Main-actor isolated on purpose: PDFKit text extraction on a displayed
+/// document has to stay on the main actor anyway, so the gate costs no thread
+/// hops and `release` can stay synchronous. What it actually buys is (a) an
+/// enforced gap after every page that had no text layer, and (b) an end to
+/// main-actor *reentrancy* between the four extraction loops, which previously
+/// interleaved into one unpaced burst.
+@MainActor
+final class PageTextExtractionGate {
+    /// The one gate the app runs through. Tests build their own instance.
+    static let shared = PageTextExtractionGate()
+
+    /// Queue position. `onDemand` (the AI needs this page to answer *now*) jumps
+    /// ahead of every queued `background` page, so a whole-document walk never
+    /// makes a chat turn wait for hundreds of pages — it only ever waits out the
+    /// single page already in flight.
+    enum Priority {
+        case background
+        case onDemand
+    }
+
+    /// Minimum gap between one Live-Text-capable read and the next, giving
+    /// PDFKit's recognition — which outlives the `page.string` call — room to
+    /// finish before another request stacks another model load on top of it.
+    /// Matches the background walk's existing 16 ms idle pacing, and is measured
+    /// from the *end* of the previous page, so the walk's own sleep normally
+    /// absorbs it rather than adding to it.
+    private static let cooldown: Duration = .milliseconds(16)
+
+    /// A read this slow went through recognition synchronously. Kept alongside
+    /// the empty-result signal because PDFKit is free to change which of the two
+    /// shapes a scanned page takes; either one means "pace the next caller".
+    private static let ocrDurationThreshold: Duration = .milliseconds(25)
+
+    private struct Waiter {
+        let id: UInt64
+        let priority: Priority
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var isBusy = false
+    private var waiters: [Waiter] = []
+    private var nextWaiterId: UInt64 = 0
+    /// When the last Live-Text-suspected read finished; nil when the previous
+    /// read came back with real text and no cooldown is owed.
+    private var lastSuspectFinish: ContinuousClock.Instant?
+
+    init() {}
+
+    /// Number of tasks queued behind the in-flight extraction. Test seam.
+    var queueDepth: Int { waiters.count }
+
+    /// Run one `page.string`-style read with exclusive process-wide access.
+    ///
+    /// `body` returns the text it extracted, or nil if it decided not to read at
+    /// all (already cached, wrong document, and so on). The gate uses that
+    /// return value to decide whether the *next* caller has to wait out the
+    /// cooldown: text back means a text layer and no pacing, empty back means a
+    /// page Live Text is likely still chewing on, nil back means no read
+    /// happened and nothing to pace.
+    ///
+    /// Returns nil without running `body` when the calling task was cancelled
+    /// (tab deactivation cancels the background walk mid-flight). The slot is
+    /// released on every exit path, cancelled or not.
+    func extractText(priority: Priority, _ body: () -> String?) async -> String? {
+        guard await acquire(priority: priority) else { return nil }
+        var suspectedLiveText = false
+        defer { release(pacingNeeded: suspectedLiveText) }
+        // Acquiring can suspend for a long time behind a queue of scanned pages;
+        // a walk cancelled in that window must not go on to extract anything.
+        guard !Task.isCancelled else { return nil }
+        let started = ContinuousClock.now
+        let text = body()
+        if let text {
+            suspectedLiveText = text.isEmpty
+                || ContinuousClock.now - started >= Self.ocrDurationThreshold
+        }
+        return text
+    }
+
+    /// Takes the slot, waiting in the priority queue if something else holds it.
+    /// Returns false only when the caller was cancelled while queued — in which
+    /// case it holds nothing and must not release.
+    private func acquire(priority: Priority) async -> Bool {
+        if Task.isCancelled { return false }
+        if isBusy {
+            let id = nextWaiterId
+            nextWaiterId += 1
+            let admitted = await withTaskCancellationHandler {
+                await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+                    // Registration is synchronous main-actor work, so the hop
+                    // scheduled by `onCancel` below can never observe a
+                    // half-registered waiter.
+                    waiters.append(Waiter(id: id, priority: priority, continuation: continuation))
+                }
+            } onCancel: {
+                Task { @MainActor in self.dropWaiter(id: id) }
+            }
+            // `release` hands the slot straight over, so `isBusy` is already
+            // true for us when we were admitted.
+            guard admitted else { return false }
+        } else {
+            isBusy = true
+        }
+        await waitOutCooldown()
+        return true
+    }
+
+    private func release(pacingNeeded: Bool) {
+        lastSuspectFinish = pacingNeeded ? ContinuousClock.now : nil
+        guard let index = nextWaiterIndex() else {
+            isBusy = false
+            return
+        }
+        let waiter = waiters.remove(at: index)
+        // Hand the slot over directly rather than clearing `isBusy`: nothing can
+        // slip in between this resume and the waiter actually running.
+        waiter.continuation.resume(returning: true)
+    }
+
+    /// The first `onDemand` waiter if there is one, else the oldest waiter —
+    /// FIFO within a band, with AI requests jumping the background walk.
+    ///
+    /// A long run of `onDemand` pages (a whole-document `searchDocument`) can
+    /// starve the walk for its duration. That is deliberate and harmless: both
+    /// fill the same `pageTexts`/`PageTextCache`, so the walk resumes afterwards
+    /// and skips everything the search already extracted.
+    private func nextWaiterIndex() -> Int? {
+        if let urgent = waiters.firstIndex(where: { $0.priority == .onDemand }) { return urgent }
+        return waiters.isEmpty ? nil : 0
+    }
+
+    /// Cancelled while queued: leave the queue without ever taking the slot.
+    /// A waiter that was already admitted is simply not here any more — it will
+    /// notice `Task.isCancelled` itself and release normally.
+    private func dropWaiter(id: UInt64) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+    }
+
+    private func waitOutCooldown() async {
+        guard let lastSuspectFinish else { return }
+        let remaining = Self.cooldown - (ContinuousClock.now - lastSuspectFinish)
+        guard remaining > .zero else { return }
+        // Cancellation here is fine to swallow: `extractText` re-checks
+        // `Task.isCancelled` before it runs anything.
+        try? await Task.sleep(for: remaining)
+    }
+}

--- a/Vellum/Views/PDF/PdfSelectionBridge.swift
+++ b/Vellum/Views/PDF/PdfSelectionBridge.swift
@@ -800,6 +800,52 @@ final class PdfViewerController {
 
     // MARK: - AI page-text feed (getTextContent pass)
 
+    /// Outcome of one gated page extraction.
+    private enum PageExtractionOutcome {
+        case extracted
+        /// Someone else (the other loop, or the cache restore) already has it.
+        case alreadyCached
+        /// The document or the active tab changed under us, or we were
+        /// cancelled: the caller must stop walking.
+        case stale
+    }
+
+    /// Extract one page's text and publish it to the AI store, the tab runtime
+    /// and the persistent cache.
+    ///
+    /// The single choke point for `page.string` on this controller: it holds
+    /// `PageTextExtractionGate` for the call, so the background walk, the AI
+    /// context fill and the tool paths can never hand PDFKit two Live Text OCR
+    /// requests at once (see PageTextExtractionGate for why that crashes). The
+    /// cache re-check happens *inside* the gate, so a page that the other loop
+    /// filled while this request sat in the queue is skipped, not re-extracted.
+    private func extractPage(
+        _ pageNumber: Int, from document: PDFDocument, tabId: String?,
+        priority: PageTextExtractionGate.Priority
+    ) async -> PageExtractionOutcome {
+        // Starts at `.stale` so a caller cancelled while queued — the gate never
+        // runs the body then — stops walking, same as a document change.
+        var outcome = PageExtractionOutcome.stale
+        _ = await PageTextExtractionGate.shared.extractText(priority: priority) { () -> String? in
+            guard self.document === document, self.app?.activeTabId == tabId,
+                  let ai = self.ai, let page = document.page(at: pageNumber - 1) else { return nil }
+            guard ai.pageTexts[pageNumber] == nil else {
+                outcome = .alreadyCached
+                return nil
+            }
+            let text = page.string ?? ""
+            guard let normalized = ai.setPageText(page: pageNumber, text: text) else {
+                outcome = .alreadyCached
+                return text
+            }
+            self.runtime?.pageTexts[pageNumber] = normalized
+            self.persister?.noteExtracted(page: pageNumber, text: normalized)
+            outcome = .extracted
+            return text
+        }
+        return outcome
+    }
+
     func startTextExtraction() {
         extractionTask?.cancel()
         guard let document else { return }
@@ -816,16 +862,14 @@ final class PdfViewerController {
                 // Idle pacing stand-in for requestIdleCallback's 16 ms fallback.
                 try? await Task.sleep(for: .milliseconds(16))
                 if Task.isCancelled { return }
-                guard let self, self.document === document,
-                      self.app?.activeTabId == tabId,
-                      let page = document.page(at: pageNumber - 1) else { return }
-                // Skip pages already restored from the cache: don't even read
-                // page.string (the expensive part) — true resume of a partial walk.
-                if self.ai?.pageTexts[pageNumber] == nil,
-                   let normalized = self.ai?.setPageText(page: pageNumber, text: page.string ?? "") {
-                    self.runtime?.pageTexts[pageNumber] = normalized
-                    self.persister?.noteExtracted(page: pageNumber, text: normalized)
-                }
+                guard let self else { return }
+                // Skip pages already restored from the cache: don't even queue
+                // for the gate, let alone read page.string (the expensive part)
+                // — true resume of a partial walk.
+                if self.ai?.pageTexts[pageNumber] != nil { continue }
+                let outcome = await self.extractPage(
+                    pageNumber, from: document, tabId: tabId, priority: .background)
+                if case .stale = outcome { return }
             }
             // Whole document walked: flush with complete = true.
             await self?.persister?.flush()
@@ -833,13 +877,24 @@ final class PdfViewerController {
     }
 
     /// On-demand text extraction for the AI request path: fill `pageTexts` for
-    /// the requested 1-indexed pages (or the whole document when `pages` is nil)
-    /// with no idle pacing, so a search/read never misses a page the background
-    /// 1→N walk hasn't reached yet. `AiStore.setPageText`'s dedupe keeps this
-    /// idempotent with that walk. Returns how many pages it newly populated
-    /// (drives the `.indexing` indicator). A cooperative yield every so often
-    /// keeps the run loop responsive during a big whole-document pass without
-    /// reintroducing the walk's 16 ms sleep.
+    /// the requested 1-indexed pages (or the whole document when `pages` is nil),
+    /// so a search/read never misses a page the background 1→N walk hasn't
+    /// reached yet. Returns how many pages it newly populated (drives the
+    /// `.indexing` indicator).
+    ///
+    /// Pages go one at a time through `PageTextExtractionGate` at `.onDemand`
+    /// priority: it both serializes this pass against the background walk (and
+    /// against a second split pane's walk) and jumps it ahead of that walk's
+    /// queued pages, so an AI turn waits for at most the one page in flight
+    /// rather than for a whole-document crawl. The gate also inserts its idle
+    /// gap after any page that came back without text — the scanned pages that
+    /// reach Live Text — which is what stops `searchDocument`'s whole-document
+    /// pass from firing bursts of recognition requests. Pages with a real text
+    /// layer are not paced at all, so ordinary PDFs index as fast as before.
+    ///
+    /// `AiStore.setPageText`'s dedupe plus the gate's in-lock cache re-check keep
+    /// this idempotent with the walk. A cooperative yield every so often keeps
+    /// the run loop responsive when the gate is uncontended and never suspends.
     @discardableResult
     func ensureExtracted(pages: Set<Int>?) async -> Int {
         guard let document, let ai else { return 0 }
@@ -855,21 +910,22 @@ final class PdfViewerController {
         var sinceYield = 0
         // Same generation guard as the walk: bail if the active tab changes
         // mid-pass (this handler slot may still be draining for an old tab).
+        // Re-evaluated per iteration inside `extractPage`, since this loop now
+        // suspends on the gate between pages.
         let tabId = app?.activeTabId
         for pageNumber in targets where ai.pageTexts[pageNumber] == nil {
-            guard self.document === document, app?.activeTabId == tabId,
-                  let page = document.page(at: pageNumber - 1) else { break }
-            if let normalized = ai.setPageText(page: pageNumber, text: page.string ?? "") {
-                runtime?.pageTexts[pageNumber] = normalized
-                persister?.noteExtracted(page: pageNumber, text: normalized)
+            switch await extractPage(
+                pageNumber, from: document, tabId: tabId, priority: .onDemand)
+            {
+            case .stale: return extracted
+            case .alreadyCached: continue
+            case .extracted: extracted += 1
             }
-            extracted += 1
             sinceYield += 1
             // PDFKit text extraction on a displayed document intentionally stays
             // on the main actor (thread-safety), so this yield cadence is the only
-            // responsiveness lever — smaller bursts keep the UI more responsive at
-            // the cost of more hops. A persistent text cache (PR B) will make
-            // whole-document on-demand extraction rare.
+            // responsiveness lever when the gate hands the slot straight back
+            // without suspending (every page of an ordinary text PDF).
             if sinceYield >= 8 {
                 sinceYield = 0
                 await Task.yield()
@@ -888,7 +944,14 @@ final class PdfViewerController {
         let needle = query
             .replacingOccurrences(of: "\\s+", with: "", options: .regularExpression)
             .lowercased()
-        guard !needle.isEmpty, let pageString = page.string else { return nil }
+        guard !needle.isEmpty else { return nil }
+        // Same Live Text hazard as the extraction loops: on a scanned page this
+        // `page.string` runs OCR, so it takes the gate rather than racing a walk
+        // that is mid-compile (see PageTextExtractionGate).
+        let extractedPage = await PageTextExtractionGate.shared.extractText(priority: .onDemand) {
+            page.string ?? ""
+        }
+        guard let pageString = extractedPage, !pageString.isEmpty else { return nil }
 
         // Whitespace-free lowercase haystack; every character remembers the
         // UTF-16 range of the source character that produced it.


### PR DESCRIPTION
## The crash

Crash reports show SIGSEGV inside **ANECompiler/Espresso** on
`com.apple.coreml.MLModelAssetResourceFactory.modelLoadQueue`, with
`TextRecognition` on the stack — in an app that never imports Vision or CoreML.

`PDFPage.string` looks like a cheap property read, but on a page with no text
layer PDFKit falls back to **Live Text**, which loads and (the first time)
*compiles* a CoreML model for the Apple Neural Engine. Overlapping first-time
compiles race on shared compiler state and take the process down. Every one of
those compiles came from a `page.string` call of ours.

## Why we were issuing bursts

Four independent producers, each its own `Task` against the same document,
interleaving at their suspension points:

| # | Path | Behaviour before |
|---|------|------------------|
| 1 | `PdfViewerView.activate()` → `startTextExtraction()` | full 1→N walk, 16 ms/page — **one per activated tab**, so two in a split |
| 2 | AI chat turn → `ensureExtracted(current + visible)` | back-to-back, `Task.yield()` every 8 pages |
| 3 | `getPageText` tool | `ensureExtracted([page])` |
| 4 | `searchDocument` tool | `ensureExtracted(nil)` — **the whole document** through that unpaced loop |

Plus a fifth the issue didn't list: `locateText` (the AI highlight locator) read
`page.string` directly, ungated.

Being on the main actor was never protection. Measured on macOS 26:

```
text-layer page:  ~1.5  ms,  93 chars
image-only page:  ~0.02 ms,   0 chars
```

`page.string` does **not** block on recognition — it returns empty immediately
and the recognition PDFKit kicked off is still running. Four loops taking turns
at `await` points is exactly how those tails end up stacked on each other.

## The fix

One main-actor-isolated `PageTextExtractionGate`, shared process-wide, that
every OCR-capable read now goes through.

- **Serialized.** One extraction in flight at a time, across all tabs, panes and
  AI paths.
- **Adaptive pacing, keyed off the text rather than the clock.** A page that came
  back *empty* — the shape that reaches Live Text — makes the next caller wait
  out a 16 ms cooldown. A page with real text isn't paced at all, so
  whole-document indexing of ordinary PDFs stays as fast as before. (A read slow
  enough to have recognized synchronously also paces, in case PDFKit ever changes
  that.) This is why the heuristic isn't duration-based: the measurement above
  shows a duration-only signal would never fire.
- **No double pacing.** The cooldown is measured from the *end* of the previous
  page, so the background walk's existing 16 ms sleep absorbs it.
- **Priority.** On-demand AI requests jump ahead of queued background pages, so a
  chat turn waits for the one page in flight, not a whole-document crawl. A long
  on-demand run can starve the walk — deliberate and harmless, since both fill the
  same cache and the walk skips what the search already extracted.
- **No duplicated work.** The `pageTexts` re-check moved *inside* the gate, so a
  page the other loop filled while this one was queued is skipped, not
  re-extracted.
- **Cancellation intact.** A walk cancelled on tab deactivate leaves the queue
  without ever taking the slot; a caller cancelled after admission still releases
  it. `pauseTextExtraction()` behaves exactly as before.

## Not covered

`PDFDocument.findString` (⌘F) also scans the whole document in one synchronous
call and can drive Live Text. Gating it means making the find handler async all
the way up through `AppStore`, so it's left alone for now and documented in the
gate — it's user-initiated and never concurrent with itself, unlike these loops.

## Testing

- 8 new unit tests (`Tests/PageTextExtractionGateTests.swift`): queue ordering,
  on-demand priority, FIFO within a band, cancellation while queued, cancellation
  before entry, both pacing signals, and that a skipped/cached read doesn't pace.
- Full unit suite green (95 tests), run three times for stability.
- `xcodebuild ... build` warning-free (the target builds with
  `SWIFT_TREAT_WARNINGS_AS_ERRORS`).
- Reviewed with the `swift-concurrency-pro` skill: continuation resumed exactly
  once on every path, no check-then-act across a suspension, cancellation handler
  can't observe a half-registered waiter.
- A GUI smoke launch was attempted via `aero-launch-m`; the app came up but
  produced no window in that non-interactive launch context, so the end-to-end
  visual check is **not** part of this verification. Worth a manual open of a
  scanned PDF before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved PDF text extraction by coordinating concurrent page reads.
  * Prioritized on-demand searches and extraction requests over background processing.
  * Added pacing for OCR- or Live Text-intensive pages to improve responsiveness.

* **Reliability**
  * Improved cancellation handling and prevented stale extraction work after document changes.
  * Reused cached page text and skipped unnecessary reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->