### PR TITLE
Replace the process-global defaults seam with a scoped, fail-closed AppDefaults

### DIFF
--- a/Tests/AppDefaultsGuardTests.swift
+++ b/Tests/AppDefaultsGuardTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import Vellum
+
+// The `AppDefaults` guard (#102), the app-state counterpart to the keychain
+// guard covered by `UITestLaunchConfigurationTests` (#97).
+//
+// Every assertion here only ever READS `UserDefaults.standard`. The claim under
+// test is that a test cannot reach the real domain, so proving it must not
+// begin by writing to it.
+
+@Suite("App state cannot reach the real defaults")
+struct AppDefaultsGuardTests {
+    /// The floor: with nothing installed, a hosted test bundle still must not
+    /// be handed the domain it shares with the app.
+    @Test("The ambient domain under test is never UserDefaults.standard")
+    func ambientDomainIsNotStandard() {
+        #expect(AppDefaults.current !== UserDefaults.standard)
+    }
+
+    /// `WorkspaceService.save` had no seam at all; a test reached it only if it
+    /// got past `WorkspaceStore.scheduleSave`'s `guard didRestore`. Calling it
+    /// directly here is the case that guard never covered.
+    @Test("A workspace save cannot land in the real domain")
+    func workspaceSaveStaysOutOfStandard() {
+        let key = "vellum.workspace"
+        let before = UserDefaults.standard.string(forKey: key)
+        defer { WorkspaceService.clear() }
+
+        WorkspaceService.save(
+            WorkspaceState(root: .leaf(tabs: [], activeTabIndex: nil), focusedLeafIndex: 0))
+
+        #expect(WorkspaceService.load() != nil, "the save still has to land somewhere readable")
+        #expect(
+            UserDefaults.standard.string(forKey: key) == before,
+            "a test's workspace save must not touch the real window layout")
+    }
+
+    @Test("A recents write cannot land in the real domain")
+    func recentsWriteStaysOutOfStandard() {
+        let path = "/tmp/guard-\(UUID().uuidString).pdf"
+        let before = UserDefaults.standard.string(forKey: RecentFilesService.storageKey)
+        defer { _ = RecentFilesService.remove(path: path) }
+
+        RecentFilesService.record(
+            DocumentInfo(kind: .pdf, pdfPath: path, title: "Guard", pageCount: 1))
+
+        #expect(RecentFilesService.getRecent().contains { $0.pdfPath == path })
+        #expect(
+            UserDefaults.standard.string(forKey: RecentFilesService.storageKey) == before,
+            "a test's recents write must not touch the real recent-documents list")
+    }
+
+    /// The isolation property the task-local buys over the process-global it
+    /// replaces: the redirect unwinds with the task that bound it, so there is
+    /// no window in which another suite could observe — or reset — it.
+    @Test("A scoped redirect is invisible outside its scope")
+    func scopedRedirectDoesNotLeak() async throws {
+        let name = "vellum.scoped.\(UUID().uuidString)"
+        let scratch = try #require(UserDefaults(suiteName: name))
+        defer { scratch.removePersistentDomain(forName: name) }
+        let path = "/tmp/scoped-\(UUID().uuidString).pdf"
+
+        await AppDefaults.withDefaults(scratch) {
+            RecentFilesService.record(
+                DocumentInfo(kind: .pdf, pdfPath: path, title: "Scoped", pageCount: 1))
+            #expect(RecentFilesService.getRecent().contains { $0.pdfPath == path })
+        }
+
+        #expect(
+            !RecentFilesService.getRecent().contains { $0.pdfPath == path },
+            "the scoped domain must not be visible once its binding has unwound")
+    }
+}

--- a/Tests/AppDefaultsGuardTests.swift
+++ b/Tests/AppDefaultsGuardTests.swift
@@ -9,9 +9,23 @@ import Testing
 // Every assertion here only ever READS `UserDefaults.standard`. The claim under
 // test is that a test cannot reach the real domain, so proving it must not
 // begin by writing to it.
+//
+// The two write tests go further and REFUSE to run unless the floor is already
+// in place: their writes go wherever `AppDefaults` points, so if the floor ever
+// regressed, a test that wrote first and checked afterwards would report the
+// damage only after doing it — deleting the developer's real window layout via
+// its own cleanup. Checking first also makes the obvious mutation (point the
+// floor at `.standard`) safe to run: all three fail without a single write.
 
 @Suite("App state cannot reach the real defaults")
 struct AppDefaultsGuardTests {
+    /// Fail fast, before writing anything, if the floor is not holding.
+    private func requireFloor() throws {
+        try #require(
+            AppDefaults.current !== UserDefaults.standard,
+            "refusing to write: the guard under test is not in place")
+    }
+
     /// The floor: with nothing installed, a hosted test bundle still must not
     /// be handed the domain it shares with the app.
     @Test("The ambient domain under test is never UserDefaults.standard")
@@ -23,7 +37,8 @@ struct AppDefaultsGuardTests {
     /// got past `WorkspaceStore.scheduleSave`'s `guard didRestore`. Calling it
     /// directly here is the case that guard never covered.
     @Test("A workspace save cannot land in the real domain")
-    func workspaceSaveStaysOutOfStandard() {
+    func workspaceSaveStaysOutOfStandard() throws {
+        try requireFloor()
         let key = "vellum.workspace"
         let before = UserDefaults.standard.string(forKey: key)
         defer { WorkspaceService.clear() }
@@ -38,18 +53,46 @@ struct AppDefaultsGuardTests {
     }
 
     @Test("A recents write cannot land in the real domain")
-    func recentsWriteStaysOutOfStandard() {
-        let path = "/tmp/guard-\(UUID().uuidString).pdf"
+    func recentsWriteStaysOutOfStandard() throws {
+        try requireFloor()
+        // Match on the file name, not the whole path: the JSON writer escapes
+        // forward slashes, so the stored text holds `\/tmp\/…`.
+        let fileName = "guard-\(UUID().uuidString).pdf"
+        let path = "/tmp/\(fileName)"
         let before = UserDefaults.standard.string(forKey: RecentFilesService.storageKey)
         defer { _ = RecentFilesService.remove(path: path) }
 
         RecentFilesService.record(
             DocumentInfo(kind: .pdf, pdfPath: path, title: "Guard", pageCount: 1))
 
-        #expect(RecentFilesService.getRecent().contains { $0.pdfPath == path })
+        // Assert on the domain the write went to, not on membership of the list
+        // it returns: the ambient domain is shared with the unseamed XCTest
+        // classes, and recents is a capped read-modify-write, so membership can
+        // be evicted by an unrelated write for reasons that are not this bug.
+        #expect(
+            AppDefaults.current.string(forKey: RecentFilesService.storageKey)?
+                .contains(fileName) == true)
         #expect(
             UserDefaults.standard.string(forKey: RecentFilesService.storageKey) == before,
             "a test's recents write must not touch the real recent-documents list")
+    }
+
+    /// The legacy scratchpad blob is the third key that reaches real state, and
+    /// the one with observed damage: two suites SEED and DELETE it to drive
+    /// migration coverage, so on `.standard` they were editing the user's
+    /// pre-folder notes — and racing any other test process doing the same.
+    @Test("The legacy note blob cannot land in the real domain")
+    func legacyBlobStaysOutOfStandard() throws {
+        try requireFloor()
+        let key = ScratchpadPersistence.notesKey
+        let before = UserDefaults.standard.data(forKey: key)
+        defer { AppDefaults.current.removeObject(forKey: key) }
+
+        ScratchpadPersistence.removeLegacyEntry(key: "/tmp/nothing-\(UUID().uuidString).pdf")
+
+        #expect(
+            UserDefaults.standard.data(forKey: key) == before,
+            "a test's legacy-blob write must not touch the real notes")
     }
 
     /// The isolation property the task-local buys over the process-global it
@@ -59,7 +102,7 @@ struct AppDefaultsGuardTests {
     func scopedRedirectDoesNotLeak() async throws {
         let name = "vellum.scoped.\(UUID().uuidString)"
         let scratch = try #require(UserDefaults(suiteName: name))
-        defer { scratch.removePersistentDomain(forName: name) }
+        defer { removeSuite(scratch, named: name) }
         let path = "/tmp/scoped-\(UUID().uuidString).pdf"
 
         await AppDefaults.withDefaults(scratch) {

--- a/Tests/DocumentDataStoreTests.swift
+++ b/Tests/DocumentDataStoreTests.swift
@@ -27,7 +27,7 @@ final class DocumentDataStoreTests: XCTestCase {
         DocumentDataStore.rootDirectoryOverride = nil
         ScratchpadAttachmentStore.directoryOverride = nil
         ScratchpadAttachmentStore.activeDirectory = nil
-        UserDefaults.standard.removeObject(forKey: ScratchpadPersistence.notesKey)
+        AppDefaults.current.removeObject(forKey: ScratchpadPersistence.notesKey)
         // Restore write perms in case a test left a folder read-only, so the
         // scratch tree can be torn down cleanly.
         if let root {
@@ -123,11 +123,11 @@ final class DocumentDataStoreTests: XCTestCase {
 
     private func seedLegacyBlob(_ entries: [BlobEntry]) throws {
         let data = try JSONEncoder().encode(entries)
-        UserDefaults.standard.set(data, forKey: ScratchpadPersistence.notesKey)
+        AppDefaults.current.set(data, forKey: ScratchpadPersistence.notesKey)
     }
 
     private func legacyBlobEntries() throws -> [BlobEntry] {
-        guard let data = UserDefaults.standard.data(forKey: ScratchpadPersistence.notesKey)
+        guard let data = AppDefaults.current.data(forKey: ScratchpadPersistence.notesKey)
         else { return [] }
         return try JSONDecoder().decode([BlobEntry].self, from: data)
     }

--- a/Tests/DocumentRenameTests.swift
+++ b/Tests/DocumentRenameTests.swift
@@ -10,14 +10,16 @@ import Testing
 // redirected to a temp directory or a scratch `UserDefaults` suite, so nothing
 // touches the real library or the real recents list.
 
-/// Redirects `DocumentDataStore`, `WebLibrary` and `RecentFilesService` at
-/// throwaway storage for the life of one test, and puts them all back after.
-/// A `class` with a `deinit` because Swift Testing has no `tearDown` — the
-/// suite holds one and the restore happens when the test's instance dies.
+/// Redirects `DocumentDataStore` and `WebLibrary` at throwaway storage for the
+/// life of one test, and puts them back after. A `class` with a `deinit`
+/// because Swift Testing has no `tearDown` — the suite holds one and the
+/// restore happens when the test's instance dies.
+///
+/// The recents domain is NOT handled here: it comes from the `.scratchDefaults`
+/// trait, which scopes it to the test's own task instead of parking it in a
+/// process-global this class would have to remember to restore (#102).
 private final class ScratchStores {
     let root: URL
-    private let defaults: UserDefaults
-    private let suiteName: String
 
     init() {
         root = FileManager.default.temporaryDirectory
@@ -27,19 +29,13 @@ private final class ScratchStores {
         try? FileManager.default.createDirectory(at: documents, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: web, withIntermediateDirectories: true)
 
-        suiteName = "vellum.rename.tests.\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: suiteName)!
-
         DocumentDataStore.rootDirectoryOverride = documents
         WebLibrary.storeDirOverride = web
-        RecentFilesService.defaultsOverride = defaults
     }
 
     deinit {
         DocumentDataStore.rootDirectoryOverride = nil
         WebLibrary.storeDirOverride = nil
-        RecentFilesService.defaultsOverride = nil
-        defaults.removePersistentDomain(forName: suiteName)
         try? FileManager.default.removeItem(at: root)
     }
 
@@ -125,7 +121,9 @@ struct DocumentRenameTargetTests {
     }
 }
 
-@Suite("Rename: persistence", .serialized)
+/// `.serialized` for `ScratchStores`' remaining process-global directory
+/// overrides; the recents domain is per-test via `.scratchDefaults`.
+@Suite("Rename: persistence", .serialized, .scratchDefaults)
 struct DocumentRenamePersistenceTests {
     private let stores = ScratchStores()
 

--- a/Tests/DocumentRenameTests.swift
+++ b/Tests/DocumentRenameTests.swift
@@ -121,8 +121,12 @@ struct DocumentRenameTargetTests {
     }
 }
 
-/// `.serialized` for `ScratchStores`' remaining process-global directory
-/// overrides; the recents domain is per-test via `.scratchDefaults`.
+/// The recents domain is per-test via `.scratchDefaults`. `.serialized` stays
+/// for `ScratchStores`' remaining process-global DIRECTORY overrides — note it
+/// is not sufficient for those, since nine suites set
+/// `DocumentDataStore.rootDirectoryOverride` and `.serialized` only orders
+/// tests within one suite. That is the same bug as #102 in the storage seams;
+/// this branch fixes the defaults half.
 @Suite("Rename: persistence", .serialized, .scratchDefaults)
 struct DocumentRenamePersistenceTests {
     private let stores = ScratchStores()

--- a/Tests/InspectorPresentationTests.swift
+++ b/Tests/InspectorPresentationTests.swift
@@ -4,9 +4,10 @@ import Testing
 
 /// `.scratchDefaults` gives each test its own domain for the recents write that
 /// `AppStore.adoptOpenedDocument` performs — opening a document is unavoidable
-/// here, it is the whole subject of these tests. `.serialized` remains only
-/// because every test drives a real `WorkspaceStore`; the recents redirect is
-/// no longer process-global, so it is not a reason to serialize (#102).
+/// here, it is the whole subject of these tests. The recents redirect is no
+/// longer process-global, so it is no longer a reason to serialize (#102);
+/// `.serialized` stays because opening a document also reaches the storage
+/// seams, which ARE still process-global.
 @MainActor
 @Suite(.serialized, .scratchDefaults)
 struct InspectorPresentationTests {

--- a/Tests/InspectorPresentationTests.swift
+++ b/Tests/InspectorPresentationTests.swift
@@ -2,18 +2,14 @@ import Foundation
 import Testing
 @testable import Vellum
 
-/// `.serialized` because `RecentFilesService.defaultsOverride` (installed by
-/// `ScratchRecents` below) is process-global mutable state, and because every
-/// test here drives a real `WorkspaceStore`.
+/// `.scratchDefaults` gives each test its own domain for the recents write that
+/// `AppStore.adoptOpenedDocument` performs — opening a document is unavoidable
+/// here, it is the whole subject of these tests. `.serialized` remains only
+/// because every test drives a real `WorkspaceStore`; the recents redirect is
+/// no longer process-global, so it is not a reason to serialize (#102).
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .scratchDefaults)
 struct InspectorPresentationTests {
-    /// Redirects the recents write that `AppStore.adoptOpenedDocument` performs
-    /// into a throwaway domain. Opening a document is unavoidable here — it is
-    /// the whole subject of these tests — and the test bundle is hosted, so
-    /// without this the suite would rewrite the real app's recent-documents
-    /// list with `/tmp` paths (exactly what `defaultsOverride` was added for).
-    private let recents = ScratchRecents()
 
     @Test("PDF to New Tab to PDF preserves inspector state")
     func pdfNewTabPdf() async throws {
@@ -181,25 +177,6 @@ struct InspectorPresentationTests {
         #expect(workspace.sidebarOpen == false)
         #expect(workspace.inspectorPresented == false)
         #expect(workspace.sidebarTab == .ai)
-    }
-}
-
-/// Scratch UserDefaults domain for the recents write, restored when the test
-/// instance dies. A `class` with a `deinit` because Swift Testing has no
-/// `tearDown` — mirrors `ScratchStores` in `DocumentRenameTests`.
-private final class ScratchRecents {
-    private let defaults: UserDefaults
-    private let suiteName: String
-
-    init() {
-        suiteName = "vellum.inspector.tests.\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: suiteName)!
-        RecentFilesService.defaultsOverride = defaults
-    }
-
-    deinit {
-        RecentFilesService.defaultsOverride = nil
-        defaults.removePersistentDomain(forName: suiteName)
     }
 }
 

--- a/Tests/ScratchDefaultsTrait.swift
+++ b/Tests/ScratchDefaultsTrait.swift
@@ -13,10 +13,16 @@ import Testing
 /// its users had to be `.serialized` — and `.serialized` only orders tests
 /// within one suite, so two such suites still raced each other (#102).
 ///
-/// Only needed by suites that want their OWN domain, e.g. to assert on what a
-/// write left behind. Merely keeping a test out of the real user's recents and
-/// workspace needs nothing: `AppDefaults` already refuses to hand a hosted test
-/// bundle `UserDefaults.standard`.
+/// Not needed merely to stay out of the real user's recents and workspace —
+/// `AppDefaults` already refuses to hand a hosted test bundle
+/// `UserDefaults.standard`. Reach for it when a suite wants its own domain: to
+/// assert on what a write left behind, or to keep its writes from piling up in
+/// the shared scratch domain alongside every unseamed suite's.
+///
+/// The binding unwinds as soon as the test body returns, so a write still in
+/// flight at that point (a debounced `WorkspaceStore` save, say) lands in the
+/// base domain and can recreate this suite after teardown. Join such work
+/// before returning if a test arms any.
 struct ScratchDefaultsTrait: TestTrait, SuiteTrait, TestScoping {
     /// Applies to every test in a suite it is attached to.
     var isRecursive: Bool { true }
@@ -29,9 +35,23 @@ struct ScratchDefaultsTrait: TestTrait, SuiteTrait, TestScoping {
         let name = "vellum.scratch.\(UUID().uuidString)"
         let defaults = try #require(
             UserDefaults(suiteName: name), "could not open scratch suite \(name)")
-        defer { defaults.removePersistentDomain(forName: name) }
+        defer { removeSuite(defaults, named: name) }
         try await AppDefaults.withDefaults(defaults) { try await function() }
     }
+}
+
+/// Empty a scratch suite AND unlink its plist.
+///
+/// `removePersistentDomain` clears the contents but leaves the file behind, so
+/// a per-test UUID domain leaves one plist in `~/Library/Preferences` per test
+/// per run — the hand-rolled scratch classes this trait replaces had already
+/// left over a thousand of them.
+func removeSuite(_ defaults: UserDefaults, named name: String) {
+    defaults.removePersistentDomain(forName: name)
+    UserDefaults.standard.removeSuite(named: name)
+    let plist = URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent("Library/Preferences/\(name).plist")
+    try? FileManager.default.removeItem(at: plist)
 }
 
 extension Trait where Self == ScratchDefaultsTrait {

--- a/Tests/ScratchDefaultsTrait.swift
+++ b/Tests/ScratchDefaultsTrait.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+
+@testable import Vellum
+
+/// `.scratchDefaults` — points `AppDefaults` at a throwaway `UserDefaults`
+/// suite for the duration of each test, then removes it.
+///
+/// A trait rather than a stored property with a `deinit` (the shape this
+/// replaces) because the redirect is a task-local: it is bound around the test's
+/// own body and unwinds with it, so a suite finishing concurrently cannot unhook
+/// it mid-test. The process-global it replaces could be, which is why both of
+/// its users had to be `.serialized` — and `.serialized` only orders tests
+/// within one suite, so two such suites still raced each other (#102).
+///
+/// Only needed by suites that want their OWN domain, e.g. to assert on what a
+/// write left behind. Merely keeping a test out of the real user's recents and
+/// workspace needs nothing: `AppDefaults` already refuses to hand a hosted test
+/// bundle `UserDefaults.standard`.
+struct ScratchDefaultsTrait: TestTrait, SuiteTrait, TestScoping {
+    /// Applies to every test in a suite it is attached to.
+    var isRecursive: Bool { true }
+
+    func provideScope(
+        for test: Test,
+        testCase: Test.Case?,
+        performing function: @Sendable () async throws -> Void
+    ) async throws {
+        let name = "vellum.scratch.\(UUID().uuidString)"
+        let defaults = try #require(
+            UserDefaults(suiteName: name), "could not open scratch suite \(name)")
+        defer { defaults.removePersistentDomain(forName: name) }
+        try await AppDefaults.withDefaults(defaults) { try await function() }
+    }
+}
+
+extension Trait where Self == ScratchDefaultsTrait {
+    static var scratchDefaults: Self { Self() }
+}

--- a/Tests/StorageManagementTests.swift
+++ b/Tests/StorageManagementTests.swift
@@ -20,7 +20,7 @@ final class StorageManagementTests: XCTestCase {
 
     override func tearDown() async throws {
         DocumentDataStore.rootDirectoryOverride = nil
-        UserDefaults.standard.removeObject(forKey: ScratchpadPersistence.notesKey)
+        AppDefaults.current.removeObject(forKey: ScratchpadPersistence.notesKey)
         UserDefaults.standard.removeObject(forKey: AiPersistence.conversationsKey)
         UserDefaults.standard.removeObject(forKey: StorageHousekeeping.retentionMonthsKey)
         if let base { try? FileManager.default.removeItem(at: base) }
@@ -366,7 +366,7 @@ final class StorageManagementTests: XCTestCase {
             BlobEntry(key: "/tmp/a.pdf", text: "note a"),
             BlobEntry(key: "/tmp/b.pdf", text: "longer note b"),
         ]
-        UserDefaults.standard.set(try JSONEncoder().encode(entries), forKey: ScratchpadPersistence.notesKey)
+        AppDefaults.current.set(try JSONEncoder().encode(entries), forKey: ScratchpadPersistence.notesKey)
 
         let listed = ScratchpadPersistence.listLegacyEntries()
         XCTAssertEqual(Set(listed.map(\.key)), ["/tmp/a.pdf", "/tmp/b.pdf"])

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		610646426C95711C3BAD33BA /* AiToolSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4DB73291B8E06F452CEBCD /* AiToolSummaryTests.swift */; };
 		65858805EE10C9DAA53531F5 /* KaTeX_Script-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 529B3D1901669D3F00BBCF74 /* KaTeX_Script-Regular.woff2 */; };
 		67B320CA1556DCBF8C2A8507 /* PdfGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102BFBC5EF5B66C15AC2BC86 /* PdfGeometry.swift */; };
+		6A2252DEAA424409E0A605FC /* AppDefaultsGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A1D1FEFF7CFD752BF6D390 /* AppDefaultsGuardTests.swift */; };
 		6AF2B59C76A57D0A112B2015 /* KaTeX_Caligraphic-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = A7508380103E3495A82E0771 /* KaTeX_Caligraphic-Regular.woff2 */; };
 		6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30CD609AEA2C0A662890153 /* TabBarView.swift */; };
 		6BC16B7A757748F3E6A3F126 /* DocumentRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F74ED028819A0D803E89E25 /* DocumentRenameTests.swift */; };
@@ -230,6 +231,7 @@
 		1AF164F3710054DE83B01BD6 /* ScratchDefaultsTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchDefaultsTrait.swift; sourceTree = "<group>"; };
 		1B7D1E617157C08AD0AB7246 /* HomeSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchStore.swift; sourceTree = "<group>"; };
 		1DE37DD793875C0DBF92E050 /* KaTeX_Main-BoldItalic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-BoldItalic.woff2"; sourceTree = "<group>"; };
+		20A1D1FEFF7CFD752BF6D390 /* AppDefaultsGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDefaultsGuardTests.swift; sourceTree = "<group>"; };
 		20B2D17372EC7164FEB6B7AF /* KaTeX_Math-Italic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Math-Italic.woff2"; sourceTree = "<group>"; };
 		22F535D1F42D4D7C29D060EC /* TabResidencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabResidencyTests.swift; sourceTree = "<group>"; };
 		236D6A7A9EA6BF08E9D6FB10 /* DocumentRenameService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentRenameService.swift; sourceTree = "<group>"; };
@@ -499,6 +501,7 @@
 				9674A1105A70C761C2EC40AB /* AiReferencePersistenceTests.swift */,
 				7A4DB73291B8E06F452CEBCD /* AiToolSummaryTests.swift */,
 				372DC33960E8DFA9E3444D41 /* AiTranscriptFollowTests.swift */,
+				20A1D1FEFF7CFD752BF6D390 /* AppDefaultsGuardTests.swift */,
 				F125F1382328217B11BF1DB2 /* AttachmentDropTests.swift */,
 				717C1543B2E8976D6267F8A5 /* DocumentActionsTests.swift */,
 				E9CE9BA76EA961FB5939EDCE /* DocumentDataStoreTests.swift */,
@@ -1140,6 +1143,7 @@
 				F4ED32A7851D641FB6F47CA4 /* AiReferencePersistenceTests.swift in Sources */,
 				610646426C95711C3BAD33BA /* AiToolSummaryTests.swift in Sources */,
 				21C5244660D9DDC7CF6BA218 /* AiTranscriptFollowTests.swift in Sources */,
+				6A2252DEAA424409E0A605FC /* AppDefaultsGuardTests.swift in Sources */,
 				0A8D06EC43340A3149052C29 /* AttachmentDropTests.swift in Sources */,
 				E43B370B9FE717B8FBDB16F4 /* DocumentActionsTests.swift in Sources */,
 				252A859CBF3B6F40740EC8BB /* DocumentDataStoreTests.swift in Sources */,

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		9C7F3F0B4C0CDEE7ED83CBB4 /* AnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18CA5A14795BD97D91F2056 /* AnnotationStore.swift */; };
 		9E139713CC03274E03B94E92 /* ToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E2B3DF66E30481C363C740 /* ToolbarView.swift */; };
 		9E702B90F8729B9145F7D31B /* SelectableMessageText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4601C034B834B5E610FD84 /* SelectableMessageText.swift */; };
+		A53C7337EE653AC598D9FD13 /* ScratchDefaultsTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF164F3710054DE83B01BD6 /* ScratchDefaultsTrait.swift */; };
 		A5E5A42BE09B4A7911646AFF /* UpdateChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723EC058218A6DF8D994CC26 /* UpdateChecker.swift */; };
 		A5E81D63CD3B19716028FF80 /* UITestLaunchConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84875506ADE5E9DDF4F20CC4 /* UITestLaunchConfiguration.swift */; };
 		A84C2B18F7A53ECE5F96F618 /* PaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD27558DB4D8DB212826B68 /* PaneView.swift */; };
@@ -158,6 +159,7 @@
 		D33775936E6D0F9CAF3F2223 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82487970E20F6628200C4BE /* KeychainStore.swift */; };
 		D3E15D784AC0EF97D1BE22E8 /* purify.min.js in Resources */ = {isa = PBXBuildFile; fileRef = 4B707464546ECFFA1A49EBDE /* purify.min.js */; };
 		D4A79DFDB08A01D35D47933A /* AiStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01F38132FDC803C6ACEB43CC /* AiStore.swift */; };
+		D4B81230A40F81C6E5B6F408 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF26A8AE533298D45E31BC6A /* AppDefaults.swift */; };
 		D529B1BD4F7B9FA1E791246F /* PageTextPersister.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504DC8725E6198531EC21429 /* PageTextPersister.swift */; };
 		D5F586434585D55B08108B40 /* StorageSettingsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB83E31DAAFDC48C15F2F130 /* StorageSettingsTab.swift */; };
 		D657C92463B102EF093DC4CB /* KaTeX_Main-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 90AB7C8FB37749DA52B6CF96 /* KaTeX_Main-Regular.woff2 */; };
@@ -225,6 +227,7 @@
 		14BA2FED5E906C5D311882E3 /* ChatGPTAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatGPTAuth.swift; sourceTree = "<group>"; };
 		14F128F9801AD030A1C8DA97 /* HomeResultViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeResultViews.swift; sourceTree = "<group>"; };
 		195A20D8270BAD8604C2E641 /* PdfAnnotationCodec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PdfAnnotationCodec.swift; sourceTree = "<group>"; };
+		1AF164F3710054DE83B01BD6 /* ScratchDefaultsTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScratchDefaultsTrait.swift; sourceTree = "<group>"; };
 		1B7D1E617157C08AD0AB7246 /* HomeSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchStore.swift; sourceTree = "<group>"; };
 		1DE37DD793875C0DBF92E050 /* KaTeX_Main-BoldItalic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-BoldItalic.woff2"; sourceTree = "<group>"; };
 		20B2D17372EC7164FEB6B7AF /* KaTeX_Math-Italic.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Math-Italic.woff2"; sourceTree = "<group>"; };
@@ -374,6 +377,7 @@
 		CC1F783F50CC2705F7C3733D /* SafeClearTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeClearTests.swift; sourceTree = "<group>"; };
 		CCBBA9A1DAB0373185D8F5EA /* DocumentIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentIdentityTests.swift; sourceTree = "<group>"; };
 		CD3D09C89D224F5C322CE8BB /* AiToolSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiToolSummaryView.swift; sourceTree = "<group>"; };
+		CF26A8AE533298D45E31BC6A /* AppDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDefaults.swift; sourceTree = "<group>"; };
 		D1784468C7F465AAEB5C63E9 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		D3510D3AF43D77CE2F65AECB /* DocumentSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentSessionManager.swift; sourceTree = "<group>"; };
 		D3AD047DB403B0B0530AC89B /* KaTeX_Main-Bold.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Main-Bold.woff2"; sourceTree = "<group>"; };
@@ -513,6 +517,7 @@
 				A5003641A54B311693588C6C /* PdfPersistenceTests.swift */,
 				BB2C2905E4A08861E42C2EED /* RecentsResolveTests.swift */,
 				CC1F783F50CC2705F7C3733D /* SafeClearTests.swift */,
+				1AF164F3710054DE83B01BD6 /* ScratchDefaultsTrait.swift */,
 				B1F8F1A0CB094398C5390128 /* ScratchpadDropRegistrationTests.swift */,
 				2E0D324F9CE4133DCC02BBD4 /* ScratchpadImportTests.swift */,
 				37F7B1CD3853E8F7239B9191 /* ScratchpadMarkdownExporterTests.swift */,
@@ -569,6 +574,7 @@
 		684DAB4695BAAAC3D1F963FF /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				CF26A8AE533298D45E31BC6A /* AppDefaults.swift */,
 				BA9D539B1461FC063BC82C78 /* DocumentDataStore.swift */,
 				28BDBF0FA0F7F13C32A07F05 /* DocumentIdentity.swift */,
 				236D6A7A9EA6BF08E9D6FB10 /* DocumentRenameService.swift */,
@@ -1014,6 +1020,7 @@
 				30F9DFF4371A901244DAD7BE /* AiUsage.swift in Sources */,
 				9AC827DE4385CD8EC4201A49 /* AnnotationSidebar.swift in Sources */,
 				9C7F3F0B4C0CDEE7ED83CBB4 /* AnnotationStore.swift in Sources */,
+				D4B81230A40F81C6E5B6F408 /* AppDefaults.swift in Sources */,
 				F5DFB55D5AEB2B65E76E5613 /* AppStore.swift in Sources */,
 				B861F8FD72248FD16E1562D4 /* AttachmentDrop.swift in Sources */,
 				EAE379048674CB8DF953D09D /* ChatGPTAuth.swift in Sources */,
@@ -1151,6 +1158,7 @@
 				806EDA3BB34A3680F7B39E1B /* PdfPersistenceTests.swift in Sources */,
 				17CEDFD80E708ADD26650928 /* RecentsResolveTests.swift in Sources */,
 				2708447E7B0AB5779FD79A5B /* SafeClearTests.swift in Sources */,
+				A53C7337EE653AC598D9FD13 /* ScratchDefaultsTrait.swift in Sources */,
 				C6A3A0FCEB6C19A3CA8DEE10 /* ScratchpadDropRegistrationTests.swift in Sources */,
 				36CA355A9BBDE3BB111BC559 /* ScratchpadImportTests.swift in Sources */,
 				F588EF4EEF4D4DA1E50F5D85 /* ScratchpadMarkdownExporterTests.swift in Sources */,

--- a/Vellum.xcodeproj/project.pbxproj
+++ b/Vellum.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		5ECD33C8989F2BEF18A108A4 /* AiAddAsNoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBC6D7A36009931F223DB9C2 /* AiAddAsNoteTests.swift */; };
 		5FF82C62FE4C7CC82FD160FD /* AiConversationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 327F0E350D7D13A26878EB77 /* AiConversationStoreTests.swift */; };
 		610646426C95711C3BAD33BA /* AiToolSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4DB73291B8E06F452CEBCD /* AiToolSummaryTests.swift */; };
+		64B391AA816FE70BC4C51874 /* TestEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E27D5C4D285C243BF0A68572 /* TestEnvironment.swift */; };
 		65858805EE10C9DAA53531F5 /* KaTeX_Script-Regular.woff2 in Resources */ = {isa = PBXBuildFile; fileRef = 529B3D1901669D3F00BBCF74 /* KaTeX_Script-Regular.woff2 */; };
 		67B320CA1556DCBF8C2A8507 /* PdfGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102BFBC5EF5B66C15AC2BC86 /* PdfGeometry.swift */; };
 		6A2252DEAA424409E0A605FC /* AppDefaultsGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A1D1FEFF7CFD752BF6D390 /* AppDefaultsGuardTests.swift */; };
@@ -395,6 +396,7 @@
 		E064C75923B5E7D98E256470 /* WebArchive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebArchive.swift; sourceTree = "<group>"; };
 		E201F2530645C6348ECC59AA /* AiStreaming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AiStreaming.swift; sourceTree = "<group>"; };
 		E2042B70E9B14894B30A1877 /* WalkthroughTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkthroughTests.swift; sourceTree = "<group>"; };
+		E27D5C4D285C243BF0A68572 /* TestEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestEnvironment.swift; sourceTree = "<group>"; };
 		E30CD609AEA2C0A662890153 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		E70BA19480CF71B6E14A7984 /* HomeSearchProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeSearchProvider.swift; sourceTree = "<group>"; };
 		E8C9F22335B2DEA99AF5ABF5 /* KaTeX_Typewriter-Regular.woff2 */ = {isa = PBXFileReference; path = "KaTeX_Typewriter-Regular.woff2"; sourceTree = "<group>"; };
@@ -587,6 +589,7 @@
 				7280818785023514C87C04C9 /* SessionService.swift */,
 				4FA50A523F4D87396EC11A8B /* StorageHousekeeping.swift */,
 				4E69330A4F460353FBCB25AB /* TabResidency.swift */,
+				E27D5C4D285C243BF0A68572 /* TestEnvironment.swift */,
 				95809D33AB6DF0D9BCF1BE88 /* VellumBundle.swift */,
 				C6A0F0FCE599D735A694D605 /* WalkthroughSettings.swift */,
 				7E530DFE8240A79EA6D77961 /* WorkspaceService.swift */,
@@ -1098,6 +1101,7 @@
 				6BA39956BEE5A9BB036F74E7 /* TabBarView.swift in Sources */,
 				07AE67F8DC12B0AAD737C3FD /* TabDrag.swift in Sources */,
 				D8FB17ACCD415EFD9623E48B /* TabResidency.swift in Sources */,
+				64B391AA816FE70BC4C51874 /* TestEnvironment.swift in Sources */,
 				1F177B6D7BEF6B4E7C7620CE /* Theme.swift in Sources */,
 				9E139713CC03274E03B94E92 /* ToolbarView.swift in Sources */,
 				A5E81D63CD3B19716028FF80 /* UITestLaunchConfiguration.swift in Sources */,

--- a/Vellum/App/UITestLaunchConfiguration.swift
+++ b/Vellum/App/UITestLaunchConfiguration.swift
@@ -55,7 +55,12 @@ enum UITestLaunchConfiguration {
         }
 
         if ProcessInfo.processInfo.arguments.contains("--ui-test-corrupt-restoration") {
-            defaults.set("{not valid workspace json", forKey: "vellum.workspace")
+            // Through `AppDefaults`, the same door `WorkspaceService.load` reads
+            // from. Seeding `.standard` directly would only be equivalent as
+            // long as this process resolves to `.standard`, and if that ever
+            // stopped holding the restoration test would not fail — it would
+            // find no workspace at all and still reach a usable Home screen.
+            AppDefaults.current.set("{not valid workspace json", forKey: "vellum.workspace")
         }
 
         if let root = storageRoot {

--- a/Vellum/Services/AppDefaults.swift
+++ b/Vellum/Services/AppDefaults.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// The `UserDefaults` domain the app-state services read and write — currently
+/// `RecentFilesService` (the recent-documents list) and `WorkspaceService` (the
+/// split-screen layout).
+///
+/// It exists to make two guarantees that a bare `UserDefaults.standard` and a
+/// process-global override variable could not (#102):
+///
+/// 1. **A test cannot reach the real user's state, even by accident.** The unit
+///    test bundle is *hosted* — it runs inside the app and therefore shares the
+///    app's defaults domain. Any test that happens to open a document (which
+///    records a recent) or drive a `WorkspaceStore` through a restore (which
+///    saves a layout) would otherwise rewrite the developer's own recents list
+///    and window layout. Under test the base domain is a private scratch suite,
+///    never `.standard`, so the protection does not depend on each test
+///    remembering to install a seam — the same fail-safe as `KeychainStore`'s
+///    in-memory store (#97). Before this, `WorkspaceService.save` had no seam at
+///    all and was kept out of real defaults only by the incidental
+///    `guard didRestore` in `WorkspaceStore.scheduleSave`.
+///
+/// 2. **Suites cannot clobber each other's redirect.** `override` is a
+///    task-local, so it unwinds with the test's own task and an unrelated suite
+///    finishing at the same moment cannot unhook it. The
+///    `RecentFilesService.defaultsOverride` global it replaces forced
+///    `.serialized` onto both of its users, and `.serialized` only orders tests
+///    *within* one suite — two such suites running concurrently still raced
+///    each other's install and teardown, silently sending one suite's recents
+///    writes into the other's domain or the real one.
+enum AppDefaults {
+    /// The domain to read and write. Never `.standard` under test.
+    static var current: UserDefaults { override?.defaults ?? base }
+
+    /// Run `operation` with app state redirected at `defaults`. Scoped, so
+    /// there is no teardown to forget and nothing another suite can reset out
+    /// from under this one. The binding follows the task tree, so work the
+    /// operation starts with `Task { }` inherits it too.
+    static func withDefaults<R>(
+        _ defaults: UserDefaults, operation: () async throws -> R
+    ) async rethrows -> R {
+        try await $override.withValue(Box(defaults: defaults), operation: operation)
+    }
+
+    /// Per-test redirect, scoped to the task that binds it. Always nil in
+    /// production; reached only through `withDefaults`.
+    @TaskLocal private static var override: Box?
+
+    /// `UserDefaults` is thread-safe, but its `Sendable` conformance is
+    /// explicitly unavailable, so carrying one across isolation needs a box
+    /// that vouches for it — the same reasoning as the `nonisolated(unsafe)`
+    /// markers on the directory seams elsewhere in the app.
+    private struct Box: @unchecked Sendable {
+        let defaults: UserDefaults
+    }
+
+    /// `.standard` in production; a private scratch suite under test.
+    nonisolated(unsafe) private static let base: UserDefaults = {
+        guard isHostedInTestBundle else { return .standard }
+        let name = "com.vellum.tests.defaults"
+        guard let scratch = UserDefaults(suiteName: name) else {
+            // Fail closed: silently falling back to `.standard` would hand the
+            // whole test suite the real user's recents and workspace, which is
+            // exactly what this type exists to prevent.
+            fatalError("could not open the scratch defaults suite '\(name)'")
+        }
+        // Start every test process from empty. A domain that accumulated state
+        // across runs would be its own source of order-dependent flakes.
+        scratch.removePersistentDomain(forName: name)
+        return scratch
+    }()
+
+    /// True inside a hosted XCTest bundle — the case that matters here, because
+    /// such a bundle runs within the app process and shares its defaults.
+    ///
+    /// Deliberately NARROWER than `KeychainStore`'s equivalent, which also
+    /// counts `--ui-testing` app launches. A UI-test launch runs under the
+    /// `UITesting` build configuration, so it already has its own bundle
+    /// identifier and therefore its own defaults domain, and its harness seeds
+    /// that domain on purpose (`UITestLaunchConfiguration.prepare` writes
+    /// `vellum.workspace` for the corrupt-restoration test). Redirecting it
+    /// here would hide those seeds from the app under test. The keychain has no
+    /// such per-configuration partition, which is why its guard is broader.
+    private static let isHostedInTestBundle: Bool = {
+        let env = ProcessInfo.processInfo.environment
+        return env["XCTestConfigurationFilePath"] != nil
+            || env["XCTestSessionIdentifier"] != nil
+            || env["XCTestBundlePath"] != nil
+            || NSClassFromString("XCTestCase") != nil
+    }()
+}

--- a/Vellum/Services/KeychainStore.swift
+++ b/Vellum/Services/KeychainStore.swift
@@ -21,14 +21,11 @@ enum KeychainStore {
     /// argument the harness always passes is the only signal available there,
     /// so it counts as "under test" too — otherwise every UI-test launch of an
     /// ad-hoc-signed build would re-prompt for the login keychain password.
-    private static let isRunningTests: Bool = {
-        if UITestLaunchConfiguration.isEnabled { return true }
-        let env = ProcessInfo.processInfo.environment
-        return env["XCTestConfigurationFilePath"] != nil
-            || env["XCTestSessionIdentifier"] != nil
-            || env["XCTestBundlePath"] != nil
-            || NSClassFromString("XCTestCase") != nil
-    }()
+    /// That extra term is the only difference from `AppDefaults`' guard, which
+    /// shares the hosted-process half of the detection so the two cannot drift.
+    private static var isRunningTests: Bool {
+        UITestLaunchConfiguration.isEnabled || TestEnvironment.isHostedTestProcess
+    }
 
     /// In-memory stand-in used instead of the keychain while under test, so
     /// set/get/delete still round-trip within a test process.

--- a/Vellum/Services/RecentFilesService.swift
+++ b/Vellum/Services/RecentFilesService.swift
@@ -7,14 +7,12 @@ enum RecentFilesService {
     static let storageKey = "vellum.recent-pdfs"
     static let maxRecent = 8
 
-    /// Test seam, mirroring `DocumentDataStore.rootDirectoryOverride` and
-    /// `WebLibrary.storeDirOverride`. Without it any test that exercises a
-    /// recents WRITE would edit the real app's recents list, because a hosted
-    /// test bundle shares the app's `UserDefaults` domain — so before this
-    /// existed the only testable parts of this service were the pure ones.
-    nonisolated(unsafe) static var defaultsOverride: UserDefaults?
-
-    private static var defaults: UserDefaults { defaultsOverride ?? .standard }
+    /// A hosted test bundle shares the app's `UserDefaults` domain, so a recents
+    /// WRITE from a test would edit the real app's recents list. `AppDefaults`
+    /// owns that problem for every app-state service: under test it resolves to
+    /// a scratch domain rather than `.standard`, and a suite can scope its own
+    /// domain without a process-global another suite could clobber (#102).
+    private static var defaults: UserDefaults { AppDefaults.current }
 
     static func getRecent() -> [RecentDocument] {
         guard let raw = defaults.string(forKey: storageKey),

--- a/Vellum/Services/Scratchpad/ScratchpadPersistence.swift
+++ b/Vellum/Services/Scratchpad/ScratchpadPersistence.swift
@@ -165,8 +165,13 @@ enum ScratchpadPersistence {
         writeEntries(entries)
     }
 
+    // The legacy blob goes through `AppDefaults` for the same reason the
+    // recents list and the workspace do: two suites seed and DELETE this key to
+    // drive migration coverage, and on `.standard` that is the real user's
+    // pre-folder notes — and a shared domain any other test process can wipe
+    // mid-test (#102).
     private static func readEntries() -> [Entry] {
-        guard let data = UserDefaults.standard.data(forKey: notesKey),
+        guard let data = AppDefaults.current.data(forKey: notesKey),
               let entries = try? JSONDecoder().decode([Entry].self, from: data)
         else { return [] }
         return entries
@@ -174,7 +179,7 @@ enum ScratchpadPersistence {
 
     private static func writeEntries(_ entries: [Entry]) {
         guard let data = try? JSONEncoder().encode(entries) else { return }
-        UserDefaults.standard.set(data, forKey: notesKey)
+        AppDefaults.current.set(data, forKey: notesKey)
     }
 }
 

--- a/Vellum/Services/TestEnvironment.swift
+++ b/Vellum/Services/TestEnvironment.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Whether this process is running tests.
+///
+/// One definition, shared by the guards that must fail closed under test
+/// (`KeychainStore`'s in-memory store, `AppDefaults`' scratch domain), so the
+/// detection cannot drift between them. They compose it differently on purpose
+/// — see each guard for why.
+enum TestEnvironment {
+    /// True inside a *hosted* test bundle: the bundle is injected into the app
+    /// process, so it shares the app's `UserDefaults` domain and its file
+    /// storage. Detected via the XCTest environment, which is set from process
+    /// start (before the bundle is injected), with the class lookup as a
+    /// fallback.
+    ///
+    /// False in the app process an XCUITest launches: that is a second process
+    /// boundary, started fresh by `XCUIApplication().launch()`, and it inherits
+    /// none of these markers.
+    static let isHostedTestProcess: Bool = {
+        let env = ProcessInfo.processInfo.environment
+        return env["XCTestConfigurationFilePath"] != nil
+            || env["XCTestSessionIdentifier"] != nil
+            || env["XCTestBundlePath"] != nil
+            || NSClassFromString("XCTestCase") != nil
+    }()
+}

--- a/Vellum/Services/WorkspaceService.swift
+++ b/Vellum/Services/WorkspaceService.swift
@@ -82,14 +82,22 @@ struct WorkspaceState: Codable, Equatable {
 enum WorkspaceService {
     private static let storageKey = "vellum.workspace"
 
+    /// Reads and writes go through `AppDefaults`, not `UserDefaults.standard`,
+    /// so a test cannot persist over the developer's own window layout. Nothing
+    /// used to stop it: `save` had no seam, and tests stayed out of real
+    /// defaults only because `WorkspaceStore.scheduleSave` happens to bail on
+    /// `guard didRestore` — incidental protection that any test calling
+    /// `restoreFromDisk()` or `saveNow()` would walk straight past (#102).
+    private static var defaults: UserDefaults { AppDefaults.current }
+
     static func save(_ state: WorkspaceState) {
         guard let data = try? JSONEncoder().encode(state),
               let json = String(data: data, encoding: .utf8) else { return }
-        UserDefaults.standard.set(json, forKey: storageKey)
+        defaults.set(json, forKey: storageKey)
     }
 
     static func load() -> WorkspaceState? {
-        guard let json = UserDefaults.standard.string(forKey: storageKey),
+        guard let json = defaults.string(forKey: storageKey),
               let data = json.data(using: .utf8),
               let state = try? JSONDecoder().decode(WorkspaceState.self, from: data) else {
             return nil
@@ -98,6 +106,6 @@ enum WorkspaceService {
     }
 
     static func clear() {
-        UserDefaults.standard.removeObject(forKey: storageKey)
+        defaults.removeObject(forKey: storageKey)
     }
 }


### PR DESCRIPTION
Closes #102

## Root cause

Two separate holes, one shared consequence — a test could write the developer's real `UserDefaults`.

1. **`RecentFilesService.defaultsOverride` was a process-global.** Its two users each installed it in an `init` and cleared it in a `deinit`, and both had to be `.serialized` because of it. But `.serialized` only orders tests *within* one suite: `InspectorPresentationTests` and `Rename: persistence` can still run concurrently, so either one's `deinit` (`defaultsOverride = nil`) could unhook the other mid-test and send its recents writes to the real list.
2. **`WorkspaceService.save` had no seam at all.** Tests stayed out of real defaults only because `WorkspaceStore.scheduleSave` bails on `guard didRestore` — incidental protection that any test calling `restoreFromDisk()` or `saveNow()` walks straight past.

**This is not theoretical.** The real `com.vellum.app` domain on this machine currently holds `/tmp/safe-clear-*.pdf` and `/tmp/safe-note-*.pdf` entries in `vellum.recent-pdfs`, written by `SafeClearTests` — an XCTest class that has no seam and never had one. The reviewer confirmed the same by reading the scratch domain this branch creates: those writes now land there instead.

## Fix

New `AppDefaults`, used by both services (and a third key, below). Two layers:

**A fail-closed floor.** Under a hosted XCTest bundle the base domain is a private scratch suite, **never `.standard`**. The hosted bundle is injected into the app process and shares its domain — that is the actual hazard — so protection can't depend on each test remembering to install a seam. Same principle as the `KeychainStore` guard (#97). The suite name is per-process, because running several `xcodebuild test` invocations at once is routine with worktrees.

**A scoped override.** The per-test redirect is a `@TaskLocal` (boxed — `UserDefaults`' `Sendable` conformance is unavailable) reached only through `AppDefaults.withDefaults`. It unwinds with the test's own task, so no concurrent suite can unhook it and there is no teardown to forget. The `.scratchDefaults` Swift Testing trait replaces both hand-rolled scratch classes.

### Why not full constructor injection

The issue allows either an injected dependency or "a structured seam... pick the smallest change that makes suites independent, and justify." Both services are caseless `enum` namespaces with static funcs and ~12 production call sites (`AppStore`, `HomeSearchStore`, `WelcomeScreen`, `DocumentRenameService`, `StorageSettingsTab`, `HomeSearchProvider`, `WorkspaceStore`). Threading an instance through all of them is a large behavioural-risk diff for a test-isolation fix, and the issue also requires production call sites to be zero-diff in behaviour. Only the private `defaults` accessor in each service changed. The task-local buys the independence that a "set once per test with teardown restore" global would not.

### Also fixed: the legacy note blob

`ScratchpadPersistence.notesKey` was the third key reaching real state, and the one with observed damage. `DocumentDataStoreTests` and `StorageManagementTests` both **seed and delete** it to drive migration coverage — on `.standard`, that is the user's own pre-folder notes, in a domain any concurrent test process can wipe mid-test. This explains intermittent failures reported in exactly those two suites (`testLazyMigrationCopiesSharedAttachmentForSecondNote`, `testAiLegacyListAndRemove`); see the analysis appended to #111.

## Reviewer findings (fresh-context opus, adversarial)

It confirmed the design and empirically verified the floor works, then found 7 real defects. All addressed:

1. **The guard tests wrote first and checked afterwards.** A floor regression would have been reported only *after* rewriting the developer's recents, and the `defer { WorkspaceService.clear() }` would have **deleted their window layout**. They now refuse to run unless the floor is in place — see verification below.
2. **Fixed scratch-suite name + wipe at first access** let two concurrent test processes clear each other's domain. Now per-process.
3. **The recents assertion depended on surviving an 8-slot capped list** shared with unseamed suites (7 of 8 slots were occupied at review time). It now asserts on the domain the write went to.
4. **Leaked preference plists** — `removePersistentDomain` empties a domain but doesn't unlink its file; 1203 orphans had accumulated. Scratch suites now unlink, and I removed the existing orphans.
5. **`DocumentRenameService.apply` sits behind `Task.detached`** in both store APIs, where task-locals don't propagate. The floor still catches it (degraded isolation, never real defaults); documented on `withDefaults`.
6. **The UI-test asymmetry was unverified and would fail *vacuously***: `prepare()` seeded `.standard` while `load()` read elsewhere, and the restoration UI test passes on an absent workspace too. `prepare()` now seeds through the same door `load()` reads from, removing the assumption rather than testing it.
7. **Debounced saves can outlive the trait's teardown** — latent (no unit test sets `didRestore`); documented.

Plus nits: shared `TestEnvironment.isHostedTestProcess` instead of copy-pasting the predicate into `KeychainStore`; `withDefaults` forwards `isolation:`; corrected two `.serialized` comments that overstated what serialization buys.

## Verification

Clean build, warnings-as-errors on, zero new warnings. `xcodegen generate` run for the three new files.

- **Full suite green: 471 XCTest + 152 Swift Testing** (147 baseline + 5 new guard tests), twice consecutively, plus an earlier green run before the review fixes.
- **Mutation — override ignored** (`current` returns `base`): only the scoping test failed, exactly as predicted.
- **Mutation — floor forced off**: all four floor tests fail **and none of them writes anything** ("refusing to write: the guard under test is not in place"). Confirmed afterwards that `com.vellum.app` contained zero `guard-*` entries and still held `vellum.workspace` — i.e. the safety fix in finding 1 is what made this mutation runnable at all. This was the mutation I had deliberately skipped in the first round as too dangerous to execute.

## Follow-up worth filing

The same bug class remains in the *storage* seams: `DocumentDataStore.rootDirectoryOverride` is a process-global set by nine suites, with `.serialized` again only ordering within each. This branch fixes the defaults half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)