### PR TITLE
Budget output around the thinking that actually happens (#96)

### DIFF
--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -851,14 +851,16 @@ final class AiPipelineTests: XCTestCase {
     }
 
     /// The #96 regression: `.auto` sends no thinkingConfig on every family but
-    /// 2.5 flash, so the server picks the level — and it documents that pick as
-    /// `high` across the Gemini 3 line and dynamic on 2.5. The cap stayed at the
-    /// flat 8192 base anyway, leaving zero headroom for reasoning the model was
-    /// going to do regardless, on the app's default provider at its default
-    /// thinking mode.
+    /// 2.5 flash, so the server picks the level — and Google documents that pick
+    /// as `high` on the Pro and 3-flash rows and dynamic on 2.5. The cap stayed
+    /// at the flat 8192 base anyway, leaving zero headroom for reasoning the
+    /// model was going to do regardless, on the app's default provider at its
+    /// default thinking mode.
+    ///
+    /// The reserve is sized off each family's *documented* default rather than a
+    /// blanket assumption, so the expected caps below differ per row.
     func testGeminiAutoBudgetsForTheThinkingTheServerWillDo() {
-        for model in ["gemini-3.1-flash-lite-preview", "gemini-3-pro-preview",
-                      "gemini-3-flash-preview", "gemini-2.5-pro"] {
+        for model in ["gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro"] {
             XCTAssertNil(
                 Self.geminiConfig(.auto, model)["thinkingConfig"],
                 "Auto must leave the level to the server on \(model)")
@@ -866,9 +868,45 @@ final class AiPipelineTests: XCTestCase {
                 Self.geminiCap(.auto, model), 32768,
                 "Auto must budget for server-chosen thinking on \(model)")
         }
-        // A family with no row still gets the reserve: unknown ids are the case
-        // that produced #94, and a ceiling costs nothing until it is spent.
-        XCTAssertEqual(Self.geminiCap(.auto, "gemini-9-ultra"), 32768)
+        // 3.5-flash defaults to `medium`, so it reserves a medium's worth.
+        XCTAssertEqual(Self.geminiCap(.auto, "gemini-3.5-flash"), 24576)
+    }
+
+    /// The flash-lite rows document their default as `minimal`, so there is
+    /// nothing for Auto to reserve and the base stands — including on
+    /// `gemini-3.1-flash-lite-preview`, which is the app's default model. Pinned
+    /// because the tempting blanket fix ("Auto always budgets as High") would
+    /// quadruple the cost guard on the single most common request the app makes,
+    /// for thinking the server has documented it will not do.
+    func testGeminiAutoKeepsTheBaseWhereTheServerDefaultsToMinimal() {
+        XCTAssertNil(Self.geminiConfig(.auto, "gemini-3.1-flash-lite-preview")["thinkingConfig"])
+        XCTAssertEqual(Self.geminiCap(.auto, "gemini-3.1-flash-lite-preview"), 8192)
+    }
+
+    /// A family with no row keeps the flat base in *every* mode. The safe branch
+    /// for a budget is the conservative one, opposite to `supportedThinkingLevels`:
+    /// several ids this endpoint serves cap output at 8192, and Gemini rejects a
+    /// `maxOutputTokens` above the model's limit — so guessing generously would
+    /// turn a truncated answer into a request that fails outright.
+    func testGeminiUnknownFamiliesKeepTheBaseBudget() {
+        for model in ["gemini-9-ultra", "gemma-3-27b-it", "gemini-1.0-pro"] {
+            for mode in AiThinkingMode.allCases {
+                XCTAssertEqual(Self.geminiCap(mode, model), 8192, "\(model)/\(mode)")
+            }
+        }
+    }
+
+    /// The reserve keys off "no config is going out while the model thinks
+    /// anyway", not off the mode — so a family can never have its High budgeted
+    /// below its Auto for the very same request JSON.
+    func testGeminiAutoIsNeverBudgetedAboveAnExplicitMode() {
+        for model in AiModelCatalog.gemini + ["gemini-9-ultra", "gemini-3.9-ultra"] {
+            let auto = Self.geminiCap(.auto, model) ?? 0
+            let high = Self.geminiCap(.high, model) ?? 0
+            XCTAssertLessThanOrEqual(
+                auto, high,
+                "\(model): Auto (\(auto)) must not out-budget High (\(high))")
+        }
     }
 
     /// Auto on 2.5 flash still disables thinking outright, so its budget stays
@@ -913,10 +951,36 @@ final class AiPipelineTests: XCTestCase {
                        ["minimal", "low", "medium", "high"])
         // Off the 3 line there is no level vocabulary at all.
         XCTAssertTrue(GeminiClient.supportedThinkingLevels(model: "gemini-2.5-pro").isEmpty)
-        // An unrecognized 3.x id gets the intersection of every row above, so it
+        // The image variants are the exception to "the flash line takes the full
+        // ladder", and the substring that matches the flash rows would otherwise
+        // swallow them and send a level they reject.
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3.1-flash-lite-image"),
+                       ["minimal", "high"])
+        // An unrecognized 3.x id gets the intersection of the text rows, so it
         // can never be sent a level some future Pro release rejects.
         XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3.9-ultra"),
                        ["low", "high"])
+    }
+
+    /// What the server does when the field is omitted, which is what the Auto
+    /// reserve is sized from. Written out per family because the whole point of
+    /// the #96 fix is that this is *not* uniform across the line.
+    func testGeminiDocumentedDefaultsDriveTheAutoReserve() {
+        func level(_ model: String) -> String? {
+            GeminiClient.unconfiguredThinking(model: model)?["thinkingLevel"] as? String
+        }
+        XCTAssertEqual(level("gemini-3-pro-preview"), "high")
+        XCTAssertEqual(level("gemini-3-flash-preview"), "high")
+        XCTAssertEqual(level("gemini-3.5-flash"), "medium")
+        XCTAssertEqual(level("gemini-3.1-flash-lite-preview"), "minimal")
+        // 2.5 defaults to dynamic thinking, which is the -1 budget.
+        XCTAssertEqual(
+            GeminiClient.unconfiguredThinking(model: "gemini-2.5-pro")?["thinkingBudget"] as? Int, -1)
+        // Families that do no thinking, and ids with no row at all, reserve
+        // nothing — an omitted config there really means zero reasoning tokens.
+        for model in ["gemini-2.0-flash", "gemini-1.5-pro", "gemma-3-27b-it", "gemini-9-ultra"] {
+            XCTAssertNil(GeminiClient.unconfiguredThinking(model: model), model)
+        }
     }
 
     /// The end-to-end shape of the bug above, asserted on the request body: no
@@ -963,10 +1027,27 @@ final class AiPipelineTests: XCTestCase {
     }
 
     /// Every cap the shipped catalog can produce stays inside the model's own
-    /// output limit: 65536 on 2.5 and 3.x, 8192 on the 2.0 and 1.5 families.
+    /// documented output limit. The limits are written out per id rather than
+    /// derived from the code under test: reading them back out of the
+    /// implementation would let a misclassified model raise its own allowed
+    /// limit and pass green while the app sent a cap the API rejects.
     func testGeminiCapsStayInsideDocumentedOutputLimits() {
-        for model in AiModelCatalog.gemini {
-            let limit = GeminiClient.thinksWhenUnconfigured(model: model) ? 65536 : 8192
+        let documentedLimit = [
+            "gemini-3.1-flash-lite-preview": 65536,
+            "gemini-3-pro-preview": 65536,
+            "gemini-3-flash-preview": 65536,
+            "gemini-2.5-pro": 65536,
+            "gemini-2.5-flash": 65536,
+            "gemini-2.5-flash-lite": 65536,
+            "gemini-2.0-flash": 8192,
+            "gemini-2.0-flash-lite": 8192,
+            "gemini-1.5-pro": 8192,
+            "gemini-1.5-flash": 8192,
+        ]
+        // Fails loudly when the catalog gains a model this table doesn't cover,
+        // rather than skipping it.
+        XCTAssertEqual(Set(documentedLimit.keys), Set(AiModelCatalog.gemini))
+        for (model, limit) in documentedLimit {
             for mode in AiThinkingMode.allCases {
                 let cap = Self.geminiCap(mode, model) ?? 0
                 XCTAssertLessThanOrEqual(cap, limit, "\(model)/\(mode) asks for more than it can return")
@@ -999,7 +1080,6 @@ final class AiPipelineTests: XCTestCase {
     /// answer than Instant did. The cap now scales through the same table the
     /// direct OpenAI client uses.
     func testChatGPTOutputBudgetScalesWithThinkingMode() {
-        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.5")["max_output_tokens"] as? Int, 4096)
         XCTAssertEqual(Self.chatGPTBody(.low, "gpt-5.5")["max_output_tokens"] as? Int, 8192)
         XCTAssertEqual(Self.chatGPTBody(.medium, "gpt-5.5")["max_output_tokens"] as? Int, 16384)
         XCTAssertEqual(Self.chatGPTBody(.high, "gpt-5.5")["max_output_tokens"] as? Int, 32768)
@@ -1009,24 +1089,44 @@ final class AiPipelineTests: XCTestCase {
         XCTAssertNil(Self.chatGPTBody(.auto, "gpt-5.5")["reasoning"])
     }
 
-    /// The cap is budgeted off the effort *resolved* for the model, not the one
-    /// requested: gpt-5.5 has no "minimal", so Instant becomes "none"; the codex
-    /// slug has neither "none" nor "minimal", so Instant becomes "low" — and
-    /// each cap follows the effort that is actually sent.
+    /// The fix only ever raises a cap. Instant on the four slugs whose `minimal`
+    /// resolves to effort `none` would otherwise *drop* to the table's 4096, and
+    /// `none` spends no reasoning tokens — so that reduction would come straight
+    /// out of visible answer length, reintroducing this issue's own symptom on
+    /// the one mode nobody reported it for.
+    func testChatGPTNoModeLosesAnswerRoom() {
+        for model in AiModelCatalog.chatgpt {
+            for mode in AiThinkingMode.allCases {
+                let cap = Self.chatGPTBody(mode, model)["max_output_tokens"] as? Int ?? 0
+                XCTAssertGreaterThanOrEqual(
+                    cap, 8192, "\(model)/\(mode) budgets less than the flat cap it replaced")
+            }
+        }
+        XCTAssertEqual(
+            (Self.chatGPTBody(.instant, "gpt-5.5")["reasoning"] as? [String: Any])?["effort"] as? String,
+            "none")
+        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.5")["max_output_tokens"] as? Int, 8192)
+    }
+
+    /// Above the floor, the cap follows the effort *resolved* for the model
+    /// rather than the one requested — so a slug whose vocabulary bumps the
+    /// user's choice up or down gets a budget that matches what it will do.
     func testChatGPTBudgetFollowsTheResolvedEffort() {
         for model in AiModelCatalog.chatgpt {
-            let body = Self.chatGPTBody(.instant, model)
-            let effort = (body["reasoning"] as? [String: Any])?["effort"] as? String
-            XCTAssertEqual(
-                body["max_output_tokens"] as? Int,
-                OpenAIClient.maxOutputTokens(forEffort: effort, reasoning: true),
-                "\(model) budget must match the effort it sends")
+            for mode in AiThinkingMode.allCases {
+                let body = Self.chatGPTBody(mode, model)
+                let effort = (body["reasoning"] as? [String: Any])?["effort"] as? String
+                XCTAssertEqual(
+                    body["max_output_tokens"] as? Int,
+                    max(8192, OpenAIClient.maxOutputTokens(forEffort: effort, reasoning: true)),
+                    "\(model)/\(mode) budget must match the effort it sends")
+            }
         }
+        // The codex slug has neither "none" nor "minimal", so Instant resolves
+        // up to "low" where the others resolve down to "none".
         XCTAssertEqual(
             (Self.chatGPTBody(.instant, "gpt-5.3-codex")["reasoning"] as? [String: Any])?["effort"] as? String,
             "low")
-        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.3-codex")["max_output_tokens"] as? Int, 8192)
-        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.5")["max_output_tokens"] as? Int, 4096)
     }
 
     /// The rest of the ChatGPT turn payload is untouched by #96.

--- a/Tests/AiPipelineTests.swift
+++ b/Tests/AiPipelineTests.swift
@@ -821,6 +821,224 @@ final class AiPipelineTests: XCTestCase {
         XCTAssertTrue(AiModelCatalog.supportsVision(provider: .openrouter, model: "vendor/unknown", catalog: nil))
     }
 
+    // MARK: - §5 Gemini thinking levels & output budget (#96)
+
+    /// `maxOutputTokens` for the mode/model, read off the body that actually
+    /// ships rather than the helper, so a wiring mistake in `generationConfig`
+    /// fails these too.
+    private static func geminiBody(_ mode: AiThinkingMode, _ model: String) -> [String: Any] {
+        GeminiClient.requestBody(
+            systemPrompt: "system",
+            contents: [["role": "user", "parts": [["text": "hi"]]]],
+            generationConfig: GeminiClient.generationConfig(for: mode, model: model)
+        )
+    }
+
+    private static func geminiConfig(_ mode: AiThinkingMode, _ model: String) -> [String: Any] {
+        (geminiBody(mode, model)["generation_config"] as? [String: Any]) ?? [:]
+    }
+
+    private static func geminiCap(_ mode: AiThinkingMode, _ model: String) -> Int? {
+        geminiConfig(mode, model)["maxOutputTokens"] as? Int
+    }
+
+    private static func geminiLevel(_ mode: AiThinkingMode, _ model: String) -> String? {
+        (geminiConfig(mode, model)["thinkingConfig"] as? [String: Any])?["thinkingLevel"] as? String
+    }
+
+    private static func geminiBudget(_ mode: AiThinkingMode, _ model: String) -> Int? {
+        (geminiConfig(mode, model)["thinkingConfig"] as? [String: Any])?["thinkingBudget"] as? Int
+    }
+
+    /// The #96 regression: `.auto` sends no thinkingConfig on every family but
+    /// 2.5 flash, so the server picks the level — and it documents that pick as
+    /// `high` across the Gemini 3 line and dynamic on 2.5. The cap stayed at the
+    /// flat 8192 base anyway, leaving zero headroom for reasoning the model was
+    /// going to do regardless, on the app's default provider at its default
+    /// thinking mode.
+    func testGeminiAutoBudgetsForTheThinkingTheServerWillDo() {
+        for model in ["gemini-3.1-flash-lite-preview", "gemini-3-pro-preview",
+                      "gemini-3-flash-preview", "gemini-2.5-pro"] {
+            XCTAssertNil(
+                Self.geminiConfig(.auto, model)["thinkingConfig"],
+                "Auto must leave the level to the server on \(model)")
+            XCTAssertEqual(
+                Self.geminiCap(.auto, model), 32768,
+                "Auto must budget for server-chosen thinking on \(model)")
+        }
+        // A family with no row still gets the reserve: unknown ids are the case
+        // that produced #94, and a ceiling costs nothing until it is spent.
+        XCTAssertEqual(Self.geminiCap(.auto, "gemini-9-ultra"), 32768)
+    }
+
+    /// Auto on 2.5 flash still disables thinking outright, so its budget stays
+    /// at the base — the mode sends `thinkingBudget: 0` and there is nothing to
+    /// reserve for. Unchanged by #96, and pinned so the new Auto branch can't
+    /// quietly widen it.
+    func testGeminiAutoKeepsTheBaseBudgetWhereThinkingIsDisabled() {
+        for model in ["gemini-2.5-flash", "gemini-2.5-flash-lite"] {
+            XCTAssertEqual(Self.geminiBudget(.auto, model), 0)
+            XCTAssertEqual(Self.geminiCap(.auto, model), 8192)
+        }
+    }
+
+    /// The 2.0 flash models and the 1.5 line don't think at all *and* cap output
+    /// at 8192 tokens total, so handing them a reasoning reserve would ask for
+    /// more than the model can return. Every mode stays at the base.
+    func testGeminiNonThinkingFamiliesNeverExceedTheirOutputLimit() {
+        for model in ["gemini-2.0-flash", "gemini-2.0-flash-lite",
+                      "gemini-1.5-pro", "gemini-1.5-flash"] {
+            for mode in AiThinkingMode.allCases {
+                XCTAssertNil(Self.geminiConfig(mode, model)["thinkingConfig"], "\(model)/\(mode)")
+                XCTAssertEqual(Self.geminiCap(mode, model), 8192, "\(model)/\(mode)")
+            }
+        }
+    }
+
+    /// The `contains("gemini-3-pro")` bug: `gemini-3.1-pro` does not contain
+    /// that substring, so it fell into the branch that sends `minimal` — a level
+    /// the 3.1 Pro row doesn't have, which 400s the request the way #94 did.
+    /// Google's rows: 3-pro is low/high, 3.1-pro adds medium but still has no
+    /// minimal, and the flash line takes the full ladder.
+    func testGeminiThinkingLevelRowsMatchTheDocumentedFamilies() {
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3-pro-preview"),
+                       ["low", "high"])
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3.1-pro-preview"),
+                       ["low", "medium", "high"])
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3-flash-preview"),
+                       ["minimal", "low", "medium", "high"])
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3.1-flash-lite-preview"),
+                       ["minimal", "low", "medium", "high"])
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3.5-flash"),
+                       ["minimal", "low", "medium", "high"])
+        // Off the 3 line there is no level vocabulary at all.
+        XCTAssertTrue(GeminiClient.supportedThinkingLevels(model: "gemini-2.5-pro").isEmpty)
+        // An unrecognized 3.x id gets the intersection of every row above, so it
+        // can never be sent a level some future Pro release rejects.
+        XCTAssertEqual(GeminiClient.supportedThinkingLevels(model: "gemini-3.9-ultra"),
+                       ["low", "high"])
+    }
+
+    /// The end-to-end shape of the bug above, asserted on the request body: no
+    /// shipped Gemini id may ever be sent a level outside its own row.
+    func testNoShippedGeminiModelIsSentAnUnsupportedLevel() {
+        for model in AiModelCatalog.gemini {
+            let supported = GeminiClient.supportedThinkingLevels(model: model)
+            for mode in AiThinkingMode.allCases {
+                guard let level = Self.geminiLevel(mode, model) else { continue }
+                XCTAssertTrue(
+                    supported.contains(level),
+                    "\(model) must not be sent thinkingLevel \(level) for \(mode)")
+            }
+        }
+        // Specifically: Instant on a Pro row rounds to `low` instead of sending
+        // the `minimal` that row doesn't have.
+        XCTAssertEqual(Self.geminiLevel(.instant, "gemini-3.1-pro-preview"), "low")
+        XCTAssertEqual(Self.geminiLevel(.instant, "gemini-3-pro-preview"), "low")
+        // …while a flash row, which does have it, still gets `minimal`.
+        XCTAssertEqual(Self.geminiLevel(.instant, "gemini-3.1-flash-lite-preview"), "minimal")
+    }
+
+    /// Ties round up on the Gemini ladder: 3-pro offers only low/high, and
+    /// Medium sits equidistant between them. Rounding down would demote a
+    /// Medium request to the weakest setting the model has.
+    func testGeminiLevelTiesRoundUp() {
+        XCTAssertEqual(Self.geminiLevel(.medium, "gemini-3-pro-preview"), "high")
+        // 3.1-pro has a real `medium`, so nothing to round.
+        XCTAssertEqual(Self.geminiLevel(.medium, "gemini-3.1-pro-preview"), "medium")
+    }
+
+    /// Explicit modes budget off the level actually sent, so the cap tracks the
+    /// resolved level rather than the requested one.
+    func testGeminiExplicitModeBudgetsTrackTheResolvedLevel() {
+        XCTAssertEqual(Self.geminiCap(.instant, "gemini-3.1-flash-lite-preview"), 8192)
+        XCTAssertEqual(Self.geminiCap(.low, "gemini-3.1-flash-lite-preview"), 16384)
+        XCTAssertEqual(Self.geminiCap(.medium, "gemini-3.1-flash-lite-preview"), 24576)
+        XCTAssertEqual(Self.geminiCap(.high, "gemini-3.1-flash-lite-preview"), 32768)
+        // Instant on 3-pro resolves up to `low`, and the cap follows it up too.
+        XCTAssertEqual(Self.geminiCap(.instant, "gemini-3-pro-preview"), 16384)
+        // 2.5 Pro cannot disable thinking; its floor is the documented 128.
+        XCTAssertEqual(Self.geminiBudget(.instant, "gemini-2.5-pro"), 128)
+        XCTAssertEqual(Self.geminiCap(.instant, "gemini-2.5-pro"), 8320)
+    }
+
+    /// Every cap the shipped catalog can produce stays inside the model's own
+    /// output limit: 65536 on 2.5 and 3.x, 8192 on the 2.0 and 1.5 families.
+    func testGeminiCapsStayInsideDocumentedOutputLimits() {
+        for model in AiModelCatalog.gemini {
+            let limit = GeminiClient.thinksWhenUnconfigured(model: model) ? 65536 : 8192
+            for mode in AiThinkingMode.allCases {
+                let cap = Self.geminiCap(mode, model) ?? 0
+                XCTAssertLessThanOrEqual(cap, limit, "\(model)/\(mode) asks for more than it can return")
+                XCTAssertGreaterThan(cap, 0, "\(model)/\(mode)")
+            }
+        }
+    }
+
+    /// The body still carries everything the turn needs; `generation_config` is
+    /// the only part #96 reshapes.
+    func testGeminiRequestBodyKeepsItsTurnPayload() throws {
+        let body = Self.geminiBody(.high, "gemini-3-flash-preview")
+        let instruction = try XCTUnwrap(body["system_instruction"] as? [String: Any])
+        XCTAssertEqual(((instruction["parts"] as? [[String: Any]])?.first?["text"]) as? String, "system")
+        XCTAssertNotNil(body["contents"])
+        XCTAssertNotNil(body["tools"])
+        XCTAssertEqual(Self.geminiConfig(.high, "gemini-3-flash-preview")["temperature"] as? Double, 0.2)
+    }
+
+    // MARK: - §5 ChatGPT output budget (#96)
+
+    private static func chatGPTBody(_ mode: AiThinkingMode, _ model: String) -> [String: Any] {
+        ChatGPTClient.requestBody(
+            model: model, systemPrompt: "system", input: [], thinkingMode: mode,
+            sessionIdAtStart: "tab-1")
+    }
+
+    /// The #96 regression: every mode got a flat 8192, so High spent most of one
+    /// shared budget on reasoning tokens and had no more room left for the
+    /// answer than Instant did. The cap now scales through the same table the
+    /// direct OpenAI client uses.
+    func testChatGPTOutputBudgetScalesWithThinkingMode() {
+        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.5")["max_output_tokens"] as? Int, 4096)
+        XCTAssertEqual(Self.chatGPTBody(.low, "gpt-5.5")["max_output_tokens"] as? Int, 8192)
+        XCTAssertEqual(Self.chatGPTBody(.medium, "gpt-5.5")["max_output_tokens"] as? Int, 16384)
+        XCTAssertEqual(Self.chatGPTBody(.high, "gpt-5.5")["max_output_tokens"] as? Int, 32768)
+        // Auto omits the effort, so the server picks; budget it mid-range for
+        // the same reason #95 did on the direct client.
+        XCTAssertEqual(Self.chatGPTBody(.auto, "gpt-5.5")["max_output_tokens"] as? Int, 16384)
+        XCTAssertNil(Self.chatGPTBody(.auto, "gpt-5.5")["reasoning"])
+    }
+
+    /// The cap is budgeted off the effort *resolved* for the model, not the one
+    /// requested: gpt-5.5 has no "minimal", so Instant becomes "none"; the codex
+    /// slug has neither "none" nor "minimal", so Instant becomes "low" — and
+    /// each cap follows the effort that is actually sent.
+    func testChatGPTBudgetFollowsTheResolvedEffort() {
+        for model in AiModelCatalog.chatgpt {
+            let body = Self.chatGPTBody(.instant, model)
+            let effort = (body["reasoning"] as? [String: Any])?["effort"] as? String
+            XCTAssertEqual(
+                body["max_output_tokens"] as? Int,
+                OpenAIClient.maxOutputTokens(forEffort: effort, reasoning: true),
+                "\(model) budget must match the effort it sends")
+        }
+        XCTAssertEqual(
+            (Self.chatGPTBody(.instant, "gpt-5.3-codex")["reasoning"] as? [String: Any])?["effort"] as? String,
+            "low")
+        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.3-codex")["max_output_tokens"] as? Int, 8192)
+        XCTAssertEqual(Self.chatGPTBody(.instant, "gpt-5.5")["max_output_tokens"] as? Int, 4096)
+    }
+
+    /// The rest of the ChatGPT turn payload is untouched by #96.
+    func testChatGPTRequestBodyKeepsItsTurnPayload() {
+        let body = Self.chatGPTBody(.medium, "gpt-5.5")
+        XCTAssertEqual(body["prompt_cache_key"] as? String, "vellum-tab-1")
+        XCTAssertEqual(body["stream"] as? Bool, true)
+        XCTAssertEqual(body["store"] as? Bool, false)
+        XCTAssertEqual(body["instructions"] as? String, "system")
+        XCTAssertNotNil(body["tools"])
+    }
+
     /// Bytes for a blank bitmap in PNG, as a stand-in for a dropped file.
     private static func bitmap(width: Int, height: Int, alpha: Bool) -> Data {
         let rep = NSBitmapImageRep(

--- a/Vellum/Services/Ai/ChatGPTClient.swift
+++ b/Vellum/Services/Ai/ChatGPTClient.swift
@@ -121,6 +121,10 @@ final class ChatGPTClient {
         return AiProviderResult(reply: Self.finalize("", actions: actionResults), actionResults: actionResults)
     }
 
+    /// The cap this client sent for every mode before #96, kept as the floor so
+    /// the fix can only ever raise a budget.
+    static let previousFlatOutputCap = 8192
+
     /// Request body for one tool-loop turn.
     ///
     /// Reasoning effort on the gpt-5 family: `.auto` omits the field so the
@@ -140,6 +144,15 @@ final class ChatGPTClient {
     /// this client ships is a gpt-5 variant, so `isReasoningModel` is true for
     /// all of them today; it is still passed rather than assumed so a future
     /// non-reasoning slug keeps the flat cap.
+    ///
+    /// Floored at `previousFlatOutputCap`, so the fix only ever raises a cap.
+    /// Without the floor, Instant would *fall* to 4096 on the four slugs whose
+    /// `minimal` resolves to effort `none`: `none` spends no reasoning tokens at
+    /// all, so that reduction would come entirely out of visible answer length —
+    /// reintroducing this issue's own symptom on the one mode it wasn't reported
+    /// for. The direct `OpenAIClient` keeps the unfloored table because 4096 has
+    /// been its shipped Instant budget since #95; here 8192 is the shipped value
+    /// and lowering it isn't this fix's job.
     static func requestBody(
         model: String,
         systemPrompt: String,
@@ -166,8 +179,10 @@ final class ChatGPTClient {
             // Cost guard: cap the output, scaled to the thinking mode. Hitting
             // it is surfaced via `response.incomplete` instead of clipping
             // silently.
-            "max_output_tokens": OpenAIClient.maxOutputTokens(
-                forEffort: effort, reasoning: OpenAIClient.isReasoningModel(model)),
+            "max_output_tokens": max(
+                previousFlatOutputCap,
+                OpenAIClient.maxOutputTokens(
+                    forEffort: effort, reasoning: OpenAIClient.isReasoningModel(model))),
         ]
         if let effort {
             body["reasoning"] = ["effort": effort]

--- a/Vellum/Services/Ai/ChatGPTClient.swift
+++ b/Vellum/Services/Ai/ChatGPTClient.swift
@@ -44,36 +44,13 @@ final class ChatGPTClient {
         onEvent(.status("Thinking"))
 
         for _ in 0..<8 {
-            var body: [String: Any] = [
-                "model": model,
-                "instructions": systemPrompt,
-                "input": input,
-                "tools": Self.functionTools,
-                "tool_choice": "auto",
-                "parallel_tool_calls": true,
-                "store": false,
-                // Prompt caching (PR A.5): a per-session key so the stable prompt
-                // prefix is reused across tool-loop iterations and follow-ups.
-                // NOTE: acceptance by the ChatGPT OAuth (Codex) backend is pending
-                // live verification; drop from this client only if the backend 400s.
-                "prompt_cache_key": "vellum-\(sessionIdAtStart)",
-                "stream": true,
-                // Cost guard: cap the output. Reasoning tokens count against
-                // this budget too, so it stays generous; hitting it is surfaced
-                // via `response.incomplete` below instead of clipping silently.
-                "max_output_tokens": 8192,
-            ]
-            // Reasoning effort on the gpt-5 family. `.auto` omits the field so
-            // the Codex backend applies its own default (the removed codex-CLI
-            // path sent none); explicit modes set it — resolved through the same
-            // per-family table the direct client uses. The Codex slugs name the
-            // same models, so passing the raw value through meant Instant sent
-            // "minimal" to gpt-5.5 (the default here), which is the value #94 is
-            // about: the family rejects it outright.
-            if let effort = OpenAIClient.supportedReasoningEffort(
-                model: model, requested: thinkingMode.openAIEffort) {
-                body["reasoning"] = ["effort": effort]
-            }
+            let body = Self.requestBody(
+                model: model,
+                systemPrompt: systemPrompt,
+                input: input,
+                thinkingMode: thinkingMode,
+                sessionIdAtStart: sessionIdAtStart
+            )
             let request = try await makeRequest(url: url, body: body)
             let bytes = try await openStream(request)
 
@@ -142,6 +119,60 @@ final class ChatGPTClient {
             onEvent(.status("Thinking"))
         }
         return AiProviderResult(reply: Self.finalize("", actions: actionResults), actionResults: actionResults)
+    }
+
+    /// Request body for one tool-loop turn.
+    ///
+    /// Reasoning effort on the gpt-5 family: `.auto` omits the field so the
+    /// Codex backend applies its own default (the removed codex-CLI path sent
+    /// none); explicit modes set it — resolved through the same per-family table
+    /// the direct client uses. The Codex slugs name the same models, so passing
+    /// the raw value through meant Instant sent "minimal" to gpt-5.5 (the
+    /// default here), which is the value #94 is about: the family rejects it
+    /// outright.
+    ///
+    /// The output cap is scaled by that same resolved effort through
+    /// `OpenAIClient.maxOutputTokens`. It used to be a flat 8192 for every mode,
+    /// which is the #96 bug: reasoning tokens are billed against
+    /// `max_output_tokens` on the Responses API, so High spent most of one
+    /// shared budget thinking and got the same room for the answer as Instant —
+    /// which is exactly how a long High answer ends up truncated. Every slug
+    /// this client ships is a gpt-5 variant, so `isReasoningModel` is true for
+    /// all of them today; it is still passed rather than assumed so a future
+    /// non-reasoning slug keeps the flat cap.
+    static func requestBody(
+        model: String,
+        systemPrompt: String,
+        input: [[String: Any]],
+        thinkingMode: AiThinkingMode,
+        sessionIdAtStart: String
+    ) -> [String: Any] {
+        let effort = OpenAIClient.supportedReasoningEffort(
+            model: model, requested: thinkingMode.openAIEffort)
+        var body: [String: Any] = [
+            "model": model,
+            "instructions": systemPrompt,
+            "input": input,
+            "tools": Self.functionTools,
+            "tool_choice": "auto",
+            "parallel_tool_calls": true,
+            "store": false,
+            // Prompt caching (PR A.5): a per-session key so the stable prompt
+            // prefix is reused across tool-loop iterations and follow-ups.
+            // NOTE: acceptance by the ChatGPT OAuth (Codex) backend is pending
+            // live verification; drop from this client only if the backend 400s.
+            "prompt_cache_key": "vellum-\(sessionIdAtStart)",
+            "stream": true,
+            // Cost guard: cap the output, scaled to the thinking mode. Hitting
+            // it is surfaced via `response.incomplete` instead of clipping
+            // silently.
+            "max_output_tokens": OpenAIClient.maxOutputTokens(
+                forEffort: effort, reasoning: OpenAIClient.isReasoningModel(model)),
+        ]
+        if let effort {
+            body["reasoning"] = ["effort": effort]
+        }
+        return body
     }
 
     /// Builds a Responses request with fresh OAuth credentials and the CLI's

--- a/Vellum/Services/Ai/GeminiClient.swift
+++ b/Vellum/Services/Ai/GeminiClient.swift
@@ -37,36 +37,14 @@ final class GeminiClient {
 
         onEvent(.status("Thinking"))
 
-        // Cost guard: cap output (MAX_TOKENS truncation is surfaced below) and
-        // map the user's thinking mode to a thinkingBudget. Newer families
-        // ignore an unknown thinkingConfig.
-        var generationConfig: [String: Any] = ["temperature": 0.2]
-        var thinkingConfig: [String: Any]?
-        if thinkingMode == .auto {
-            // `.auto` preserves the prior default byte-for-byte: for the 2.5
-            // flash family disable extended thinking (0 budget); everything else
-            // omits thinkingConfig. 2.5 Pro rejects thinkingBudget 0 (its minimum
-            // is 128); only 2.5 Flash/Flash-Lite accept 0, so exclude Pro.
-            if model.contains("2.5") && !model.lowercased().contains("pro") {
-                thinkingConfig = ["thinkingBudget": 0]
-            }
-        } else {
-            thinkingConfig = Self.thinkingConfig(for: thinkingMode, model: model)
-        }
-        if let thinkingConfig { generationConfig["thinkingConfig"] = thinkingConfig }
-        // Reasoning tokens are drawn from the same output budget, so a flat cap
-        // can be exhausted by thinking before any visible answer. Reserve
-        // headroom above the resolved thinking budget; the flat 8192 base when
-        // thinking is disabled.
-        generationConfig["maxOutputTokens"] = Self.maxOutputTokens(thinkingConfig: thinkingConfig)
+        let generationConfig = Self.generationConfig(for: thinkingMode, model: model)
 
         for _ in 0..<8 {
-            let body: [String: Any] = [
-                "system_instruction": ["parts": [["text": systemPrompt]]],
-                "contents": contents,
-                "tools": [["function_declarations": Self.functionDeclarations]],
-                "generation_config": generationConfig,
-            ]
+            let body = Self.requestBody(
+                systemPrompt: systemPrompt,
+                contents: contents,
+                generationConfig: generationConfig
+            )
             var request = URLRequest(url: url)
             request.httpMethod = "POST"
             request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
@@ -241,52 +219,220 @@ final class GeminiClient {
         )
     }
 
+    /// One tool-loop turn's request body.
+    static func requestBody(
+        systemPrompt: String,
+        contents: [[String: Any]],
+        generationConfig: [String: Any]
+    ) -> [String: Any] {
+        [
+            "system_instruction": ["parts": [["text": systemPrompt]]],
+            "contents": contents,
+            "tools": [["function_declarations": Self.functionDeclarations]],
+            "generation_config": generationConfig,
+        ]
+    }
+
+    /// The `generation_config` for a turn: the thinking level/budget actually
+    /// sent, and an output cap sized around it.
+    static func generationConfig(for mode: AiThinkingMode, model: String) -> [String: Any] {
+        var config: [String: Any] = ["temperature": 0.2]
+        if let thinking = resolvedThinkingConfig(for: mode, model: model) {
+            config["thinkingConfig"] = thinking
+        }
+        config["maxOutputTokens"] = maxOutputTokens(for: mode, model: model)
+        return config
+    }
+
+    /// The thinkingConfig actually sent for `mode`, including the `.auto`
+    /// branch that used to sit inline in `generate`.
+    ///
+    /// `.auto` preserves the prior default byte-for-byte: for the 2.5 flash
+    /// family disable extended thinking (0 budget); everything else omits
+    /// thinkingConfig and lets the server pick. 2.5 Pro rejects thinkingBudget 0
+    /// (its documented minimum is 128); only 2.5 Flash (range 0–24576) and
+    /// Flash-Lite (0, then 512–24576) accept 0, so exclude Pro.
+    static func resolvedThinkingConfig(for mode: AiThinkingMode, model: String) -> [String: Any]? {
+        let lowered = model.lowercased()
+        guard mode == .auto else { return thinkingConfig(for: mode, model: model) }
+        if lowered.contains("2.5") && !lowered.contains("pro") {
+            return ["thinkingBudget": 0]
+        }
+        return nil
+    }
+
+    /// Whether omitting thinkingConfig still leaves the model thinking at a
+    /// level the server picks. True for the whole Gemini 3 line (its default
+    /// `thinkingLevel` is `high` on the Pro and 3-flash rows, `medium` on
+    /// 3.5-flash, `minimal` on 3.1-flash-lite) and for 2.5, whose default is
+    /// dynamic thinking. The 2.0 flash models and the retired 1.5 line don't
+    /// think at all, so an omitted config really does mean no reasoning tokens —
+    /// which matters, because those two families cap output at 8192 total and
+    /// must not be handed a larger budget.
+    static func thinksWhenUnconfigured(model: String) -> Bool {
+        let lowered = model.lowercased()
+        if lowered.contains("1.5") { return false }
+        if lowered.contains("2.0") { return lowered.contains("thinking") }
+        return true
+    }
+
+    /// Output-token cap for a turn, sized so thinking can't starve the answer.
+    ///
+    /// The `.auto` hole this closes (#96): Auto sends no thinkingConfig on every
+    /// family except 2.5 flash, so the *server* picks the thinking level — and
+    /// the level it picks is not a low one. Google documents the default
+    /// `thinkingLevel` as `high` for `gemini-3-pro-preview`,
+    /// `gemini-3.1-pro-preview` and `gemini-3-flash-preview`, and 2.5's default
+    /// as dynamic thinking. The cap nonetheless stayed at the flat 8192 base, so
+    /// on the app's default provider the default thinking mode reserved room for
+    /// *no* reasoning while the server did its most expensive kind. That is the
+    /// same trade #95 removed from the OpenAI path, and the same truncation.
+    ///
+    /// So Auto is budgeted at the top of the ladder rather than #95's mid-range:
+    /// the mid-range assumption there matched OpenAI's documented default effort
+    /// of `medium`, and the equivalent evidence-led answer for Gemini is `high`.
+    /// Over-reserving is free — `maxOutputTokens` is a ceiling, not a spend —
+    /// while under-reserving truncates a finished answer. The resulting caps stay
+    /// well inside the 65536 output limit every 2.5 and 3.x model documents.
+    static func maxOutputTokens(for mode: AiThinkingMode, model: String) -> Int {
+        let config = resolvedThinkingConfig(for: mode, model: model)
+        guard mode == .auto, config == nil, thinksWhenUnconfigured(model: model) else {
+            return maxOutputTokens(thinkingConfig: config)
+        }
+        // Budget the server's own choice as if High had been asked for. A family
+        // with no row (a future release) has no level to resolve, so fall back to
+        // the same reserve the level ladder's top rung gets.
+        guard let topOfLadder = thinkingConfig(for: .high, model: model) else {
+            return highThinkingReserve + baseMaxOutputTokens
+        }
+        return maxOutputTokens(thinkingConfig: topOfLadder)
+    }
+
     /// Output-token cap sized so thinking can't starve the visible answer.
     /// 8192 when thinking is off (nil config or a 0 thinkingBudget) — generous
     /// enough that replies don't clip silently; truncation is surfaced via
     /// finishReason regardless. Otherwise reserves the resolved thinking budget
     /// plus 8192 headroom for the reply. Gemini-3 thinkingLevel has no numeric
-    /// budget, so map each level to a generous cap.
+    /// budget — Google calls the levels "relative allowances for thinking rather
+    /// than strict token guarantees" — so map each level to a generous cap.
     static let baseMaxOutputTokens = 8192
+    /// Thinking headroom reserved for the strongest level, and for Auto.
+    static let highThinkingReserve = 24576
     static func maxOutputTokens(thinkingConfig config: [String: Any]?) -> Int {
         let base = baseMaxOutputTokens
         guard let config else { return base }
         if let budget = config["thinkingBudget"] as? Int {
-            if budget == 0 { return base }          // thinking disabled
-            if budget < 0 { return 24576 + base }   // dynamic: model decides
-            return budget + base                    // reserve budget + reply headroom
+            if budget == 0 { return base }                          // thinking disabled
+            if budget < 0 { return highThinkingReserve + base }     // dynamic: model decides
+            return budget + base                                    // reserve budget + reply headroom
         }
         if let level = config["thinkingLevel"] as? String {
             switch level {
             case "low": return 8192 + base
             case "medium": return 16384 + base
-            case "high": return 24576 + base
+            case "high": return highThinkingReserve + base
             default: return base                    // "minimal" / unknown
             }
         }
         return base
     }
 
+    /// Thinking levels ordered weakest to strongest. Used to fall back to the
+    /// nearest level a model actually accepts when the user's choice isn't in
+    /// its set.
+    private static let thinkingLevelLadder = ["minimal", "low", "medium", "high"]
+
+    /// The `thinkingLevel` values `model` accepts, or `[]` for a family that
+    /// doesn't take a level at all (2.x takes numeric budgets, 1.5 takes
+    /// nothing).
+    ///
+    /// Deliberately shaped as "what this family supports" rather than the old
+    /// "which one id is special", the same inversion `OpenAIClient
+    /// .supportedEfforts` made for #94. The previous form asked
+    /// `contains("gemini-3-pro")` and treated everything else on the 3 line as
+    /// supporting the full ladder. `gemini-3.1-pro` does not contain that
+    /// substring, so it landed in the permissive branch and Instant sent it
+    /// `minimal` — a level the 3.1 Pro row does not have, so the request 400s
+    /// before streaming. That is #94's failure mode reappearing on a point
+    /// release, which is why the shape and not just the string is what changes
+    /// here.
+    ///
+    /// Rows come from the Gemini 3 developer guide plus each model's page under
+    /// `ai.google.dev/gemini-api/docs/models`:
+    /// - `gemini-3-pro-preview` is the narrow one: `low`/`high` only.
+    /// - `gemini-3.1-pro-preview` added `medium` but still has no `minimal`.
+    /// - The flash line (`3-flash`, `3.1-flash`/`-flash-lite`, `3.5-flash`)
+    ///   takes the full ladder.
+    ///
+    /// An unrecognized id on the 3 line falls to `low`/`high`: that is the
+    /// intersection of every row above, so it can't send a level some future
+    /// Pro release rejects. Note the safe branch here is a *narrower set*, not
+    /// the empty set `supportedEfforts` uses — omitting the field on Gemini
+    /// means the server default, which on this line is `high`, so an omit would
+    /// silently turn Instant into the slowest and priciest setting.
+    static func supportedThinkingLevels(model: String) -> Set<String> {
+        let lowered = model.lowercased()
+        guard lowered.contains("gemini-3") else { return [] }
+        if lowered.contains("gemini-3-flash")
+            || lowered.contains("gemini-3.1-flash")
+            || lowered.contains("gemini-3.5-flash") {
+            return ["minimal", "low", "medium", "high"]
+        }
+        if lowered.contains("gemini-3.1-pro") { return ["low", "medium", "high"] }
+        if lowered.contains("gemini-3-pro") { return ["low", "high"] }
+        return ["low", "high"]
+    }
+
+    /// The level to send for `model`, or nil to omit the field.
+    ///
+    /// When the user's choice isn't in the model's set, fall back to the
+    /// nearest rung rather than dropping the choice. Ties round *up* — the
+    /// opposite of the OpenAI ladder, because Gemini's level vocabulary has no
+    /// "off" rung: every level still thinks, so the cost of rounding up is some
+    /// extra thinking, while rounding down on a Pro model that only offers
+    /// `low`/`high` would quietly demote a Medium request to the weakest
+    /// setting it has.
+    static func resolvedThinkingLevel(model: String, requested: String?) -> String? {
+        guard let requested else { return nil }
+        let supported = supportedThinkingLevels(model: model)
+        guard !supported.isEmpty else { return nil }
+        if supported.contains(requested) { return requested }
+        guard let target = thinkingLevelLadder.firstIndex(of: requested) else { return nil }
+        return thinkingLevelLadder.enumerated()
+            .filter { supported.contains($0.element) }
+            .min { lhs, rhs in
+                let left = abs(lhs.offset - target), right = abs(rhs.offset - target)
+                return left == right ? lhs.offset > rhs.offset : left < right
+            }?
+            .element
+    }
+
+    /// The `thinkingLevel` a thinking mode asks for, before it is resolved
+    /// against what the model actually accepts.
+    private static func requestedLevel(for mode: AiThinkingMode) -> String? {
+        switch mode {
+        case .auto: nil
+        case .instant: "minimal"
+        case .low: "low"
+        case .medium: "medium"
+        case .high: "high"
+        }
+    }
+
     /// thinkingConfig payload for the given effort, or nil to omit it.
     /// Gemini 3 families take a discrete thinkingLevel — numeric budgets are a
     /// request error there. 2.x keeps numeric budgets (Pro floors at 128, its
     /// minimum — 2.5 Pro cannot disable thinking; -1 means dynamic, the model
-    /// decides). 1.5 and unknown families send nothing. `.auto` is the
-    /// caller's branch and must never be routed here.
+    /// decides). 1.5 and unknown families send nothing. `.auto` is
+    /// `resolvedThinkingConfig`'s branch and must never be routed here.
     static func thinkingConfig(for mode: AiThinkingMode, model: String) -> [String: Any]? {
         guard mode != .auto else { return nil }
         let lowered = model.lowercased()
         if lowered.contains("1.5") { return nil }
         if lowered.contains("gemini-3") {
-            // gemini-3-pro (not 3.1) supports only low/high; round toward them.
-            let onlyLowHigh = lowered.contains("gemini-3-pro")
-            switch mode {
-            case .instant: return ["thinkingLevel": onlyLowHigh ? "low" : "minimal"]
-            case .low:     return ["thinkingLevel": "low"]
-            case .medium:  return ["thinkingLevel": onlyLowHigh ? "high" : "medium"]
-            case .high:    return ["thinkingLevel": "high"]
-            case .auto:    return nil
-            }
+            guard let level = resolvedThinkingLevel(
+                model: lowered, requested: requestedLevel(for: mode)) else { return nil }
+            return ["thinkingLevel": level]
         }
         // 2.5 accepts numeric thinkingBudget across the family. Of the 2.0
         // models only the documented *-thinking variants do — plain

--- a/Vellum/Services/Ai/GeminiClient.swift
+++ b/Vellum/Services/Ai/GeminiClient.swift
@@ -261,51 +261,73 @@ final class GeminiClient {
         return nil
     }
 
-    /// Whether omitting thinkingConfig still leaves the model thinking at a
-    /// level the server picks. True for the whole Gemini 3 line (its default
-    /// `thinkingLevel` is `high` on the Pro and 3-flash rows, `medium` on
-    /// 3.5-flash, `minimal` on 3.1-flash-lite) and for 2.5, whose default is
-    /// dynamic thinking. The 2.0 flash models and the retired 1.5 line don't
-    /// think at all, so an omitted config really does mean no reasoning tokens —
-    /// which matters, because those two families cap output at 8192 total and
-    /// must not be handed a larger budget.
-    static func thinksWhenUnconfigured(model: String) -> Bool {
+    /// The thinking the server does on its own when no thinkingConfig is sent,
+    /// expressed as the config it is equivalent to — or nil for a family that
+    /// does no thinking, where an omitted config really does mean zero reasoning
+    /// tokens.
+    ///
+    /// A *positive* list, and deliberately so. The rows below are the families
+    /// whose thinking defaults are documented and whose output limit is 65536,
+    /// which is what makes it safe to reserve room. Everything else — the 2.0
+    /// flash models, the retired 1.5 line, `gemma-*`, and any id this table has
+    /// never heard of — returns nil and keeps the flat base. A permissive
+    /// fallback here would be worse than the bug it guards: several ids this
+    /// endpoint serves cap output at 8192 total, and Gemini rejects a
+    /// `maxOutputTokens` above a model's limit, so guessing generously would
+    /// turn a truncated answer into a request that fails outright. As with
+    /// `OpenAIClient.supportedEfforts`, a family the picker ships needs a row.
+    ///
+    /// Levels come from the Gemini 3 thinking-levels table: the default is
+    /// `high` on `gemini-3-pro`, `gemini-3.1-pro` and `gemini-3-flash`,
+    /// `medium` on `gemini-3.5-flash`, and `minimal` on the flash-lite rows.
+    /// 2.5's default is dynamic thinking, which is the `-1` budget.
+    static func unconfiguredThinking(model: String) -> [String: Any]? {
         let lowered = model.lowercased()
-        if lowered.contains("1.5") { return false }
-        if lowered.contains("2.0") { return lowered.contains("thinking") }
-        return true
+        if lowered.contains("gemini-3") {
+            if lowered.contains("flash-lite") { return ["thinkingLevel": "minimal"] }
+            if lowered.contains("gemini-3.5-flash") { return ["thinkingLevel": "medium"] }
+            return ["thinkingLevel": "high"]
+        }
+        // Check the retired lines explicitly so a future "2.5"-shaped id can't
+        // slip past on a substring.
+        if lowered.contains("1.5") || lowered.contains("2.0") { return nil }
+        if lowered.contains("2.5") { return ["thinkingBudget": -1] }
+        return nil
     }
 
     /// Output-token cap for a turn, sized so thinking can't starve the answer.
     ///
-    /// The `.auto` hole this closes (#96): Auto sends no thinkingConfig on every
-    /// family except 2.5 flash, so the *server* picks the thinking level — and
-    /// the level it picks is not a low one. Google documents the default
-    /// `thinkingLevel` as `high` for `gemini-3-pro-preview`,
+    /// The hole this closes (#96): on every family except 2.5 flash, Auto sends
+    /// no thinkingConfig, so the *server* picks the thinking level — and on the
+    /// rows that dominate usage it does not pick a cheap one. Google documents
+    /// the default `thinkingLevel` as `high` for `gemini-3-pro-preview`,
     /// `gemini-3.1-pro-preview` and `gemini-3-flash-preview`, and 2.5's default
     /// as dynamic thinking. The cap nonetheless stayed at the flat 8192 base, so
-    /// on the app's default provider the default thinking mode reserved room for
-    /// *no* reasoning while the server did its most expensive kind. That is the
-    /// same trade #95 removed from the OpenAI path, and the same truncation.
+    /// the mode reserved room for *no* reasoning while the server did its most
+    /// expensive kind. Same trade #95 removed from the OpenAI path, same
+    /// truncation.
     ///
-    /// So Auto is budgeted at the top of the ladder rather than #95's mid-range:
-    /// the mid-range assumption there matched OpenAI's documented default effort
-    /// of `medium`, and the equivalent evidence-led answer for Gemini is `high`.
-    /// Over-reserving is free — `maxOutputTokens` is a ceiling, not a spend —
-    /// while under-reserving truncates a finished answer. The resulting caps stay
-    /// well inside the 65536 output limit every 2.5 and 3.x model documents.
+    /// The reserve is therefore sized off `unconfiguredThinking` — what the
+    /// server will actually do — rather than a blanket assumption. That is the
+    /// same evidence-led move #95 made by budgeting Auto at OpenAI's documented
+    /// default effort of `medium`; Gemini simply documents a different default
+    /// per family, so the number differs per family too. Note this leaves the
+    /// flash-lite rows at the base: their documented default really is
+    /// `minimal`, so there is nothing there to reserve for, and inflating them
+    /// would only widen a cost guard that isn't the bug — on, as it happens, the
+    /// app's own default model.
+    ///
+    /// Gated on the config being absent rather than on `mode == .auto`: what
+    /// makes the reserve necessary is that nothing is being sent while the model
+    /// thinks anyway, which is a property of the request, not of the mode. No
+    /// shipped pair differs between the two spellings — the 3.x and 2.5 rows
+    /// return a config for every explicit mode — but keying on the mode would
+    /// leave a future family's High budgeted below its Auto.
     static func maxOutputTokens(for mode: AiThinkingMode, model: String) -> Int {
-        let config = resolvedThinkingConfig(for: mode, model: model)
-        guard mode == .auto, config == nil, thinksWhenUnconfigured(model: model) else {
+        if let config = resolvedThinkingConfig(for: mode, model: model) {
             return maxOutputTokens(thinkingConfig: config)
         }
-        // Budget the server's own choice as if High had been asked for. A family
-        // with no row (a future release) has no level to resolve, so fall back to
-        // the same reserve the level ladder's top rung gets.
-        guard let topOfLadder = thinkingConfig(for: .high, model: model) else {
-            return highThinkingReserve + baseMaxOutputTokens
-        }
-        return maxOutputTokens(thinkingConfig: topOfLadder)
+        return maxOutputTokens(thinkingConfig: unconfiguredThinking(model: model))
     }
 
     /// Output-token cap sized so thinking can't starve the visible answer.
@@ -350,29 +372,38 @@ final class GeminiClient {
     /// "which one id is special", the same inversion `OpenAIClient
     /// .supportedEfforts` made for #94. The previous form asked
     /// `contains("gemini-3-pro")` and treated everything else on the 3 line as
-    /// supporting the full ladder. `gemini-3.1-pro` does not contain that
-    /// substring, so it landed in the permissive branch and Instant sent it
-    /// `minimal` — a level the 3.1 Pro row does not have, so the request 400s
-    /// before streaming. That is #94's failure mode reappearing on a point
-    /// release, which is why the shape and not just the string is what changes
-    /// here.
+    /// supporting the full ladder — so a Pro id that doesn't contain that exact
+    /// substring would land in the permissive branch and be sent `minimal` on
+    /// Instant, a level no Pro row has, which 400s before streaming.
+    ///
+    /// `gemini-3.1-pro` is the id that shows the shape is wrong: it ships in
+    /// `AiModelCatalog.opencode` today. It cannot reach *this* function — the
+    /// OpenCode gateways are OpenAI-shaped and send `reasoning_effort` through
+    /// `OpenCodeZenClient` — so nothing is live-broken. But it is exactly the
+    /// name a future `AiModelCatalog.gemini` entry would carry, and #94 was the
+    /// same story: a point release nobody re-checked taking the wrong branch.
+    /// So the fix is the shape, not the string.
     ///
     /// Rows come from the Gemini 3 developer guide plus each model's page under
     /// `ai.google.dev/gemini-api/docs/models`:
-    /// - `gemini-3-pro-preview` is the narrow one: `low`/`high` only.
-    /// - `gemini-3.1-pro-preview` added `medium` but still has no `minimal`.
-    /// - The flash line (`3-flash`, `3.1-flash`/`-flash-lite`, `3.5-flash`)
-    ///   takes the full ladder.
+    /// - `gemini-3-pro` is the narrow one: `low`/`high` only.
+    /// - `gemini-3.1-pro` added `medium` but still has no `minimal`.
+    /// - The text flash line (`3-flash`, `3.1-flash`/`-flash-lite`,
+    ///   `3.5-flash`) takes the full ladder.
+    /// - The `-image` variants are the exception to that: the thinking-levels
+    ///   table gives `gemini-3.1-flash-lite-image` `minimal`/`high` only, so
+    ///   they are matched before the flash rows rather than inheriting them.
     ///
-    /// An unrecognized id on the 3 line falls to `low`/`high`: that is the
-    /// intersection of every row above, so it can't send a level some future
-    /// Pro release rejects. Note the safe branch here is a *narrower set*, not
-    /// the empty set `supportedEfforts` uses — omitting the field on Gemini
-    /// means the server default, which on this line is `high`, so an omit would
-    /// silently turn Instant into the slowest and priciest setting.
+    /// An unrecognized id on the 3 line falls to `low`/`high`: the intersection
+    /// of the text rows above, so it can't send a level some future Pro release
+    /// rejects. Note the safe branch here is a *narrower set*, not the empty set
+    /// `supportedEfforts` uses — omitting the field on Gemini means the server
+    /// default, which on most of this line is `high`, so an omit would silently
+    /// turn Instant into the slowest and priciest setting.
     static func supportedThinkingLevels(model: String) -> Set<String> {
         let lowered = model.lowercased()
         guard lowered.contains("gemini-3") else { return [] }
+        if lowered.contains("-image") { return ["minimal", "high"] }
         if lowered.contains("gemini-3-flash")
             || lowered.contains("gemini-3.1-flash")
             || lowered.contains("gemini-3.5-flash") {


### PR DESCRIPTION
Closes #96.

Three variants of one bug: the output-token cap didn't track the reasoning the model was actually going to do, so the answer got truncated.

## Root cause

Reasoning tokens are drawn from the same `max_output_tokens` / `maxOutputTokens` budget as the visible answer. Both clients sized that budget as if no reasoning would happen.

1. **Gemini Auto.** `.auto` sends no `thinkingConfig` on every family except 2.5 flash, so the *server* picks the thinking level — and on most rows it doesn't pick a cheap one. The cap stayed at the flat 8192 base regardless, reserving room for *no* reasoning while the server did its most expensive kind. This is the app's default provider.
2. **ChatGPT flat cap.** `max_output_tokens` was a literal `8192` for every thinking mode, so High spent most of one shared budget thinking and had no more room left for the answer than Instant.
3. **Gemini family matching.** `contains("gemini-3-pro")` is a single-id string test; anything else on the 3 line fell into the permissive branch and could be sent a `thinkingLevel` its row doesn't have, which 400s before streaming — #94's failure mode, one point release later.

## Fix

**Gemini.** The Auto reserve is sized off `unconfiguredThinking(model:)`, a documented per-family table of what the server does when the field is omitted, rather than a blanket assumption. Level rows move into `supportedThinkingLevels(model:)` + `resolvedThinkingLevel(model:requested:)` — explicit rows for what each family accepts, nearest-rung fallback, unrecognized ids falling to a safe branch — mirroring `OpenAIClient.supportedEfforts` post-#95.

**ChatGPT.** The cap scales through the same `OpenAIClient.maxOutputTokens` table, keyed off the effort actually resolved for the model, floored at the 8192 that used to be sent unconditionally so the fix only ever *raises* a budget.

Both request bodies move behind static `requestBody` factories (matching `OpenRouterClient.requestBody`) so tests assert the JSON that ships rather than the helpers behind it.

## Measured numbers

Gemini `maxOutputTokens`, before → after:

| model | Auto | Instant / Low / Medium / High |
|---|---|---|
| `gemini-3.1-flash-lite-preview` (app default) | 8192 → 8192 | 8192 / 16384 / 24576 / 32768 |
| `gemini-3-pro-preview` | 8192 → **32768** | 16384 / 16384 / 32768 / 32768 |
| `gemini-3-flash-preview` | 8192 → **32768** | 8192 / 16384 / 24576 / 32768 |
| `gemini-2.5-pro` | 8192 → **32768** | 8320 / 8320 / 32768 / 32768 |
| `gemini-2.5-flash`, `-flash-lite` | 8192 (Auto disables thinking) | 8192 / 8704 / 32768 / 32768 |
| `gemini-2.0-*`, `gemini-1.5-*` | 8192, unchanged in every mode | 8192 |

ChatGPT `max_output_tokens`, flat 8192 before: Instant **8192**, Low **8192**, Medium **16384**, High **32768**, Auto **16384**.

`thinkingConfig` output is byte-for-byte unchanged for all 10 shipped Gemini ids × 5 modes — the restructure is behaviour-preserving on what ships and hardens what doesn't yet.

Doc-verified against Google's Gemini API docs: `gemini-3-pro-preview` takes low/high only; `gemini-3.1-pro-preview` adds medium but still has no `minimal`; the text flash line takes the full ladder; 2.5-pro's budget floor is 128 (it cannot disable thinking); output limits are 65536 on 2.5/3.x and 8192 on 2.0. Every cap above stays inside those limits.

## Reviewer findings (two independent fresh-context Opus reviews)

Both approved the structure and confirmed no shipped request can 400. Six substantive findings, all applied in `1973e4e`:

- **Auto over-budgeted the app's default model.** The first pass budgeted Auto as `high` for the whole 3 line, but Google documents `gemini-3.1-flash-lite`'s default as `minimal` — so the blanket rule quadrupled the cap on the single most common request the app makes, and contradicted a comment in the same file. Now sized off the documented per-family default, which leaves flash-lite at the base.
- **ChatGPT Instant silently halved, 8192 → 4096.** `minimal` resolves to effort `none`, which spends *zero* reasoning tokens, so the entire drop would have come out of visible answer length — this issue's own symptom, on the one mode nobody reported it for. Fixed with the floor.
- **The unknown-family fallback reserved the widest budget**, inverting the safe direction for a cap: ids this endpoint serves with an 8192 output limit would have been sent 32768, and Gemini rejects a `maxOutputTokens` above the model's limit — turning a truncated answer into a request that fails outright. Unknown ids now keep the flat base; the table is a positive list.
- **The reserve keyed off `mode == .auto`** rather than off the config being absent, so a future family with no row would budget its High *below* its Auto for byte-identical JSON.
- **Comment accuracy.** The `gemini-3.1-pro` 400 is not reachable through this client (that id ships only in `AiModelCatalog.opencode`, which is OpenAI-shaped and routes through `OpenCodeZenClient`); the claim is now counterfactual. And `-image` variants take minimal/high only, so they no longer inherit the flash rows.
- **Two tests read expected values out of the implementation** — the output-limit test derived its own allowed limit from the code under test, so a misclassified model could raise its own ceiling and pass green. Both now use literal documented tables.

Reviewers also flagged, out of scope: `gemini-3.1-flash-lite-preview` (the app's default model) is documented as shut down 2026-05-25 in favour of `gemini-3.1-flash-lite`. Worth its own issue.

## Verification

Clean build, zero warnings (warnings-as-errors is on). Full suite green: **488 XCTest** (471 baseline + 17 new) and **147 Swift Testing**, run four times.

All 17 new tests mutation-checked: reverting the Auto reserve, the 3.1-pro row, the per-family defaults, the unknown-family fallback, the `-image` row and the ChatGPT floor each fail the intended test and only that test.

One caveat worth recording: during this work the machine hit a window where the test host crashed repeatedly with WebKit sandbox denials (`WebContent … Couldn't connect to launchservicesd`), taking down seven *different* unrelated filesystem/WebKit suites across six runs. Base `origin/main` was re-run five times and the branch four times to separate signal from noise; the AI tests passed 64/64 in every run including the crashed ones, and both branch and base pass cleanly now. Same class as the isolation flake in #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
