### PR TITLE
Make inspector sidebar resizable again

### DIFF
--- a/UITests/VellumConsistencyUITests.swift
+++ b/UITests/VellumConsistencyUITests.swift
@@ -71,4 +71,68 @@ final class VellumConsistencyUITests: VellumUITestCase {
             app.textFields["welcome.urlField"].waitForExistence(timeout: 8),
             "The first-run hero should offer the URL field on an empty library")
     }
+
+    /// Regression for the side panel that could not be resized.
+    ///
+    /// `.inspectorColumnWidth` was applied *inside* `.onGeometryChange` on the
+    /// inspector content. The column-width envelope is a view trait the
+    /// inspector host reads off the root of that content, and it does not
+    /// survive being wrapped — so the host saw nothing, fell back to its
+    /// built-in 270pt column, and registered no min/max range for AppKit to
+    /// resize between. The divider was inert.
+    ///
+    /// What this pins is the observable signature of that fallback: the column
+    /// must open at its declared 360pt ideal, and expose a seam. 270pt here
+    /// means the trait got swallowed again and the panel is stuck.
+    ///
+    /// The seam drag itself is deliberately NOT driven here. XCUITest's
+    /// synthesized press-and-drag does not drive AppKit's divider tracking
+    /// loop — it reports success and the splitter never moves, on fixed and
+    /// broken builds alike, so an assertion on it would pass vacuously or fail
+    /// for the wrong reason. Dragging was verified out of band against the
+    /// splitter's settable `AXValue`: on this code it moves (360pt -> 500pt and
+    /// stays); with `.inspectorColumnWidth` back inside `.onGeometryChange` the
+    /// same write is refused and the column holds at 270pt.
+    func testInspectorColumnUsesItsDeclaredWidthEnvelope() throws {
+        let app = makeApp(opening: try makePDF())
+        app.launch()
+        waitForDocument(in: app)
+
+        let annotations = app.descendants(matching: .any)["sidebarTab.annotations"].firstMatch
+        let scratchpad = app.descendants(matching: .any)["sidebarTab.scratchpad"].firstMatch
+        if !annotations.waitForExistence(timeout: 3) {
+            app.buttons["toolbar.sidebarToggle"].tap()
+        }
+        XCTAssertTrue(annotations.waitForExistence(timeout: 5))
+        XCTAssertTrue(scratchpad.waitForExistence(timeout: 5))
+
+        // AppKit exposes the inspector seam as the window's one AXSplitter, so
+        // the column is exactly the strip to its right. Measuring off the
+        // splitter (rather than the switcher's insets) keeps this honest if the
+        // panel's padding ever changes.
+        let window = app.windows.firstMatch
+        let splitter = app.splitters.firstMatch
+        XCTAssertTrue(
+            splitter.waitForExistence(timeout: 5),
+            "The inspector column exposed no splitter to drag")
+        func columnWidth() -> CGFloat {
+            window.frame.maxX - splitter.frame.midX
+        }
+
+        let opened = columnWidth()
+        XCTAssertEqual(
+            opened, 360, accuracy: 6,
+            "Inspector opened at ~\(Int(opened))pt. Expected the declared 360pt ideal; "
+            + "~270pt means .inspectorColumnWidth stopped reaching the inspector host, "
+            + "which also leaves the seam with no range to drag between.")
+
+        // The seam must sit inside the declared envelope, not against the
+        // window edge — a column pinned at a framework default would still
+        // expose a splitter, so existence alone is not enough.
+        XCTAssertGreaterThan(
+            splitter.frame.midX, window.frame.minX,
+            "The inspector seam is not inside the window")
+        XCTAssertLessThanOrEqual(opened, 700, "The column overran its declared maximum")
+        XCTAssertGreaterThanOrEqual(opened, 280, "The column undercut its declared minimum")
+    }
 }

--- a/Vellum/App/ContentView.swift
+++ b/Vellum/App/ContentView.swift
@@ -19,7 +19,9 @@ struct ContentView: View {
         // is hosted separately and only inherits ancestor environment — injecting
         // inside WindowChrome's own body would leave the toolbar without an
         // AppStore. Each pane's subtree re-injects its own triple, overriding this.
-        WindowChrome(sidebarHovering: $sidebarHovering)
+        WindowChrome(
+            sidebarHovering: $sidebarHovering,
+            initialColumnWidth: workspace.sidebarWidth)
             .environment(focused.app)
             .environment(focused.annotations)
             .environment(focused.ai)
@@ -188,6 +190,35 @@ private struct WindowChrome: View {
     @Environment(\.palette) private var palette
     @Binding var sidebarHovering: Bool
 
+    /// The `ideal:` handed to `.inspectorColumnWidth`, held FROZEN for as long as
+    /// the column is on screen.
+    ///
+    /// This is belt-and-braces, not the resize bug itself — that was the
+    /// modifier ORDER, documented at the call site. But it becomes load-bearing
+    /// the moment the envelope actually reaches the inspector host, so it lands
+    /// with it: `ideal:` must not be `workspace.sidebarWidth` read live.
+    /// SwiftUI re-applies `ideal:` to the column whenever that argument changes
+    /// between updates, and `.onGeometryChange` below writes every width it
+    /// measures back into the store — so a live read closes a loop through
+    /// AppKit's layout, and a body re-run landing mid-drag re-applies a stale
+    /// width over the one the user is dragging to.
+    ///
+    /// `sidebarWidth` being `@ObservationIgnored` does not cover this on its
+    /// own: it only stops the *store write* from invalidating the view.
+    /// Anything else that re-runs this body — hovering the panel, a toolbar
+    /// change, a tab switch — still re-reads the property and hands SwiftUI a
+    /// new `ideal:`.
+    ///
+    /// Re-seeded from the store in `.onChange` below only when the column is
+    /// (re)presented, which is the one moment `ideal:` is legitimately
+    /// consulted — so reopening a document still restores the user's width.
+    @State private var idealColumnWidth: CGFloat
+
+    init(sidebarHovering: Binding<Bool>, initialColumnWidth: CGFloat) {
+        _sidebarHovering = sidebarHovering
+        _idealColumnWidth = State(initialValue: initialColumnWidth)
+    }
+
     private var focused: PaneModel { workspace.focusedPane }
 
     var body: some View {
@@ -229,18 +260,38 @@ private struct WindowChrome: View {
                 Divider()
                 sidebar
             }
-            .inspectorColumnWidth(
-                min: InspectorLayout.minimumWidth,
-                ideal: workspace.sidebarWidth,
-                max: InspectorLayout.maximumWidth)
             // Feeds the user's splitter drag back to the store so the next
             // document reopens the column where they left it. The store
-            // rejects the collapsed measurements a start tab produces.
+            // rejects the collapsed measurements a start tab produces. Safe to
+            // write from here only because `ideal:` below is frozen — see
+            // `idealColumnWidth`.
             .onGeometryChange(for: CGFloat.self) { proxy in
                 proxy.size.width
             } action: { width in
                 workspace.rememberSidebarWidth(width)
             }
+            // MUST STAY THE OUTERMOST MODIFIER ON THE INSPECTOR CONTENT.
+            // This is not a style preference: the column-width envelope is a
+            // view trait the inspector host reads off the ROOT of this closure,
+            // and it does not survive being wrapped. With `.onGeometryChange`
+            // applied after it (as it was), the trait was invisible to the
+            // host, which then fell back to its built-in 270pt column and — far
+            // worse — registered NO min/max envelope, so AppKit gave the
+            // divider nothing to drag between and the side panel could not be
+            // resized at all. Measured: identical 270pt column whether this
+            // said 280/360/700 or 450/500/700; moved out here, the column
+            // lands on exactly the width asked for.
+            .inspectorColumnWidth(
+                min: InspectorLayout.minimumWidth,
+                ideal: idealColumnWidth,
+                max: InspectorLayout.maximumWidth)
+        }
+        // The column is inserted (and `ideal:` consulted) when this flips true,
+        // so this is the one safe moment to adopt the width the user last left.
+        // Reading the store anywhere else would re-open the loop described on
+        // `idealColumnWidth`.
+        .onChange(of: workspace.inspectorPresented) { _, isPresented in
+            if isPresented { idealColumnWidth = workspace.sidebarWidth }
         }
     }
 

--- a/Vellum/Stores/WorkspaceStore.swift
+++ b/Vellum/Stores/WorkspaceStore.swift
@@ -41,16 +41,18 @@ final class WorkspaceStore {
 
     /// The width to reopen the inspector at, tracking the user's last drag.
     ///
-    /// Deliberately NOT observed. It is read in `WindowChrome.body` as the
-    /// `ideal:` of `.inspectorColumnWidth`, and written from that same view's
+    /// Deliberately NOT observed. It seeds the `ideal:` of
+    /// `.inspectorColumnWidth`, and is written from `WindowChrome`'s
     /// `.onGeometryChange` — once per frame while the splitter is being dragged.
     /// Were it observed, each of those writes would invalidate the whole window
     /// chrome (pane tree and toolbar included) mid-drag, and feed a fresh
     /// `ideal:` back into the very layout pass that produced the measurement.
-    /// A stale read is impossible where it matters: `ideal:` is only consulted
-    /// when the column appears, and `inspectorPresented` — which *is* observed —
-    /// has to change for that to happen, so the body re-runs and re-reads this
-    /// value at exactly the moment it is used.
+    ///
+    /// Not observing it is necessary but NOT sufficient, so `WindowChrome` does
+    /// not read it live either: it copies this value into `@State` and holds
+    /// that frozen while the column is on screen, re-seeding only when the
+    /// inspector is (re)presented — the one moment `ideal:` is consulted. See
+    /// `WindowChrome.idealColumnWidth` for why a live read reopens the loop.
     @ObservationIgnored
     private(set) var sidebarWidth: CGFloat = InspectorLayout.idealWidth
 


### PR DESCRIPTION
## Bug

The right-hand side panel (the `.inspector` column holding Annotations / AI / Scratchpad) could not be resized by dragging its edge. The seam was inert.

## Root cause

Modifier **order** on the inspector content in `ContentView.swift`:

```swift
.inspector(isPresented: inspectorPresented) {
    VStack { ... }
        .inspectorColumnWidth(min: 280, ideal: 360, max: 700)   // ← wrapped
        .onGeometryChange(...) { workspace.rememberSidebarWidth($0) }
}
```

The column-width envelope is a view trait the inspector host reads off the **root** of the `.inspector` content closure, and it does not survive being wrapped. With `.onGeometryChange` applied after it, the host never saw the trait. It fell back to its built-in **270pt** column and — the part that actually broke the feature — registered **no min/max range**, so AppKit had nothing to let the divider drag between.

Note this is not the `ideal:` feedback loop that was the obvious suspect. That loop was real in the source but entirely inert, precisely because the modifier it fed never reached the host.

## Evidence

Measured against the running app (window 2056pt wide, boundary read off screenshots and cross-checked against the `AXSplitter` frame):

| Build | Requested | Actual column | `AXValue` write to resize |
|---|---|---|---|
| before | `min 280 / ideal 360 / max 700` | **270pt** | refused, stays 1785.5 |
| before | `min 450 / ideal 500 / max 700` | **270pt** (unchanged) | — |
| after | `min 280 / ideal 360 / max 700` | **360pt** | 1695.5 → 1555.5, column 360pt → 500pt, holds |
| after | `min 450 / ideal 500 / max 700` | **500pt** | — |

The "before" row that asks for 450/500 and still renders 270 is the decisive one: the values were being ignored wholesale, not clamped.

## Fix

1. **`.inspectorColumnWidth` is now the outermost modifier** on the inspector content, with a comment saying it must stay there and why.
2. **`ideal:` is frozen.** It was `workspace.sidebarWidth` read live while `.onGeometryChange` writes every measured width back into that same property — a loop through AppKit's layout that re-applies a stale width over whatever the user is dragging to. Harmless only while the trait was ignored; load-bearing the moment it works. `WindowChrome` now copies the stored width into `@State` and holds it frozen while the column is on screen, re-seeding on `.onChange(of: workspace.inspectorPresented)` — the one moment `ideal:` is consulted — so reopening a document still restores the user's width. (`@ObservationIgnored` from #72 stops the store *write* from invalidating the view, but not the many other reasons this body re-runs.)

## Verification

- `xcodebuild build` — succeeds, warning-free (the project builds with `-warnings-as-errors`).
- `VellumTests/InspectorPresentationTests` + `InspectorTabSwitcherTests` — 13/13 pass.
- New `testInspectorColumnUsesItsDeclaredWidthEnvelope` — passes with the fix; **fails at `270.25` vs `360.0` without it**, so it genuinely pins the regression.
- Runtime, on the built app: opened a PDF, confirmed the column renders at 360pt, then moved the seam through the splitter's settable `AXValue` — 360pt → 500pt, visually confirmed and stable. The same write is refused on the unfixed build.

Two honest caveats:

- **The seam drag is not asserted in the UI test.** XCUITest's synthesized press-and-drag does not drive AppKit's divider tracking loop — it reports success and the splitter never moves, on fixed *and* broken builds alike. Asserting it would pass vacuously or fail for the wrong reason, so the test pins the observable signature (the declared 360pt ideal) and the drag was verified out of band via `AXValue`.
- **`testDocumentExposesCommandSidebarAndTabAffordances` fails, and is unrelated.** It fails identically on the branch point with this change stashed — a pre-existing failure on `tabBar.newTab`, not a regression from this PR.

## Not in scope

`sidebarWidth` is in-memory only — it has never been written to disk, so the column resets to the 360pt ideal on every launch. Width is restored *within* a session (hiding/showing the inspector, switching documents), which is what the existing code was built for. Adding `UserDefaults` persistence is a small follow-up, but it would change the default `InspectorPresentationTests` asserts against, so it is left out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)