### PR TITLE
Preserve the web note composer's draft on stray dismissal

### DIFF
--- a/Tests/AiAddAsNoteTests.swift
+++ b/Tests/AiAddAsNoteTests.swift
@@ -171,9 +171,10 @@ final class WebNoteComposerDismissalTests: XCTestCase {
 /// hand the draft back and which discard it.
 ///
 /// `WebViewerController.bindForTesting` and friends are the seam — the real
-/// `attach` ends in a `WKWebView` page load, and none of the dismissal paths
-/// touch the web view (every `post` is gated on the content script having
-/// reported in, which it never does here).
+/// `attach` ends in a `WKWebView` page load. `post` would materialise that web
+/// view (only the `push*` helpers are gated on the content script reporting
+/// in), but the dismissal branches reach it solely via `clearSelection()`,
+/// which they only call when a selection exists, and nothing here makes one.
 @MainActor
 final class WebNoteComposerControllerTests: XCTestCase {
     private func makePaneWithTab() -> AppStore {
@@ -208,18 +209,6 @@ final class WebNoteComposerControllerTests: XCTestCase {
         XCTAssertNil(controller.noteComposer)
         XCTAssertEqual(app.pendingNoteContent, "The answer.")
         XCTAssertEqual(app.mode, .note, "one more click re-offers the note")
-    }
-
-    /// Switching tabs goes through `deactivate`, which must not be a discard
-    /// either — the draft waits on the tab the user is coming back to.
-    func testDeactivatingTheTabHandsTheReplyBack() {
-        let app = makePaneWithTab()
-        let controller = composerHolding("The answer.", on: app)
-
-        controller.deactivate()
-
-        XCTAssertNil(controller.noteComposer)
-        XCTAssertEqual(app.pendingNoteContent, "The answer.")
     }
 
     /// Cancel, Escape, and a completed submit all route through
@@ -312,7 +301,10 @@ final class WebNoteComposerControllerTests: XCTestCase {
 
         XCTAssertEqual(app.pendingNoteContent, "Reply for the tab now on screen")
         XCTAssertEqual(app.mode, .note, "the foreground tab stays armed")
-        XCTAssertEqual(controller.noteComposer?.initialContent, "")
+        XCTAssertNil(
+            controller.noteComposer,
+            "no composer at all: annotationStore is pane-scoped, so a background mount now "
+                + "points at another document and a submit would file the note against it")
     }
 
     /// The controller belongs to one tab. A teardown it reports after the user
@@ -329,5 +321,153 @@ final class WebNoteComposerControllerTests: XCTestCase {
         XCTAssertEqual(app.mode, .view, "the foreground tab must not be dragged into note mode")
         XCTAssertNil(app.pendingNoteContent)
         XCTAssertEqual(app.tabs.first(where: { $0.id == origin })?.pendingNoteContent, "The answer.")
+    }
+}
+
+/// The five incidental dismissals are all bridge-message branches, driven here
+/// exactly as the content script drives them — including the literal repro in
+/// issue #92's title, a stray click on the page, which arrives as
+/// `"selection-cleared"`. Without these, reverting any one branch to
+/// `noteComposer = nil` leaves the suite green.
+@MainActor
+final class WebNoteComposerBridgeDismissalTests: XCTestCase {
+    private func makePaneWithTab() -> AppStore {
+        let app = WorkspaceStore(sessions: DocumentSessionManager()).focusedPane.app
+        app.newStartTab()
+        return app
+    }
+
+    /// Post-placement state, with the composer aged past the `clickOutside`
+    /// grace period so the next page event counts as a real dismissal.
+    private func agedComposer(
+        holding content: String, on app: AppStore, annotations: AnnotationStore? = nil
+    ) -> WebViewerController {
+        app.beginNoteWithContent(content)
+        _ = app.consumePendingNoteContent()
+        app.finishNotePlacement(forSessionId: app.activeTabId!)
+        let controller = WebViewerController()
+        controller.bindForTesting(
+            app: app, tabId: app.activeTabId!, annotationStore: annotations)
+        controller.openNoteComposerForTesting(
+            content: content, openedAt: Date().addingTimeInterval(-1))
+        return controller
+    }
+
+    func testAStrayClickOnThePageHandsTheReplyBack() {
+        let app = makePaneWithTab()
+        let controller = agedComposer(holding: "The answer.", on: app)
+
+        controller.handleBridgeMessageForTesting("selection-cleared")
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+        XCTAssertEqual(app.mode, .note)
+    }
+
+    /// The grace period is load-bearing in the other direction: the placement
+    /// click's own event arrives milliseconds after the composer opens, so too
+    /// short a window would make every placement instantly self-dismiss.
+    func testThePlacementClicksOwnEventDoesNotDismissTheComposer() {
+        let app = makePaneWithTab()
+        app.beginNoteWithContent("The answer.")
+        _ = app.consumePendingNoteContent()
+        app.finishNotePlacement(forSessionId: app.activeTabId!)
+        let controller = WebViewerController()
+        controller.bindForTesting(app: app, tabId: app.activeTabId!)
+        controller.openNoteComposerForTesting(content: "The answer.")
+
+        controller.handleBridgeMessageForTesting("selection-cleared")
+
+        XCTAssertNotNil(controller.noteComposer, "a composer this young is not dismissed")
+        XCTAssertNil(app.pendingNoteContent, "and nothing is re-queued behind it")
+    }
+
+    func testScrollingThePageHandsTheReplyBack() {
+        let app = makePaneWithTab()
+        let controller = agedComposer(holding: "The answer.", on: app)
+
+        controller.handleBridgeMessageForTesting("viewport-scrolled")
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+    }
+
+    func testAFreshComposerSurvivesTheScrollThePlacementClickCauses() {
+        let app = makePaneWithTab()
+        app.beginNoteWithContent("The answer.")
+        _ = app.consumePendingNoteContent()
+        app.finishNotePlacement(forSessionId: app.activeTabId!)
+        let controller = WebViewerController()
+        controller.bindForTesting(app: app, tabId: app.activeTabId!)
+        controller.openNoteComposerForTesting(content: "The answer.")
+
+        controller.handleBridgeMessageForTesting("viewport-scrolled")
+
+        XCTAssertNotNil(controller.noteComposer)
+        XCTAssertNil(app.pendingNoteContent)
+    }
+
+    func testRightClickingThePageHandsTheReplyBack() {
+        let app = makePaneWithTab()
+        let controller = agedComposer(holding: "The answer.", on: app)
+
+        controller.handleBridgeMessageForTesting("context-menu", ["found": false])
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+        // The branch installs a real NSEvent monitor; take it back down.
+        controller.hideContextMenu()
+    }
+
+    func testClickingAnExistingNoteHandsTheReplyBack() async {
+        let app = makePaneWithTab()
+        let annotations = AnnotationStore(app: app)
+        let note = await annotations.addNote(
+            CreateAnnotationInput(
+                type: .note, pageNumber: 1, color: nil, content: "existing",
+                positionData: nil))
+        let controller = agedComposer(holding: "The answer.", on: app, annotations: annotations)
+
+        controller.handleBridgeMessageForTesting("annotation-click", ["id": note?.id ?? ""])
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+    }
+
+    func testClickingAnExistingHighlightHandsTheReplyBack() async {
+        let app = makePaneWithTab()
+        let annotations = AnnotationStore(app: app)
+        let highlight = await annotations.addHighlight(
+            CreateAnnotationInput(
+                type: .highlight, pageNumber: 1, color: nil, content: nil,
+                positionData: nil))
+        let controller = agedComposer(holding: "The answer.", on: app, annotations: annotations)
+
+        controller.handleBridgeMessageForTesting("annotation-click", ["id": highlight?.id ?? ""])
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+    }
+
+    /// A second "Add as note" while a composer is still open. The panel's
+    /// button is not gated on one, so the placement click that follows used to
+    /// overwrite the first reply with the second and lose it outright.
+    func testASecondPlacementRescuesTheComposerItReplaces() {
+        let app = makePaneWithTab()
+        let controller = agedComposer(holding: "First reply.", on: app)
+
+        // The user picks "Add as note" on a second reply, then clicks the page.
+        app.beginNoteWithContent("Second reply.")
+        controller.handleBridgeMessageForTesting(
+            "note-placed",
+            ["start": 0, "end": 4, "text": "word", "pageNumber": 1, "x": 0, "y": 0])
+
+        XCTAssertEqual(
+            controller.noteComposer?.initialContent, "Second reply.",
+            "the composer shows the reply that was just placed")
+        XCTAssertEqual(
+            app.pendingNoteContent, "First reply.",
+            "and the one it displaced goes back on the queue rather than vanishing")
+        XCTAssertEqual(app.mode, .note)
     }
 }

--- a/Tests/AiAddAsNoteTests.swift
+++ b/Tests/AiAddAsNoteTests.swift
@@ -61,3 +61,131 @@ final class AiAddAsNoteTests: XCTestCase {
         XCTAssertEqual(state.initialContent, "")
     }
 }
+
+/// Issue #92: on the web path the placement click only *opens* a composer, so
+/// between the click and the submit the composer holds the sole copy of the
+/// queued reply — `consumePendingNoteContent` has already emptied the store. A
+/// stray click on the page unmounted that composer and the reply went with it.
+/// `restorePendingNote` is the recovery seam the viewer calls for every
+/// dismissal the user did not explicitly ask for.
+@MainActor
+final class WebNoteComposerDismissalTests: XCTestCase {
+    /// A pane with one real tab — `restorePendingNote` is tab-scoped, so the
+    /// bare `AppStore` used above (no tabs) is not enough here.
+    private func makePaneWithTab() -> AppStore {
+        let app = WorkspaceStore(sessions: DocumentSessionManager()).focusedPane.app
+        app.newStartTab()
+        return app
+    }
+
+    /// Walks the real placement sequence: arm, click (consume + leave note
+    /// mode), then a stray click dismisses the composer.
+    private func placeNote(_ app: AppStore, content: String) -> String? {
+        app.beginNoteWithContent(content)
+        let consumed = app.consumePendingNoteContent()
+        app.finishNotePlacement(forSessionId: app.activeTabId!)
+        return consumed
+    }
+
+    func testStrayDismissalReturnsTheReplyAndTheNextPlacementUsesIt() {
+        let app = makePaneWithTab()
+        let session = app.activeTabId!
+        XCTAssertEqual(placeNote(app, content: "The answer."), "The answer.")
+        // Post-placement, pre-dismissal: the store is empty, which is why the
+        // old code lost the reply outright.
+        XCTAssertNil(app.pendingNoteContent)
+
+        app.restorePendingNote("The answer.", forSessionId: session)
+
+        XCTAssertEqual(app.mode, .note, "placement re-arms, so one more click re-offers the note")
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+        XCTAssertEqual(
+            app.consumePendingNoteContent(), "The answer.",
+            "the next placement click gets the reply back")
+    }
+
+    /// Cancel (or Escape, or a completed submit) never routes through
+    /// `restorePendingNote` — a discard the user asked for stays a discard.
+    func testExplicitCancelLeavesNothingQueued() {
+        let app = makePaneWithTab()
+        _ = placeNote(app, content: "The answer.")
+
+        XCTAssertEqual(app.mode, .view)
+        XCTAssertNil(app.pendingNoteContent)
+        XCTAssertNil(app.tabs.first(where: { $0.id == app.activeTabId })?.pendingNoteContent)
+    }
+
+    /// The draft handed back is the composer's live text, so edits made before
+    /// the misclick survive too — not just the reply it opened with.
+    func testEditsMadeInTheComposerSurviveTheDismissal() {
+        let app = makePaneWithTab()
+        let session = app.activeTabId!
+        _ = placeNote(app, content: "The answer.")
+
+        app.restorePendingNote("The answer. — check this", forSessionId: session)
+
+        XCTAssertEqual(app.pendingNoteContent, "The answer. — check this")
+    }
+
+    /// A plain note-tool placement clicked away from has nothing to preserve;
+    /// re-arming note mode there would be friction with no payoff.
+    func testEmptyDraftDoesNotReArmNoteMode() {
+        let app = makePaneWithTab()
+        let session = app.activeTabId!
+        app.setMode(.note)
+        XCTAssertNil(app.consumePendingNoteContent())
+        app.finishNotePlacement(forSessionId: session)
+
+        app.restorePendingNote("   \n ", forSessionId: session)
+
+        XCTAssertEqual(app.mode, .view)
+        XCTAssertNil(app.pendingNoteContent)
+    }
+
+    /// The draft belongs to the tab that was composing it. Switching tabs also
+    /// unmounts the composer, so the restore must land on the origin tab and
+    /// leave the tab now on screen completely alone.
+    func testDraftIsRestoredOntoItsOwnTabNotTheOneOnScreen() {
+        let app = makePaneWithTab()
+        let origin = app.activeTabId!
+        _ = placeNote(app, content: "The answer.")
+        app.newStartTab()
+        let other = app.activeTabId!
+
+        app.restorePendingNote("The answer.", forSessionId: origin)
+
+        XCTAssertEqual(app.activeTabId, other)
+        XCTAssertEqual(app.mode, .view, "the foreground tab must not be dragged into note mode")
+        XCTAssertNil(app.pendingNoteContent)
+
+        app.activateTab(origin)
+        XCTAssertEqual(app.mode, .note)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+    }
+
+    /// A dismissal reported after its tab is gone has nowhere to land.
+    func testRestoringForAnUnknownTabIsIgnored() {
+        let app = makePaneWithTab()
+        _ = placeNote(app, content: "The answer.")
+
+        app.restorePendingNote("The answer.", forSessionId: "closed-tab")
+
+        XCTAssertEqual(app.mode, .view)
+        XCTAssertNil(app.pendingNoteContent)
+    }
+
+    /// Restoring must not strand the tab in a half-armed state: note mode and
+    /// region capture are mutually exclusive everywhere else in `AppStore`.
+    func testRestoringClearsAnyArmedRegionCapture() {
+        let app = makePaneWithTab()
+        let session = app.activeTabId!
+        _ = placeNote(app, content: "The answer.")
+        app.beginRegionCapture(target: .scratchpad)
+
+        app.restorePendingNote("The answer.", forSessionId: session)
+
+        XCTAssertEqual(app.mode, .note)
+        XCTAssertEqual(app.regionCaptureTarget, .ai)
+        XCTAssertNil(app.tabs.first(where: { $0.id == session })?.regionCaptureTarget)
+    }
+}

--- a/Tests/AiAddAsNoteTests.swift
+++ b/Tests/AiAddAsNoteTests.swift
@@ -104,29 +104,6 @@ final class WebNoteComposerDismissalTests: XCTestCase {
             "the next placement click gets the reply back")
     }
 
-    /// Cancel (or Escape, or a completed submit) never routes through
-    /// `restorePendingNote` — a discard the user asked for stays a discard.
-    func testExplicitCancelLeavesNothingQueued() {
-        let app = makePaneWithTab()
-        _ = placeNote(app, content: "The answer.")
-
-        XCTAssertEqual(app.mode, .view)
-        XCTAssertNil(app.pendingNoteContent)
-        XCTAssertNil(app.tabs.first(where: { $0.id == app.activeTabId })?.pendingNoteContent)
-    }
-
-    /// The draft handed back is the composer's live text, so edits made before
-    /// the misclick survive too — not just the reply it opened with.
-    func testEditsMadeInTheComposerSurviveTheDismissal() {
-        let app = makePaneWithTab()
-        let session = app.activeTabId!
-        _ = placeNote(app, content: "The answer.")
-
-        app.restorePendingNote("The answer. — check this", forSessionId: session)
-
-        XCTAssertEqual(app.pendingNoteContent, "The answer. — check this")
-    }
-
     /// A plain note-tool placement clicked away from has nothing to preserve;
     /// re-arming note mode there would be friction with no payoff.
     func testEmptyDraftDoesNotReArmNoteMode() {
@@ -187,5 +164,170 @@ final class WebNoteComposerDismissalTests: XCTestCase {
         XCTAssertEqual(app.mode, .note)
         XCTAssertEqual(app.regionCaptureTarget, .ai)
         XCTAssertNil(app.tabs.first(where: { $0.id == session })?.regionCaptureTarget)
+    }
+}
+
+/// The half of issue #92 that lives in the viewer: which composer dismissals
+/// hand the draft back and which discard it.
+///
+/// `WebViewerController.bindForTesting` and friends are the seam — the real
+/// `attach` ends in a `WKWebView` page load, and none of the dismissal paths
+/// touch the web view (every `post` is gated on the content script having
+/// reported in, which it never does here).
+@MainActor
+final class WebNoteComposerControllerTests: XCTestCase {
+    private func makePaneWithTab() -> AppStore {
+        let app = WorkspaceStore(sessions: DocumentSessionManager()).focusedPane.app
+        app.newStartTab()
+        return app
+    }
+
+    /// Leaves the store in the exact post-placement-click state the bug lived
+    /// in: note mode finished, the queue emptied by the placement, and the only
+    /// copy of the reply now inside the composer.
+    private func composerHolding(_ content: String, on app: AppStore) -> WebViewerController {
+        app.beginNoteWithContent(content)
+        _ = app.consumePendingNoteContent()
+        app.finishNotePlacement(forSessionId: app.activeTabId!)
+        XCTAssertNil(app.pendingNoteContent, "precondition: the composer holds the only copy")
+
+        let controller = WebViewerController()
+        controller.bindForTesting(app: app, tabId: app.activeTabId!)
+        controller.openNoteComposerForTesting(content: content)
+        return controller
+    }
+
+    /// A stray click on a link, an SPA soft-navigation, or a tab switch all
+    /// land here. This is the path the first cut of the fix missed.
+    func testIncidentalTeardownHandsTheReplyBack() {
+        let app = makePaneWithTab()
+        let controller = composerHolding("The answer.", on: app)
+
+        controller.closeNotePopovers()
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+        XCTAssertEqual(app.mode, .note, "one more click re-offers the note")
+    }
+
+    /// Switching tabs goes through `deactivate`, which must not be a discard
+    /// either — the draft waits on the tab the user is coming back to.
+    func testDeactivatingTheTabHandsTheReplyBack() {
+        let app = makePaneWithTab()
+        let controller = composerHolding("The answer.", on: app)
+
+        controller.deactivate()
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertEqual(app.pendingNoteContent, "The answer.")
+    }
+
+    /// Cancel, Escape, and a completed submit all route through
+    /// `closeNoteComposer`. Wiring that one to the restore path would make the
+    /// note queue impossible to empty, so this is the guard on the guard.
+    func testExplicitCloseDiscardsTheDraft() {
+        let app = makePaneWithTab()
+        let controller = composerHolding("The answer.", on: app)
+
+        controller.closeNoteComposer()
+
+        XCTAssertNil(controller.noteComposer)
+        XCTAssertNil(app.pendingNoteContent, "a discard the user asked for stays a discard")
+        XCTAssertEqual(app.mode, .view)
+    }
+
+    /// What comes back is the composer's live text, not the reply it opened
+    /// with — edits made before the misclick survive too.
+    func testEditsMadeInTheComposerAreWhatComesBack() {
+        let app = makePaneWithTab()
+        let controller = composerHolding("The answer.", on: app)
+
+        controller.updateNoteComposerDraft("The answer. — check this")
+        controller.closeNotePopovers()
+
+        XCTAssertEqual(app.pendingNoteContent, "The answer. — check this")
+    }
+
+    /// A plain note-tool placement holds nothing worth preserving, so clicking
+    /// away from it is unchanged — no queue, no re-armed note mode.
+    func testDismissingAnEmptyComposerArmsNothing() {
+        let app = makePaneWithTab()
+        let controller = WebViewerController()
+        controller.bindForTesting(app: app, tabId: app.activeTabId!)
+        controller.openNoteComposerForTesting(content: "")
+
+        controller.closeNotePopovers()
+
+        XCTAssertNil(app.pendingNoteContent)
+        XCTAssertEqual(app.mode, .view)
+    }
+
+    /// The draft mirror is reseeded per placement. Without that, a second
+    /// composer would inherit the first one's text and dismissing it would
+    /// re-queue a reply the user already dealt with.
+    func testTheDraftMirrorDoesNotLeakBetweenPlacements() {
+        let app = makePaneWithTab()
+        let controller = composerHolding("The answer.", on: app)
+        controller.updateNoteComposerDraft("edited")
+
+        // A second placement on the same controller, this time a plain one.
+        controller.openNoteComposerForTesting(content: "")
+        controller.closeNotePopovers()
+
+        XCTAssertNil(app.pendingNoteContent)
+        XCTAssertEqual(app.mode, .view)
+    }
+
+    /// "Add note here" is the other door into a composer, and it now takes the
+    /// queued reply with it — matching `PdfSelectionBridge.addNoteFromContextMenu`.
+    /// Leaving it empty while a reply sat armed was the stranding case.
+    func testContextMenuAddNoteCarriesTheQueuedReply() {
+        let app = makePaneWithTab()
+        let controller = WebViewerController()
+        controller.bindForTesting(app: app, tabId: app.activeTabId!)
+        controller.openContextMenuForTesting()
+        app.beginNoteWithContent("The answer.")
+
+        controller.contextMenuAddNote()
+
+        XCTAssertEqual(controller.noteComposer?.initialContent, "The answer.")
+        XCTAssertNil(app.pendingNoteContent, "consumed, not duplicated")
+        XCTAssertEqual(app.mode, .view, "placing a note leaves note mode, as on the PDF path")
+    }
+
+    /// `consumePendingNoteContent` reads the ACTIVE tab's queue, so a menu still
+    /// mounted on a tab the user has left would otherwise steal the reply armed
+    /// for the tab now on screen. The bridge-message path guards this; this one
+    /// is a button action and has to guard it itself.
+    func testContextMenuAddNoteOnABackgroundTabCannotStealTheForegroundReply() {
+        let app = makePaneWithTab()
+        let controller = WebViewerController()
+        controller.bindForTesting(app: app, tabId: app.activeTabId!)
+        controller.openContextMenuForTesting()
+
+        app.newStartTab()
+        app.beginNoteWithContent("Reply for the tab now on screen")
+
+        controller.contextMenuAddNote()
+
+        XCTAssertEqual(app.pendingNoteContent, "Reply for the tab now on screen")
+        XCTAssertEqual(app.mode, .note, "the foreground tab stays armed")
+        XCTAssertEqual(controller.noteComposer?.initialContent, "")
+    }
+
+    /// The controller belongs to one tab. A teardown it reports after the user
+    /// has moved on must land on its own tab's record and leave the tab now on
+    /// screen alone.
+    func testTeardownOnABackgroundTabDoesNotArmTheForegroundOne() {
+        let app = makePaneWithTab()
+        let origin = app.activeTabId!
+        let controller = composerHolding("The answer.", on: app)
+        app.newStartTab()
+
+        controller.closeNotePopovers()
+
+        XCTAssertEqual(app.mode, .view, "the foreground tab must not be dragged into note mode")
+        XCTAssertNil(app.pendingNoteContent)
+        XCTAssertEqual(app.tabs.first(where: { $0.id == origin })?.pendingNoteContent, "The answer.")
     }
 }

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -890,8 +890,9 @@ final class AppStore {
     /// Issue #92: the web viewer's placement click only opens a composer — the
     /// note is not written until the user submits — so between those two steps
     /// the composer holds the *only* copy of a queued AI reply
-    /// (`consumePendingNoteContent` already cleared the store). A stray click
-    /// or a page scroll unmounts that composer, and the reply went with it. The
+    /// (`consumePendingNoteContent` already cleared the store). A stray click,
+    /// a page scroll, a misclicked link, or a tab switch all unmount that
+    /// composer, and the reply used to go with it. The
     /// PDF viewer has no such window: `PdfSelectionBridge` writes the note on
     /// the placement click itself. Handing the draft back here closes the gap —
     /// a misclick now costs one more click instead of the whole reply.

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -884,6 +884,42 @@ final class AppStore {
         return target
     }
 
+    /// Put an unplaced note draft back on the queue and re-arm placement, so
+    /// the next click on the page offers the same text again.
+    ///
+    /// Issue #92: the web viewer's placement click only opens a composer — the
+    /// note is not written until the user submits — so between those two steps
+    /// the composer holds the *only* copy of a queued AI reply
+    /// (`consumePendingNoteContent` already cleared the store). A stray click
+    /// or a page scroll unmounts that composer, and the reply went with it. The
+    /// PDF viewer has no such window: `PdfSelectionBridge` writes the note on
+    /// the placement click itself. Handing the draft back here closes the gap —
+    /// a misclick now costs one more click instead of the whole reply.
+    ///
+    /// Scoped to the originating tab rather than the active one: the dismissal
+    /// may be the *reason* the tab is going away (switching tabs unmounts the
+    /// composer), and note-placement state travels with the tab anyway, so the
+    /// draft is waiting when the user comes back. A late message from a tab
+    /// that has since been closed lands nowhere.
+    ///
+    /// Empty (or whitespace-only) drafts are dropped — a plain note-tool
+    /// placement the user clicked away from has nothing worth preserving, and
+    /// re-arming note mode for it would be friction with no payoff.
+    func restorePendingNote(_ content: String, forSessionId sessionId: String) {
+        guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        updateTab(sessionId) {
+            $0.mode = .note
+            $0.pendingNoteContent = content
+            $0.regionCaptureTarget = nil
+        }
+        // Mirror onto the pane's own state only while this tab is the one on
+        // screen; otherwise `applyActiveState` picks it up on the way back in.
+        guard activeTabId == sessionId else { return }
+        mode = .note
+        pendingNoteContent = content
+        regionCaptureTarget = .ai
+    }
+
     /// Consumed by the viewer when it places a note; nil once used.
     func consumePendingNoteContent() -> String? {
         let content = pendingNoteContent

--- a/Vellum/Stores/AppStore.swift
+++ b/Vellum/Stores/AppStore.swift
@@ -907,17 +907,17 @@ final class AppStore {
     /// re-arming note mode for it would be friction with no payoff.
     func restorePendingNote(_ content: String, forSessionId sessionId: String) {
         guard !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        // While the tab is the one on screen this is exactly "arm placement
+        // again", so it goes through the same door rather than restating it —
+        // anything `setMode(.note)` grows later applies to restores too.
+        guard activeTabId != sessionId else { return beginNoteWithContent(content) }
+        // Otherwise write the tab record only; `applyActiveState` picks the
+        // state up on the way back in.
         updateTab(sessionId) {
             $0.mode = .note
             $0.pendingNoteContent = content
             $0.regionCaptureTarget = nil
         }
-        // Mirror onto the pane's own state only while this tab is the one on
-        // screen; otherwise `applyActiveState` picks it up on the way back in.
-        guard activeTabId == sessionId else { return }
-        mode = .note
-        pendingNoteContent = content
-        regionCaptureTarget = .ai
     }
 
     /// Consumed by the viewer when it places a note; nil once used.

--- a/Vellum/Views/Web/WebNotePopovers.swift
+++ b/Vellum/Views/Web/WebNotePopovers.swift
@@ -220,7 +220,15 @@ struct WebNoteComposerView: View {
                         .font(.system(size: 12, weight: .medium))
                         .foregroundStyle(palette.mutedForeground)
                 }
-                NoteTextEditor(text: $text, onSubmit: submit, onClose: onClose)
+                // Written through on set rather than observed with
+                // `.onChange`: that fires during a later update pass, so a
+                // dismissal landing in the same pass could hand back a mirror
+                // one keystroke stale. The write costs nothing — it lands on an
+                // observation-ignored field and invalidates no view.
+                NoteTextEditor(
+                    text: Binding(get: { text }, set: { text = $0; onDraftChange($0) }),
+                    onSubmit: submit,
+                    onClose: onClose)
                 HStack(spacing: 6) {
                     Spacer()
                     SmallGhostButton(title: "Cancel", action: onClose)
@@ -233,7 +241,6 @@ struct WebNoteComposerView: View {
             .padding(8)
             .frame(width: 288)
         }
-        .onChange(of: text) { _, newValue in onDraftChange(newValue) }
     }
 
     private func submit() {

--- a/Vellum/Views/Web/WebNotePopovers.swift
+++ b/Vellum/Views/Web/WebNotePopovers.swift
@@ -188,14 +188,24 @@ struct WebNoteComposerView: View {
     var initialContent: String = ""
     var onSubmit: (String) -> Void
     var onClose: () -> Void
+    /// Reports edits upward so an unasked-for dismissal (stray click, scroll)
+    /// can hand the draft back to the note queue instead of dropping it — see
+    /// `WebViewerController.returnNoteComposerDraft` and issue #92.
+    var onDraftChange: (String) -> Void = { _ in }
 
     @State private var text: String
     @Environment(\.palette) private var palette
 
-    init(initialContent: String = "", onSubmit: @escaping (String) -> Void, onClose: @escaping () -> Void) {
+    init(
+        initialContent: String = "",
+        onSubmit: @escaping (String) -> Void,
+        onClose: @escaping () -> Void,
+        onDraftChange: @escaping (String) -> Void = { _ in }
+    ) {
         self.initialContent = initialContent
         self.onSubmit = onSubmit
         self.onClose = onClose
+        self.onDraftChange = onDraftChange
         _text = State(initialValue: initialContent)
     }
 
@@ -223,6 +233,7 @@ struct WebNoteComposerView: View {
             .padding(8)
             .frame(width: 288)
         }
+        .onChange(of: text) { _, newValue in onDraftChange(newValue) }
     }
 
     private func submit() {

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -519,10 +519,6 @@ final class WebViewerController: NSObject {
     /// view, history, scroll position, and extracted text intact.
     func deactivate() {
         clearSelection()
-        // Switching tabs unmounts the composer without the user ever saying
-        // "discard", so its draft goes back on this tab's note queue and is
-        // waiting when they return (issue #92).
-        returnNoteComposerDraft()
         closeNotePopovers()
         removeEventMonitor()
     }
@@ -763,23 +759,33 @@ final class WebViewerController: NSObject {
     }
 
     func contextMenuAddNote() {
-        guard let menu = contextMenu else { return }
+        guard let menu = contextMenu, let anchor = menu.anchor else { return }
         hideContextMenu()
-        if let anchor = menu.anchor {
-            // Same payload hand-off as the note-mode placement click, and as
-            // `PdfSelectionBridge.addNoteFromContextMenu`: a queued AI reply
-            // pre-fills this composer rather than being left stranded.
-            noteComposer = WebNoteComposerState(
-                point: menu.point, anchor: anchor, openedAt: Date(),
-                initialContent: app?.consumePendingNoteContent() ?? "")
-            if let sessionId = mountTabId { app?.finishNotePlacement(forSessionId: sessionId) }
+        // Same payload hand-off as the note-mode placement click, and as
+        // `PdfSelectionBridge.addNoteFromContextMenu`: a queued AI reply
+        // pre-fills this composer rather than being left stranded.
+        //
+        // Gated on the active tab for the same reason the `"note-placed"`
+        // branch is: `consumePendingNoteContent` reads the *active* tab's
+        // queue, so a menu still mounted on a tab the user has left would
+        // otherwise steal the reply armed for the tab now on screen. This is a
+        // button action rather than a bridge message, so it does not inherit
+        // `handleMessage`'s identical guard.
+        guard let app, let sessionId = mountTabId, app.activeTabId == sessionId else {
+            noteComposer = WebNoteComposerState(point: menu.point, anchor: anchor, openedAt: Date())
+            return
         }
+        noteComposer = WebNoteComposerState(
+            point: menu.point, anchor: anchor, openedAt: Date(),
+            initialContent: app.consumePendingNoteContent() ?? "")
+        app.finishNotePlacement(forSessionId: sessionId)
     }
 
     /// Record the composer's edits as they happen. Only the mirror moves, so a
-    /// keystroke costs no view invalidation.
+    /// keystroke costs no view invalidation. A write arriving after the
+    /// composer is gone needs no guard: nothing reads the mirror without a
+    /// composer, and the next one reseeds it in `didSet`.
     func updateNoteComposerDraft(_ text: String) {
-        guard noteComposer != nil else { return }
         noteComposerDraft = text
     }
 
@@ -793,17 +799,50 @@ final class WebViewerController: NSObject {
     /// re-offers the same text instead of it being lost (issue #92).
     private func returnNoteComposerDraft() {
         guard noteComposer != nil else { return }
+        // Load-bearing order: `noteComposer`'s didSet blanks the mirror, so
+        // reading the draft after the nil would hand back an empty string and
+        // silently reinstate the bug.
         let draft = noteComposerDraft
         noteComposer = nil
         guard let app, let sessionId = mountTabId else { return }
         app.restorePendingNote(draft, forSessionId: sessionId)
     }
 
+    /// Test seams (same idiom as `WebLibrary.storeDirOverride`). `attach` ends
+    /// in a real `WKWebView` page load, but none of the popover paths above
+    /// touch the web view — every `post` is gated on the content script having
+    /// reported in — so binding the stores by hand is enough to exercise the
+    /// dismissal rules headlessly.
+    func bindForTesting(app: AppStore, tabId: String) {
+        self.app = app
+        mountTabId = tabId
+    }
+
+    /// Opens a composer the way a placement click does.
+    func openNoteComposerForTesting(content: String) {
+        noteComposer = WebNoteComposerState(
+            point: .zero, anchor: Self.testAnchor, openedAt: Date(), initialContent: content)
+    }
+
+    /// Arms the page context menu, minus the event monitor `showContextMenu`
+    /// installs (there is no window to monitor here).
+    func openContextMenuForTesting() {
+        contextMenu = WebContextMenuState(point: .zero, anchor: Self.testAnchor, openedAt: Date())
+    }
+
+    private static let testAnchor = WebNoteAnchor(
+        start: 0, end: 0, text: "", prefix: nil, suffix: nil, pageNumber: 1)
+
     func closeNoteViewer() { noteViewer = nil }
     func closeHighlightEditor() { highlightEditor = nil }
 
+    /// Tear down every popover for a reason outside the user's intent: a tab
+    /// switch, a link click, an SPA soft-navigation. None of those is a
+    /// "discard", so the composer's draft goes back on the note queue —
+    /// clicking a link on a dense article is at least as likely a misclick as
+    /// clicking whitespace, and it used to lose the reply just as completely.
     func closeNotePopovers() {
-        noteComposer = nil
+        returnNoteComposerDraft()
         hideContextMenu()
         noteViewer = nil
         highlightEditor = nil

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -152,7 +152,8 @@ struct WebViewerView: View {
                                 controller.createAnchoredNote(anchor: composer.anchor, content: content)
                                 controller.closeNoteComposer()
                             },
-                            onClose: { controller.closeNoteComposer() })
+                            onClose: { controller.closeNoteComposer() },
+                            onDraftChange: { controller.updateNoteComposerDraft($0) })
                     }
                     // The composer seeds its editable text from `initialContent`
                     // once, at init. Keying on the placement timestamp gives each
@@ -356,7 +357,18 @@ final class WebViewerController: NSObject {
     /// resulting "selection-cleared" would also unmount the popover (and the
     /// half-typed note) mid-compose.
     private(set) var selectionNoteDraft: WebSelection?
-    private(set) var noteComposer: WebNoteComposerState?
+    private(set) var noteComposer: WebNoteComposerState? {
+        didSet {
+            // Every placement reseeds the mirror below from its own initial
+            // content, so a composer can never inherit the previous one's text.
+            noteComposerDraft = noteComposer?.initialContent ?? ""
+        }
+    }
+    /// The composer's live text, mirrored out of the popover so a dismissal
+    /// that isn't an explicit cancel can hand the draft back to the note queue
+    /// (issue #92). Observation-ignored: nothing renders from it, and it
+    /// changes on every keystroke.
+    @ObservationIgnored private var noteComposerDraft = ""
     private(set) var contextMenu: WebContextMenuState?
     private(set) var noteViewer: WebNoteViewerState?
     private(set) var highlightEditor: WebHighlightEditorState? {
@@ -507,6 +519,10 @@ final class WebViewerController: NSObject {
     /// view, history, scroll position, and extracted text intact.
     func deactivate() {
         clearSelection()
+        // Switching tabs unmounts the composer without the user ever saying
+        // "discard", so its draft goes back on this tab's note queue and is
+        // waiting when they return (issue #92).
+        returnNoteComposerDraft()
         closeNotePopovers()
         removeEventMonitor()
     }
@@ -750,12 +766,39 @@ final class WebViewerController: NSObject {
         guard let menu = contextMenu else { return }
         hideContextMenu()
         if let anchor = menu.anchor {
+            // Same payload hand-off as the note-mode placement click, and as
+            // `PdfSelectionBridge.addNoteFromContextMenu`: a queued AI reply
+            // pre-fills this composer rather than being left stranded.
             noteComposer = WebNoteComposerState(
-                point: menu.point, anchor: anchor, openedAt: Date())
+                point: menu.point, anchor: anchor, openedAt: Date(),
+                initialContent: app?.consumePendingNoteContent() ?? "")
+            if let sessionId = mountTabId { app?.finishNotePlacement(forSessionId: sessionId) }
         }
     }
 
+    /// Record the composer's edits as they happen. Only the mirror moves, so a
+    /// keystroke costs no view invalidation.
+    func updateNoteComposerDraft(_ text: String) {
+        guard noteComposer != nil else { return }
+        noteComposerDraft = text
+    }
+
+    /// Explicit dismissal — Cancel, Escape, or a completed submit. The draft is
+    /// discarded, which is what the user asked for.
     func closeNoteComposer() { noteComposer = nil }
+
+    /// Dismissal the user did not ask for: a stray click on the page, a scroll
+    /// that invalidates the anchor, or another popover taking over. The draft
+    /// goes back on the note queue and placement re-arms, so one more click
+    /// re-offers the same text instead of it being lost (issue #92).
+    private func returnNoteComposerDraft() {
+        guard noteComposer != nil else { return }
+        let draft = noteComposerDraft
+        noteComposer = nil
+        guard let app, let sessionId = mountTabId else { return }
+        app.restorePendingNote(draft, forSessionId: sessionId)
+    }
+
     func closeNoteViewer() { noteViewer = nil }
     func closeHighlightEditor() { highlightEditor = nil }
 
@@ -1126,7 +1169,9 @@ final class WebViewerController: NSObject {
             }
             if let menu = contextMenu, clickOutside(menu.openedAt) { hideContextMenu() }
             if let viewer = noteViewer, clickOutside(viewer.openedAt) { noteViewer = nil }
-            if let composer = noteComposer, clickOutside(composer.openedAt) { noteComposer = nil }
+            if let composer = noteComposer, clickOutside(composer.openedAt) {
+                returnNoteComposerDraft()
+            }
             if let editor = highlightEditor, clickOutside(editor.openedAt) { highlightEditor = nil }
 
         case "note-placed":
@@ -1163,7 +1208,7 @@ final class WebViewerController: NSObject {
         case "context-menu":
             let point = frameToParent(
                 x: doubleValue(data["x"]) ?? 0, y: doubleValue(data["y"]) ?? 0)
-            noteComposer = nil
+            returnNoteComposerDraft()
             noteViewer = nil
             let found = data["found"] as? Bool ?? false
             showContextMenu(WebContextMenuState(
@@ -1178,12 +1223,12 @@ final class WebViewerController: NSObject {
             let point = frameToParent(
                 x: doubleValue(data["x"]) ?? 0, y: doubleValue(data["y"]) ?? 0)
             if annotation?.type == .note {
-                noteComposer = nil
+                returnNoteComposerDraft()
                 highlightEditor = nil
                 hideContextMenu()
                 noteViewer = WebNoteViewerState(id: id, point: point, openedAt: Date())
             } else if annotation?.type == .highlight {
-                noteComposer = nil
+                returnNoteComposerDraft()
                 noteViewer = nil
                 hideContextMenu()
                 highlightEditor = WebHighlightEditorState(id: id, point: point, openedAt: Date())
@@ -1244,7 +1289,7 @@ final class WebViewerController: NSObject {
             // can nudge scroll on some pages); otherwise typing continues.
             if let composer = noteComposer,
                Date().timeIntervalSince(composer.openedAt) >= 0.4 {
-                noteComposer = nil
+                returnNoteComposerDraft()
             }
 
         case "locate-result":

--- a/Vellum/Views/Web/WebViewerView.swift
+++ b/Vellum/Views/Web/WebViewerView.swift
@@ -759,11 +759,18 @@ final class WebViewerController: NSObject {
     }
 
     func contextMenuAddNote() {
-        guard let menu = contextMenu, let anchor = menu.anchor else { return }
+        guard let menu = contextMenu else { return }
+        // Unconditionally, and before the anchor check: the menu is going away
+        // either way, and leaving an anchorless one on screen strands it.
         hideContextMenu()
-        // Same payload hand-off as the note-mode placement click, and as
-        // `PdfSelectionBridge.addNoteFromContextMenu`: a queued AI reply
-        // pre-fills this composer rather than being left stranded.
+        guard let anchor = menu.anchor else { return }
+        // Same payload hand-off as the note-mode placement click: a queued AI
+        // reply pre-fills this composer rather than being left stranded.
+        // (`PdfSelectionBridge.addNoteFromContextMenu` consumes the reply too,
+        // but has neither of the guards below — with a reply queued it writes
+        // the note and leaves note mode armed over an emptied queue, so the
+        // next click drops a second, empty note. That is a separate PDF-side
+        // bug, not parity to copy.)
         //
         // Gated on the active tab for the same reason the `"note-placed"`
         // branch is: `consumePendingNoteContent` reads the *active* tab's
@@ -771,14 +778,18 @@ final class WebViewerController: NSObject {
         // otherwise steal the reply armed for the tab now on screen. This is a
         // button action rather than a bridge message, so it does not inherit
         // `handleMessage`'s identical guard.
-        guard let app, let sessionId = mountTabId, app.activeTabId == sessionId else {
-            noteComposer = WebNoteComposerState(point: menu.point, anchor: anchor, openedAt: Date())
-            return
-        }
-        noteComposer = WebNoteComposerState(
-            point: menu.point, anchor: anchor, openedAt: Date(),
-            initialContent: app.consumePendingNoteContent() ?? "")
-        app.finishNotePlacement(forSessionId: sessionId)
+        // No composer at all on the failing branch, rather than an empty one:
+        // `annotationStore` is pane-scoped, so a mount left on a background tab
+        // now points at whatever document the pane moved on to, and submitting
+        // there would file the note against the wrong document.
+        guard let app, let sessionId = mountTabId, app.activeTabId == sessionId else { return }
+        let pendingContent = app.consumePendingNoteContent()
+        presentNoteComposer(
+            WebNoteComposerState(
+                point: menu.point, anchor: anchor, openedAt: Date(),
+                initialContent: pendingContent ?? ""),
+            app: app,
+            sessionId: sessionId)
     }
 
     /// Record the composer's edits as they happen. Only the mirror moves, so a
@@ -792,6 +803,29 @@ final class WebViewerController: NSObject {
     /// Explicit dismissal — Cancel, Escape, or a completed submit. The draft is
     /// discarded, which is what the user asked for.
     func closeNoteComposer() { noteComposer = nil }
+
+    /// Swap in a new composer, rescuing whatever the outgoing one held.
+    ///
+    /// A second "Add as note" can be pressed while a composer is still open —
+    /// the panel's button is not gated on one — and the placement click that
+    /// follows would otherwise overwrite the first reply with the second. This
+    /// is the one dismissal path that cannot simply call
+    /// `returnNoteComposerDraft` first: the incoming reply has already been
+    /// consumed off the queue by the caller, so re-queueing the old draft
+    /// before that read would hand the caller back the WRONG text.
+    ///
+    /// So the order here is load-bearing in both directions: read the stranded
+    /// draft before the assignment (whose `didSet` blanks the mirror), and
+    /// re-queue it after `finishNotePlacement`, which routes through
+    /// `setMode(.view)` and would otherwise drop it again.
+    private func presentNoteComposer(
+        _ state: WebNoteComposerState, app: AppStore, sessionId: String
+    ) {
+        let stranded = noteComposer != nil ? noteComposerDraft : nil
+        noteComposer = state
+        app.finishNotePlacement(forSessionId: sessionId)
+        if let stranded { app.restorePendingNote(stranded, forSessionId: sessionId) }
+    }
 
     /// Dismissal the user did not ask for: a stray click on the page, a scroll
     /// that invalidates the anchor, or another popover taking over. The draft
@@ -808,30 +842,51 @@ final class WebViewerController: NSObject {
         app.restorePendingNote(draft, forSessionId: sessionId)
     }
 
-    /// Test seams (same idiom as `WebLibrary.storeDirOverride`). `attach` ends
-    /// in a real `WKWebView` page load, but none of the popover paths above
-    /// touch the web view — every `post` is gated on the content script having
-    /// reported in — so binding the stores by hand is enough to exercise the
-    /// dismissal rules headlessly.
-    func bindForTesting(app: AppStore, tabId: String) {
+    #if DEBUG
+    /// Test seams (same idiom as `WebLibrary.storeDirOverride`), because
+    /// `attach` ends in a real `WKWebView` page load.
+    ///
+    /// Careful: `post` is NOT gated on the content script having reported in —
+    /// only the `push*` helpers are — so it materialises the lazy web view.
+    /// The dismissal paths reach it solely through `clearSelection()`, which
+    /// the message branches below only call when a selection exists, and these
+    /// seams never create one. Anything driven from here that could take a
+    /// selection path needs re-checking against that.
+    func bindForTesting(app: AppStore, tabId: String, annotationStore: AnnotationStore? = nil) {
         self.app = app
         mountTabId = tabId
+        self.annotationStore = annotationStore
     }
 
-    /// Opens a composer the way a placement click does.
-    func openNoteComposerForTesting(content: String) {
+    /// Opens a composer the way a placement click does. `openedAt` is settable
+    /// so a test can age one past the `clickOutside` grace period without
+    /// sleeping.
+    func openNoteComposerForTesting(content: String, openedAt: Date = Date()) {
         noteComposer = WebNoteComposerState(
-            point: .zero, anchor: Self.testAnchor, openedAt: Date(), initialContent: content)
+            point: .zero, anchor: Self.testAnchor, openedAt: openedAt, initialContent: content)
     }
 
     /// Arms the page context menu, minus the event monitor `showContextMenu`
     /// installs (there is no window to monitor here).
-    func openContextMenuForTesting() {
-        contextMenu = WebContextMenuState(point: .zero, anchor: Self.testAnchor, openedAt: Date())
+    func openContextMenuForTesting(anchored: Bool = true) {
+        contextMenu = WebContextMenuState(
+            point: .zero, anchor: anchored ? Self.testAnchor : nil, openedAt: Date())
+    }
+
+    /// Delivers a bridge message exactly as the content script would. The five
+    /// incidental dismissals are all message branches, including the literal
+    /// stray page click from issue #92, so without this seam none of them can
+    /// be regression-tested.
+    func handleBridgeMessageForTesting(_ type: String, _ payload: [String: Any] = [:]) {
+        var body = payload
+        body["vellum"] = true
+        body["type"] = type
+        handleMessage(body)
     }
 
     private static let testAnchor = WebNoteAnchor(
         start: 0, end: 0, text: "", prefix: nil, suffix: nil, pageNumber: 1)
+    #endif
 
     func closeNoteViewer() { noteViewer = nil }
     func closeHighlightEditor() { highlightEditor = nil }
@@ -1233,16 +1288,18 @@ final class WebViewerController: NSObject {
             // consumed the reply in `PdfSelectionBridge.placeNote`, the web
             // viewer never did, so the text was silently thrown away here.
             let pendingContent = app.consumePendingNoteContent()
-            noteComposer = WebNoteComposerState(
-                point: point,
-                anchor: anchor,
-                openedAt: Date(),
-                initialContent: pendingContent ?? ""
-            )
             // Mirror the PDF viewer: placing a note returns to view mode — but
             // only when this message belongs to the tab that is still armed, so
-            // a late message cannot reset a different session's mode.
-            app.finishNotePlacement(forSessionId: sessionId)
+            // a late message cannot reset a different session's mode. The
+            // helper also rescues whatever the outgoing composer was holding.
+            presentNoteComposer(
+                WebNoteComposerState(
+                    point: point,
+                    anchor: anchor,
+                    openedAt: Date(),
+                    initialContent: pendingContent ?? ""),
+                app: app,
+                sessionId: sessionId)
 
         case "context-menu":
             let point = frameToParent(


### PR DESCRIPTION
Closes #92

## Root cause

On the web reading path the placement click only *opens* a composer — the note is not written until the user submits. `WebViewerController` calls `app.consumePendingNoteContent()` on the way in, which empties the store, so between that click and the submit **the composer holds the only copy of the AI reply**. Every incidental dismissal set `noteComposer = nil` and the reply went with it: a stray page click (`selection-cleared`), a scroll (`viewport-scrolled`), a right-click, clicking an existing annotation, a link or SPA navigation, and a tab switch.

The PDF path has no such window — `PdfSelectionBridge` writes the note to the annotation store on the placement click itself. That asymmetry is the whole bug.

## Fix, and why this shape

Per the issue's "preserve the pending content" option. Every dismissal the user did **not** explicitly ask for hands the composer's *live* text back to the originating tab's note queue via `AppStore.restorePendingNote(_:forSessionId:)`, which re-arms placement. A misclick now costs one more click instead of the whole reply. Cancel, Escape and submit still discard.

Three design calls worth stating:

- **The live draft, not the seed.** The composer mirrors its text into `WebViewerController.noteComposerDraft` through a write-through `Binding`, so edits made before the misclick survive too. `.onChange` was wrong here: it fires in a later update pass, so a dismissal landing in the same pass would hand back a mirror one keystroke stale.
- **Tab-scoped, not active-tab-scoped.** The dismissal may *be* the tab going away. Note-placement state already travels with the tab, so a background restore is waiting when the user returns.
- **Uniform re-arm, including after right-click and annotation-click.** The alternative — parking the content without arming — is fragile: `setMode(.view)` unconditionally clears `pendingNoteContent`, so Escape or a toolbar toggle would quietly destroy the "preserved" draft. A uniform rule is also explainable in one sentence.

## Reviewer findings

Two adversarial passes, both applied.

**First pass.** `closeNotePopovers()` still discarded outright, so link clicks and SPA navigation lost the reply as completely as before. `contextMenuAddNote` consumed the queue without the active-tab guard its sibling branch documents as necessary. `restorePendingNote` restated `setMode(.note)` instead of delegating. The draft mirror used deferred `.onChange`. And **every test passed with the entire viewer-side fix reverted** — the suite pinned the store method, which was never where the bug lived; two were tautologies.

**Second pass.** The `"note-placed"` branch was itself an unconverted dismissal: a second "Add as note" while a composer is open (the panel's button is not gated on one) overwrote the first reply. The repair is order-sensitive in both directions — the incoming reply is already consumed, so re-queueing first returns the wrong text, and re-queueing before `finishNotePlacement` gets wiped by `setMode(.view)`. `presentNoteComposer` now owns that sequence. The pass also found that four of five incidental paths — including the literal repro in the issue title — would still survive a revert with the suite green. Reviewer also confirmed no `scheduleSave()` is needed (`pendingNoteContent` is live-only and absent from `TabDescriptor`) and no feedback loop exists (`set-mode` posts nothing back; the note-mode click handler `stopImmediatePropagation`s).

Rejected one reviewer suggestion: making the re-arm selective. Reading the content script settles it — right-click is the *harmless* case, because `contextmenu` is not gated on `noteMode`, so the menu still opens and "Add note here" correctly consumes the restored queue.

## Known limitation (deliberate, please read)

Note mode makes the page inert to links, highlight clicks and highlight-resize drags. After an incidental re-arm the user is in that mode without having asked for it, and the natural exit — Escape, `n`, or the toolbar note toggle — routes through `setMode(.view)`, which **discards the rescued reply with no warning**. So the guarantee is "a misclick costs one more click" *provided the next input is a click*.

This is strictly better than main (where the reply was lost 100% of the time on a stray click, not just on a subsequent Escape), so it stands on its own. The proper refinement is to stop overloading one slot for "the note tool is armed" and "an AI reply is queued": a separate parked-draft slot cleared only by consumption or explicit discard would make re-arming optional. That is a semantics change beyond this fix and wants its own issue.

## Numbers

- 492 XCTest + 147 Swift Testing, 0 failures, 0 compiler warnings (warnings-as-errors on). Base was 471 + 147, so 21 new tests.
- 14 mutations applied, 14 killed: one per dismissal branch (`selection-cleared`, `viewport-scrolled`, `context-menu`, both `annotation-click` branches, `closeNotePopovers`), the 0.4s grace period, the `presentNoteComposer` stash, the read/nil ordering in `returnNoteComposerDraft`, the `didSet` mirror reseed, explicit-close-must-discard, the empty-draft guard, the active-tab gate, and both `contextMenuAddNote` guards.

## Not verifiable headlessly

- That the composer visually survives / re-appears — all popover rendering is untested; only the controller state is.
- Real click, scroll and right-click behaviour in a live `WKWebView`: the bridge messages are synthesised, not produced by a real page.
- The `onDraftChange:` wiring in `WebViewerView.body` — deleting that one line leaves the suite green, because SwiftUI body wiring is not reachable without a rendered view. It degrades the fix to "restores the reply but not the user's edits".
- Whether the re-armed note cursor and the tab-bar indicator read as intelligible to a user mid-misclick — the legibility concern above is a judgement call, not a tested one.
- Escape/`n`/toolbar-toggle discarding the rescued reply is reasoned from `setMode(.view)`, not exercised end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)