### PR TITLE
Guard the home screen's destructive removals

### DIFF
--- a/Tests/HomeSearchStoreTests.swift
+++ b/Tests/HomeSearchStoreTests.swift
@@ -184,22 +184,33 @@ struct HomeSearchStoreSelectionTests {
 
 // MARK: - Destructive-removal guards (issue #103)
 
-/// Redirects the recents list at a throwaway `UserDefaults` domain for the life
-/// of one suite instance. Swift Testing has no `tearDown`, so the restore rides
-/// on `deinit` — same shape as `ScratchRecents` in `InspectorPresentationTests`.
-private final class ScratchRecents {
-    private let defaults: UserDefaults
-    private let suiteName: String
+/// Gives every test its own throwaway recents domain, installed and removed
+/// around the test body rather than on `deinit`. Deterministic teardown matters
+/// here: `RecentFilesService.defaultsOverride` is process-global, and a
+/// `deinit` that runs late can strip the override out from under a test that is
+/// still writing — which would send `record`/`restore` at the developer's real
+/// recents list, exactly what the seam exists to prevent.
+private struct ScratchRecentsScope: SuiteTrait, TestTrait, TestScoping {
+    var isRecursive: Bool { true }
 
-    init() {
-        suiteName = "vellum.home-removal.tests.\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: suiteName)!
+    func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? { self }
+
+    func provideScope(
+        for test: Test, testCase: Test.Case?, performing function: () async throws -> Void
+    ) async throws {
+        let suiteName = "vellum.home-removal.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        // Restore the PREVIOUS override, not nil: suites run concurrently, and
+        // unconditionally clearing would drop whichever other suite is midway
+        // through its own writes into `UserDefaults.standard` — which, in a
+        // hosted test bundle, is the developer's real recents list.
+        let previous = RecentFilesService.defaultsOverride
         RecentFilesService.defaultsOverride = defaults
-    }
-
-    deinit {
-        RecentFilesService.defaultsOverride = nil
-        defaults.removePersistentDomain(forName: suiteName)
+        defer {
+            RecentFilesService.defaultsOverride = previous
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        try await function()
     }
 }
 
@@ -207,109 +218,226 @@ private final class ScratchRecents {
 /// context-menu item, with no confirmation and no undo. They are not equally
 /// recoverable, so they no longer carry the same guard — un-saving deletes the
 /// offline snapshot from disk and asks first; dropping a recent edits a list
-/// and is undoable. These pin which is which, and that the undoable one really
-/// round-trips.
-///
-/// `.serialized` because `RecentFilesService.defaultsOverride` is process-wide
-/// mutable state.
+/// and is undoable.
 @MainActor
-@Suite("Home removal guards", .serialized)
+@Suite("Home removal guards", .serialized, ScratchRecentsScope())
 struct HomeRemovalGuardTests {
-    private let recents = ScratchRecents()
-
-    /// Seeds newest-last so the resulting list reads in the given order.
+    /// Seeds newest-first with well-separated timestamps.
+    ///
+    /// Goes through `restore` rather than `record` because it is the only API
+    /// that preserves a given `openedAt`: `record` stamps `Date()`, and several
+    /// calls in a tight loop land in the same millisecond, which would leave
+    /// every ordering assertion below decided by a coin flip.
     private func seed(_ paths: [String]) {
-        for path in paths.reversed() {
-            RecentFilesService.record(
-                DocumentInfo(kind: .pdf, pdfPath: path, title: nil, pageCount: 1))
+        for (offset, path) in paths.enumerated() {
+            RecentFilesService.restore(entry(path, minutesAgo: offset))
         }
     }
 
-    @Test("Only the irreversible removal stops to ask")
-    func onlySavedIsGated() {
-        #expect(HomeSearchRemoval.saved.requiresConfirmation)
-        #expect(!HomeSearchRemoval.recent.requiresConfirmation)
+    private func entry(_ path: String, minutesAgo: Int) -> RecentDocument {
+        RecentDocument(
+            pdfPath: path, kind: .pdf, title: nil, pageCount: 1,
+            openedAt: ISO8601DateFormatter.recentTimestamp.string(
+                from: Date().addingTimeInterval(-60 * Double(minutesAgo))),
+            docId: nil)
     }
 
-    /// The dialog names the row, so a right-click that landed one row off is
-    /// caught before the snapshot is deleted rather than after.
-    @Test("The confirmation names the page and says what survives")
-    func confirmationCopy() {
-        let title = HomeSearchRemoval.saved.confirmationTitle(for: "Attention Is All You Need")
-        #expect(title.contains("Attention Is All You Need"))
-        #expect(title.contains("Saved"))
+    private func recentPaths() -> [String] { RecentFilesService.getRecent().map(\.pdfPath) }
 
-        let message = HomeSearchRemoval.saved.confirmationMessage
-        #expect(message?.contains("offline copy") == true)
-        #expect(message?.contains("Highlights and notes are kept") == true)
-        #expect(HomeSearchRemoval.recent.confirmationMessage == nil,
-                "an undoable action gets no dialog, so it has no dialog copy")
+    private func row(_ id: String) -> HomeSearchItem {
+        item(id: id, section: .recents, kind: .pdf)
+    }
+
+    /// The one-line contract the whole change rests on, plus the only signal the
+    /// user gets that two adjacent menu items behave differently.
+    @Test("Only the irreversible removal is gated, and its label says so")
+    func onlySavedIsGated() {
+        #expect(HomeSearchRemoval.saved.requiresConfirmation)
+        #expect(HomeSearchRemoval.saved.menuLabel.hasSuffix("…"))
+        #expect(!HomeSearchRemoval.recent.requiresConfirmation)
+        #expect(!HomeSearchRemoval.recent.menuLabel.hasSuffix("…"))
+        #expect(
+            HomeSearchRemoval.saved.confirmLabel == HomeSearchRemoval.saved.label,
+            "the ellipsis belongs to the menu item that opens the dialog, not to its button")
     }
 
     @Test("Removing a recent hands back everything Undo needs")
-    func removalYieldsATransaction() async throws {
+    func removalYieldsATransaction() throws {
         seed(["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
         let subject = store()
 
-        let transaction = try #require(
-            await subject.remove(item(id: "b", section: .recents, kind: .pdf), from: .recent))
+        let transaction = try #require(subject.removeFromRecent(row("b")))
 
-        #expect(transaction.index == 1)
         #expect(transaction.entry.pdfPath == "/docs/b.pdf")
-        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/a.pdf", "/docs/c.pdf"])
+        #expect(recentPaths() == ["/docs/a.pdf", "/docs/c.pdf"])
     }
 
-    /// The whole point of the transaction: the row comes back where it was,
-    /// with the timestamp it had. Re-recording it instead would jump it to the
-    /// top and claim it had just been opened.
-    @Test("Undo puts the row back at its original position and time")
-    func undoRoundTrips() async throws {
+    /// The point of the transaction: the row comes back with the timestamp it
+    /// had. Re-recording it instead would jump it to the top and claim it had
+    /// just been opened.
+    @Test("Undo puts the row back in place with its original timestamp")
+    func undoRoundTrips() throws {
         seed(["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
         let originalOpenedAt = try #require(
             RecentFilesService.getRecent().first { $0.pdfPath == "/docs/b.pdf" }?.openedAt)
         let subject = store()
-        let transaction = try #require(
-            await subject.remove(item(id: "b", section: .recents, kind: .pdf), from: .recent))
+        let transaction = try #require(subject.removeFromRecent(row("b")))
 
         #expect(subject.undoRecentRemoval(transaction))
-        #expect(RecentFilesService.getRecent().map(\.pdfPath)
-            == ["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+        #expect(recentPaths() == ["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
         #expect(RecentFilesService.getRecent()[1].openedAt == originalOpenedAt)
 
         #expect(subject.redoRecentRemoval(transaction))
-        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/a.pdf", "/docs/c.pdf"])
+        #expect(recentPaths() == ["/docs/a.pdf", "/docs/c.pdf"])
+    }
+
+    /// `record` always prepends with `Date()`, so the list is always sorted
+    /// newest-first. Reinserting at the index the row was removed from breaks
+    /// that as soon as anything is opened in between — and `prefix(maxRecent)`
+    /// evicts by position, so an unsorted list can drop a NEWER entry than the
+    /// ones it keeps.
+    @Test("Undo reinserts by timestamp, not at the old index")
+    func undoReinsertsByTimestamp() throws {
+        seed(["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+        let subject = store()
+        let transaction = try #require(subject.removeFromRecent(row("c")))
+
+        // The user opens something else before pressing ⌘Z.
+        RecentFilesService.record(
+            DocumentInfo(kind: .pdf, pdfPath: "/docs/x.pdf", title: nil, pageCount: 1))
+
+        #expect(subject.undoRecentRemoval(transaction))
+        #expect(
+            recentPaths() == ["/docs/x.pdf", "/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"],
+            "c is the oldest, so it belongs last — an index-based restore would put it above b")
     }
 
     /// An Undo that has been overtaken must not duplicate the row. Re-opening
-    /// the document puts it back at the top on its own; ⌘Z afterwards has
-    /// nothing left to restore and ends the chain.
+    /// the document puts it back on its own; ⌘Z afterwards has nothing left to
+    /// restore and ends the chain.
     @Test("Undo is a no-op once the document has been re-opened")
-    func undoAfterReopenDoesNothing() async throws {
+    func undoAfterReopenDoesNothing() throws {
         seed(["/docs/a.pdf", "/docs/b.pdf"])
         let subject = store()
-        let transaction = try #require(
-            await subject.remove(item(id: "b", section: .recents, kind: .pdf), from: .recent))
+        let transaction = try #require(subject.removeFromRecent(row("b")))
 
         RecentFilesService.record(
             DocumentInfo(kind: .pdf, pdfPath: "/docs/b.pdf", title: nil, pageCount: 1))
 
         #expect(!subject.undoRecentRemoval(transaction))
-        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/b.pdf", "/docs/a.pdf"],
-                "the re-opened row stays exactly once, at the top where re-opening put it")
+        #expect(
+            recentPaths() == ["/docs/b.pdf", "/docs/a.pdf"],
+            "the re-opened row stays exactly once, at the top where re-opening put it")
     }
 
-    /// Removing a row that is not in the recents list at all still succeeds —
-    /// it just has nothing to offer Undo, which is what stops the caller from
-    /// registering a ⌘Z that would do nothing.
+    /// The mirror image, and the nastier one: without it, Redo deletes a row the
+    /// user has just read, and a further Undo reinstates its stale timestamp —
+    /// silently demoting a real visit down the list.
+    @Test("Redo refuses once the document has been re-opened")
+    func redoAfterReopenDoesNothing() throws {
+        seed(["/docs/a.pdf", "/docs/b.pdf"])
+        let subject = store()
+        let transaction = try #require(subject.removeFromRecent(row("b")))
+        #expect(subject.undoRecentRemoval(transaction))
+
+        // The user reads b again: `record` re-stamps openedAt and re-heads it.
+        RecentFilesService.record(
+            DocumentInfo(kind: .pdf, pdfPath: "/docs/b.pdf", title: nil, pageCount: 1))
+
+        #expect(!subject.redoRecentRemoval(transaction))
+        #expect(recentPaths() == ["/docs/b.pdf", "/docs/a.pdf"])
+    }
+
+    /// At the cap, the restored row displaces the oldest — and because the list
+    /// stays sorted, the one evicted really is the oldest.
+    @Test("Restoring into a full list evicts the oldest entry")
+    func restoreAtTheCapEvictsTheOldest() throws {
+        let paths = (1...RecentFilesService.maxRecent).map { "/docs/\($0).pdf" }
+        seed(paths)
+        let subject = store()
+        let oldest = paths.last!
+        let transaction = try #require(subject.removeFromRecent(row("1")))
+        #expect(recentPaths().count == RecentFilesService.maxRecent - 1)
+
+        RecentFilesService.record(
+            DocumentInfo(kind: .pdf, pdfPath: "/docs/new.pdf", title: nil, pageCount: 1))
+        #expect(subject.undoRecentRemoval(transaction))
+
+        let after = recentPaths()
+        #expect(after.count == RecentFilesService.maxRecent)
+        #expect(after.first == "/docs/new.pdf")
+        #expect(!after.contains(oldest), "the oldest row is the one that falls off the end")
+        #expect(after.contains("/docs/1.pdf"), "the restored row survives")
+    }
+
+    /// Two removals undo last-in-first-out, and each transaction only ever
+    /// touches its own row.
+    @Test("Stacked removals undo independently")
+    func stackedRemovalsUndoIndependently() throws {
+        seed(["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+        let subject = store()
+        let first = try #require(subject.removeFromRecent(row("a")))
+        let second = try #require(subject.removeFromRecent(row("c")))
+        #expect(recentPaths() == ["/docs/b.pdf"])
+
+        #expect(subject.undoRecentRemoval(second))
+        #expect(recentPaths() == ["/docs/b.pdf", "/docs/c.pdf"])
+        #expect(subject.undoRecentRemoval(first))
+        #expect(recentPaths() == ["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+    }
+
+    /// Removing a row that is not in the recents list still succeeds — it just
+    /// has nothing to offer Undo, which is what stops the caller registering a
+    /// ⌘Z that would do nothing.
     @Test("A recent that was already gone offers no Undo")
-    func missingRecentOffersNoUndo() async {
+    func missingRecentOffersNoUndo() {
         seed(["/docs/a.pdf"])
         let subject = store()
 
-        let transaction = await subject.remove(
-            item(id: "zzz", section: .recents, kind: .pdf), from: .recent)
+        #expect(subject.removeFromRecent(row("zzz")) == nil)
+        #expect(recentPaths() == ["/docs/a.pdf"])
+    }
 
-        #expect(transaction == nil)
-        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/a.pdf"])
+    /// Removal clears the keyboard selection so the highlight cannot survive on
+    /// a row that is no longer there.
+    @Test("Removing the selected row drops the selection")
+    func removalClearsSelection() {
+        seed(["/docs/a.pdf"])
+        let subject = store()
+        subject.selectedId = "a"
+
+        _ = subject.removeFromRecent(row("a"))
+
+        #expect(subject.selectedId == nil)
+    }
+}
+
+/// Cap behaviour that the `restore` early-out exists for. Split out of the main
+/// suite only to keep its longer setup out of the way.
+@MainActor
+@Suite("Home removal cap behaviour", .serialized, ScratchRecentsScope())
+struct HomeRemovalCapTests {
+    /// An undo the cap would swallow must report failure, or ⌘Z appears to do
+    /// nothing while the Edit menu goes on to offer "Redo Remove from Recent".
+    @Test("Undo that the cap would swallow reports failure")
+    func undoSwallowedByTheCapFails() throws {
+        let cap = RecentFilesService.maxRecent
+        // The removed row is the OLDEST, and the list refills to the cap with
+        // newer rows before the undo — so there is no room left for it.
+        let oldest = RecentDocument(
+            pdfPath: "/docs/oldest.pdf", kind: .pdf, title: nil, pageCount: 1,
+            openedAt: ISO8601DateFormatter.recentTimestamp.string(
+                from: Date().addingTimeInterval(-9999)),
+            docId: nil)
+        RecentFilesService.restore(oldest)
+        for index in 0..<cap {
+            RecentFilesService.record(
+                DocumentInfo(kind: .pdf, pdfPath: "/docs/new\(index).pdf", title: nil, pageCount: 1))
+        }
+
+        #expect(RecentFilesService.getRecent().count == cap)
+        #expect(!RecentFilesService.getRecent().contains { $0.pdfPath == "/docs/oldest.pdf" })
+        #expect(!RecentFilesService.restore(oldest), "no room, so the undo must not claim success")
+        #expect(RecentFilesService.getRecent().count == cap)
     }
 }

--- a/Tests/HomeSearchStoreTests.swift
+++ b/Tests/HomeSearchStoreTests.swift
@@ -184,43 +184,21 @@ struct HomeSearchStoreSelectionTests {
 
 // MARK: - Destructive-removal guards (issue #103)
 
-/// Gives every test its own throwaway recents domain, installed and removed
-/// around the test body rather than on `deinit`. Deterministic teardown matters
-/// here: `RecentFilesService.defaultsOverride` is process-global, and a
-/// `deinit` that runs late can strip the override out from under a test that is
-/// still writing — which would send `record`/`restore` at the developer's real
-/// recents list, exactly what the seam exists to prevent.
-private struct ScratchRecentsScope: SuiteTrait, TestTrait, TestScoping {
-    var isRecursive: Bool { true }
-
-    func scopeProvider(for test: Test, testCase: Test.Case?) -> Self? { self }
-
-    func provideScope(
-        for test: Test, testCase: Test.Case?, performing function: () async throws -> Void
-    ) async throws {
-        let suiteName = "vellum.home-removal.tests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        // Restore the PREVIOUS override, not nil: suites run concurrently, and
-        // unconditionally clearing would drop whichever other suite is midway
-        // through its own writes into `UserDefaults.standard` — which, in a
-        // hosted test bundle, is the developer's real recents list.
-        let previous = RecentFilesService.defaultsOverride
-        RecentFilesService.defaultsOverride = defaults
-        defer {
-            RecentFilesService.defaultsOverride = previous
-            defaults.removePersistentDomain(forName: suiteName)
-        }
-        try await function()
-    }
-}
-
 /// Issue #103: both home-screen removals used to fire on a single click of a
 /// context-menu item, with no confirmation and no undo. They are not equally
 /// recoverable, so they no longer carry the same guard — un-saving deletes the
 /// offline snapshot from disk and asks first; dropping a recent edits a list
 /// and is undoable.
+///
+/// `.scratchDefaults` gives each test its own recents domain. These tests assert
+/// on exactly what a write left behind — the order of `getRecent()` after a
+/// remove/undo/redo — so they need a domain of their own rather than the shared
+/// scratch suite every unseamed suite writes into. Nothing here is serialized:
+/// the redirect is a task-local that unwinds with the test body (#102), the
+/// store is built with no providers, and `RecentFilesService` reads no other
+/// process-global.
 @MainActor
-@Suite("Home removal guards", .serialized, ScratchRecentsScope())
+@Suite("Home removal guards", .scratchDefaults)
 struct HomeRemovalGuardTests {
     /// Seeds newest-first with well-separated timestamps.
     ///
@@ -415,7 +393,7 @@ struct HomeRemovalGuardTests {
 /// Cap behaviour that the `restore` early-out exists for. Split out of the main
 /// suite only to keep its longer setup out of the way.
 @MainActor
-@Suite("Home removal cap behaviour", .serialized, ScratchRecentsScope())
+@Suite("Home removal cap behaviour", .scratchDefaults)
 struct HomeRemovalCapTests {
     /// An undo the cap would swallow must report failure, or ⌘Z appears to do
     /// nothing while the Edit menu goes on to offer "Redo Remove from Recent".

--- a/Tests/HomeSearchStoreTests.swift
+++ b/Tests/HomeSearchStoreTests.swift
@@ -181,3 +181,135 @@ struct HomeSearchStoreSelectionTests {
         #expect(subject.resultCount == 0)
     }
 }
+
+// MARK: - Destructive-removal guards (issue #103)
+
+/// Redirects the recents list at a throwaway `UserDefaults` domain for the life
+/// of one suite instance. Swift Testing has no `tearDown`, so the restore rides
+/// on `deinit` — same shape as `ScratchRecents` in `InspectorPresentationTests`.
+private final class ScratchRecents {
+    private let defaults: UserDefaults
+    private let suiteName: String
+
+    init() {
+        suiteName = "vellum.home-removal.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        RecentFilesService.defaultsOverride = defaults
+    }
+
+    deinit {
+        RecentFilesService.defaultsOverride = nil
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+/// Issue #103: both home-screen removals used to fire on a single click of a
+/// context-menu item, with no confirmation and no undo. They are not equally
+/// recoverable, so they no longer carry the same guard — un-saving deletes the
+/// offline snapshot from disk and asks first; dropping a recent edits a list
+/// and is undoable. These pin which is which, and that the undoable one really
+/// round-trips.
+///
+/// `.serialized` because `RecentFilesService.defaultsOverride` is process-wide
+/// mutable state.
+@MainActor
+@Suite("Home removal guards", .serialized)
+struct HomeRemovalGuardTests {
+    private let recents = ScratchRecents()
+
+    /// Seeds newest-last so the resulting list reads in the given order.
+    private func seed(_ paths: [String]) {
+        for path in paths.reversed() {
+            RecentFilesService.record(
+                DocumentInfo(kind: .pdf, pdfPath: path, title: nil, pageCount: 1))
+        }
+    }
+
+    @Test("Only the irreversible removal stops to ask")
+    func onlySavedIsGated() {
+        #expect(HomeSearchRemoval.saved.requiresConfirmation)
+        #expect(!HomeSearchRemoval.recent.requiresConfirmation)
+    }
+
+    /// The dialog names the row, so a right-click that landed one row off is
+    /// caught before the snapshot is deleted rather than after.
+    @Test("The confirmation names the page and says what survives")
+    func confirmationCopy() {
+        let title = HomeSearchRemoval.saved.confirmationTitle(for: "Attention Is All You Need")
+        #expect(title.contains("Attention Is All You Need"))
+        #expect(title.contains("Saved"))
+
+        let message = HomeSearchRemoval.saved.confirmationMessage
+        #expect(message?.contains("offline copy") == true)
+        #expect(message?.contains("Highlights and notes are kept") == true)
+        #expect(HomeSearchRemoval.recent.confirmationMessage == nil,
+                "an undoable action gets no dialog, so it has no dialog copy")
+    }
+
+    @Test("Removing a recent hands back everything Undo needs")
+    func removalYieldsATransaction() async throws {
+        seed(["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+        let subject = store()
+
+        let transaction = try #require(
+            await subject.remove(item(id: "b", section: .recents, kind: .pdf), from: .recent))
+
+        #expect(transaction.index == 1)
+        #expect(transaction.entry.pdfPath == "/docs/b.pdf")
+        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/a.pdf", "/docs/c.pdf"])
+    }
+
+    /// The whole point of the transaction: the row comes back where it was,
+    /// with the timestamp it had. Re-recording it instead would jump it to the
+    /// top and claim it had just been opened.
+    @Test("Undo puts the row back at its original position and time")
+    func undoRoundTrips() async throws {
+        seed(["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+        let originalOpenedAt = try #require(
+            RecentFilesService.getRecent().first { $0.pdfPath == "/docs/b.pdf" }?.openedAt)
+        let subject = store()
+        let transaction = try #require(
+            await subject.remove(item(id: "b", section: .recents, kind: .pdf), from: .recent))
+
+        #expect(subject.undoRecentRemoval(transaction))
+        #expect(RecentFilesService.getRecent().map(\.pdfPath)
+            == ["/docs/a.pdf", "/docs/b.pdf", "/docs/c.pdf"])
+        #expect(RecentFilesService.getRecent()[1].openedAt == originalOpenedAt)
+
+        #expect(subject.redoRecentRemoval(transaction))
+        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/a.pdf", "/docs/c.pdf"])
+    }
+
+    /// An Undo that has been overtaken must not duplicate the row. Re-opening
+    /// the document puts it back at the top on its own; ⌘Z afterwards has
+    /// nothing left to restore and ends the chain.
+    @Test("Undo is a no-op once the document has been re-opened")
+    func undoAfterReopenDoesNothing() async throws {
+        seed(["/docs/a.pdf", "/docs/b.pdf"])
+        let subject = store()
+        let transaction = try #require(
+            await subject.remove(item(id: "b", section: .recents, kind: .pdf), from: .recent))
+
+        RecentFilesService.record(
+            DocumentInfo(kind: .pdf, pdfPath: "/docs/b.pdf", title: nil, pageCount: 1))
+
+        #expect(!subject.undoRecentRemoval(transaction))
+        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/b.pdf", "/docs/a.pdf"],
+                "the re-opened row stays exactly once, at the top where re-opening put it")
+    }
+
+    /// Removing a row that is not in the recents list at all still succeeds —
+    /// it just has nothing to offer Undo, which is what stops the caller from
+    /// registering a ⌘Z that would do nothing.
+    @Test("A recent that was already gone offers no Undo")
+    func missingRecentOffersNoUndo() async {
+        seed(["/docs/a.pdf"])
+        let subject = store()
+
+        let transaction = await subject.remove(
+            item(id: "zzz", section: .recents, kind: .pdf), from: .recent)
+
+        #expect(transaction == nil)
+        #expect(RecentFilesService.getRecent().map(\.pdfPath) == ["/docs/a.pdf"])
+    }
+}

--- a/Vellum/Services/RecentFilesService.swift
+++ b/Vellum/Services/RecentFilesService.swift
@@ -45,6 +45,26 @@ enum RecentFilesService {
         return next
     }
 
+    /// Put a removed entry back where it was — the Undo of `remove(path:)`.
+    ///
+    /// Deliberately NOT `record(_:)`: that prepends and re-stamps `openedAt`,
+    /// so undoing a removal through it would claim the document had just been
+    /// opened and move it to the top. An undo restores the list, it does not
+    /// invent a visit.
+    ///
+    /// Returns false when the path is already listed — the user re-opened the
+    /// document after removing it, so the removal has been overtaken and the
+    /// undo has nothing to do. The caller uses this to stop the undo/redo
+    /// chain rather than duplicating the row.
+    @discardableResult
+    static func restore(_ entry: RecentDocument, at index: Int) -> Bool {
+        var next = getRecent()
+        guard !next.contains(where: { $0.pdfPath == entry.pdfPath }) else { return false }
+        next.insert(entry, at: min(max(0, index), next.count))
+        write(Array(next.prefix(maxRecent)))
+        return true
+    }
+
     /// Retitle a recents entry in place.
     ///
     /// Deliberately NOT `record(_:)`, which is the only other way to change a

--- a/Vellum/Services/RecentFilesService.swift
+++ b/Vellum/Services/RecentFilesService.swift
@@ -45,23 +45,55 @@ enum RecentFilesService {
         return next
     }
 
-    /// Put a removed entry back where it was — the Undo of `remove(path:)`.
+    /// Put a removed entry back — the Undo of `remove(path:)`.
     ///
     /// Deliberately NOT `record(_:)`: that prepends and re-stamps `openedAt`,
     /// so undoing a removal through it would claim the document had just been
     /// opened and move it to the top. An undo restores the list, it does not
     /// invent a visit.
     ///
+    /// Reinserted by timestamp rather than at the index it was removed from.
+    /// `record` always prepends with `Date()`, so this list is always sorted
+    /// newest-first; a stale absolute index would break that invariant as soon
+    /// as the user opened anything between the removal and the undo, and
+    /// `prefix(maxRecent)` evicts by position, so an unsorted list can drop a
+    /// NEWER entry than the ones it keeps. (`openedAt` is fixed-width UTC ISO
+    /// 8601, so string order is chronological. A legacy entry written without
+    /// fractional seconds can only tie differently within the same second,
+    /// which is below the resolution anything here cares about.)
+    ///
     /// Returns false when the path is already listed — the user re-opened the
     /// document after removing it, so the removal has been overtaken and the
     /// undo has nothing to do. The caller uses this to stop the undo/redo
     /// chain rather than duplicating the row.
     @discardableResult
-    static func restore(_ entry: RecentDocument, at index: Int) -> Bool {
+    static func restore(_ entry: RecentDocument) -> Bool {
         var next = getRecent()
         guard !next.contains(where: { $0.pdfPath == entry.pdfPath }) else { return false }
-        next.insert(entry, at: min(max(0, index), next.count))
+        let insertion = next.firstIndex { $0.openedAt < entry.openedAt } ?? next.count
+        // The list is capped, so an entry older than a full list of survivors
+        // would be written and immediately truncated away. Report that as a
+        // failure rather than a success: otherwise ⌘Z appears to do nothing
+        // while the Edit menu goes on to offer "Redo Remove from Recent".
+        guard insertion < maxRecent else { return false }
+        next.insert(entry, at: insertion)
         write(Array(next.prefix(maxRecent)))
+        return true
+    }
+
+    /// Re-apply a removal — the Redo of `restore(_:)`.
+    ///
+    /// Refuses unless the listed row is still byte-for-byte the one that was
+    /// removed. Without that, this sequence quietly forgets a real visit:
+    /// remove a row, undo, re-open the document (which re-stamps `openedAt`
+    /// and moves it to the head), then redo — which would delete the row the
+    /// user had just read, and a further undo would reinstate its *old*
+    /// timestamp, dropping it back down the list.
+    @discardableResult
+    static func removeIfUnchanged(_ entry: RecentDocument) -> Bool {
+        let current = getRecent()
+        guard current.contains(entry) else { return false }
+        write(current.filter { $0.pdfPath != entry.pdfPath })
         return true
     }
 

--- a/Vellum/Stores/HomeSearchStore.swift
+++ b/Vellum/Stores/HomeSearchStore.swift
@@ -46,7 +46,14 @@ enum HomeSearchRemoval: Hashable, Sendable {
         }
     }
 
-    /// Confirm-button wording. Repeating the menu label keeps the dialog's
+    /// Context-menu wording. The trailing ellipsis on a gated action is the
+    /// platform's one signal that this item stops to ask while the item next
+    /// to it does not — the same distinction Finder draws between "Move to
+    /// Trash" and "Delete Immediately…".
+    var menuLabel: String { requiresConfirmation ? "\(label)…" : label }
+
+    /// Confirm-button wording. Repeating the menu label (without the ellipsis,
+    /// which belongs only to the item that opens a dialog) keeps the dialog's
     /// consequence identical to the action the user reached for.
     var confirmLabel: String { label }
 
@@ -66,8 +73,13 @@ enum HomeSearchRemoval: Hashable, Sendable {
         switch self {
         case .recent: nil
         case .saved:
-            "The offline copy is deleted from this Mac. Highlights and notes are kept, "
-                + "and the page can be saved again next time it is opened."
+            // Not "from this Mac": `WebLibrary.removeLocalSnapshots` deletes
+            // through `WebICloud.removeItem`, and the web store can live in
+            // iCloud Drive — in which case the offline copy leaves every
+            // device. A confirmation is the one place that must not understate
+            // what it is about to do.
+            "The offline copy is deleted here, and from iCloud if your library syncs there. "
+                + "Highlights and notes are kept, but saving the page again needs a connection."
         }
     }
 }
@@ -75,13 +87,12 @@ enum HomeSearchRemoval: Hashable, Sendable {
 /// A "Remove from Recent" that can be put back, for session-scoped Undo — the
 /// pattern PR #79 introduced for clear-conversation and clear-scratchpad.
 ///
-/// Recents are an ordered `UserDefaults` list, so undo is exact: the entry goes
-/// back at the index it held, with the `openedAt` it had. `.saved` has no
-/// counterpart here on purpose — its removal destroys files, which is why it
-/// carries a confirmation instead.
+/// Recents are a `UserDefaults` list sorted newest-first, so undo is exact: the
+/// entry goes back with the `openedAt` it had, which is also what decides where
+/// it lands. `.saved` has no counterpart here on purpose — its removal destroys
+/// files, which is why it carries a confirmation instead.
 struct HomeRecentRemovalTransaction: Equatable, Sendable {
     var entry: RecentDocument
-    var index: Int
 }
 
 @MainActor
@@ -256,64 +267,64 @@ final class HomeSearchStore {
 
     // MARK: - Mutating the library
 
-    /// Forget a result. Recents drop out of the recents list; saved webpages
-    /// are un-saved (their annotations survive, exactly as the old welcome
-    /// screen's "Remove from Saved" did). Library documents are not removable
-    /// here — deleting a document's notes belongs to Settings ▸ Storage.
-    /// Returns the transaction needed to undo a `.recent` removal, or nil when
-    /// there is nothing to offer Undo for (a `.saved` removal, or a recents
-    /// entry that was already gone). The caller registers it with the window's
-    /// `UndoManager`; see `WelcomeScreen.registerRecentRemovalUndo`.
-    @discardableResult
-    func remove(
-        _ item: HomeSearchItem, from target: HomeSearchRemoval
-    ) async -> HomeRecentRemovalTransaction? {
-        var transaction: HomeRecentRemovalTransaction?
-        switch target {
-        case .recent:
-            let path: String
-            if case .file(_, let recordedPath) = item.target {
-                path = recordedPath
-            } else {
-                path = item.target.openKey
-            }
-            // Read the entry and its position BEFORE the write — that pair is
-            // the whole of what Undo needs to put the row back untouched.
-            if let index = RecentFilesService.getRecent().firstIndex(where: { $0.pdfPath == path }) {
-                transaction = HomeRecentRemovalTransaction(
-                    entry: RecentFilesService.getRecent()[index], index: index)
-            }
-            _ = RecentFilesService.remove(path: path)
-        case .saved:
-            let url = item.target.openKey
-            // Blocking disk work — same off-main hop `WebSessionBackend` uses.
-            await Task.detached(priority: .userInitiated) {
-                try? WebLibrary.removeSaved(rawUrl: url)
-            }.value
+    /// Drop a result from the recents list. The document, its notes and its
+    /// saved copy are all untouched.
+    ///
+    /// Synchronous, and deliberately does NOT reload: the caller needs the
+    /// transaction in hand to register Undo *before* the corpus rebuild, which
+    /// is a recents read plus a stat per saved page plus a documents-directory
+    /// walk. Registering after it would leave a window in which ⌘Z popped
+    /// whatever was on the window's undo stack beforehand. Callers follow up
+    /// with `load()`.
+    ///
+    /// Returns the transaction needed to undo this, or nil when the entry was
+    /// already gone and there is nothing to offer Undo for.
+    func removeFromRecent(_ item: HomeSearchItem) -> HomeRecentRemovalTransaction? {
+        let path: String
+        if case .file(_, let recordedPath) = item.target {
+            path = recordedPath
+        } else {
+            path = item.target.openKey
         }
+        // Read the entry BEFORE the write — it is the whole of what Undo needs
+        // to put the row back untouched.
+        let entry = RecentFilesService.getRecent().first { $0.pdfPath == path }
+        _ = RecentFilesService.remove(path: path)
         if selectedId == item.id { selectedId = nil }
-        await load()
-        return transaction
+        return entry.map(HomeRecentRemovalTransaction.init)
     }
 
-    /// Put a removed recent back at its original position. Returns false when
-    /// the removal has been overtaken — the user re-opened the document, so it
-    /// is in the list again and there is nothing to restore. The caller uses
-    /// that to stop the undo/redo chain instead of duplicating the row.
+    /// Un-save a webpage: the record and its annotations survive, the offline
+    /// snapshot does not. There is no undo for that, which is why the caller
+    /// confirms first — see `HomeSearchRemoval.requiresConfirmation`.
+    func removeFromSaved(_ item: HomeSearchItem) async {
+        let url = item.target.openKey
+        // Blocking disk work — same off-main hop `WebSessionBackend` uses.
+        await Task.detached(priority: .userInitiated) {
+            try? WebLibrary.removeSaved(rawUrl: url)
+        }.value
+        if selectedId == item.id { selectedId = nil }
+        await load()
+    }
+
+    /// Put a removed recent back. Returns false when the removal has been
+    /// overtaken — the user re-opened the document, so it is in the list again
+    /// and there is nothing to restore. The caller uses that to stop the
+    /// undo/redo chain instead of duplicating the row.
     @discardableResult
     func undoRecentRemoval(_ transaction: HomeRecentRemovalTransaction) -> Bool {
-        guard RecentFilesService.restore(transaction.entry, at: transaction.index) else {
-            return false
-        }
+        guard RecentFilesService.restore(transaction.entry) else { return false }
         Task { await load() }
         return true
     }
 
-    /// Re-apply the removal. Always succeeds against the list as it stands:
-    /// filtering by path is a no-op when the row is already gone.
+    /// Re-apply the removal, but only against the row this transaction
+    /// actually removed — see `RecentFilesService.removeIfUnchanged`. Returns
+    /// false when the row has since been re-opened, which ends the chain
+    /// rather than deleting a document the user has just read.
     @discardableResult
     func redoRecentRemoval(_ transaction: HomeRecentRemovalTransaction) -> Bool {
-        _ = RecentFilesService.remove(path: transaction.entry.pdfPath)
+        guard RecentFilesService.removeIfUnchanged(transaction.entry) else { return false }
         Task { await load() }
         return true
     }

--- a/Vellum/Stores/HomeSearchStore.swift
+++ b/Vellum/Stores/HomeSearchStore.swift
@@ -29,6 +29,59 @@ enum HomeSearchRemoval: Hashable, Sendable {
         case .saved: "Remove from Saved"
         }
     }
+
+    /// Whether this removal stops to ask (issue #103 — both used to fire on a
+    /// single click of a context-menu item with no confirmation and no undo).
+    ///
+    /// The two are not equally recoverable, so they do not get the same guard.
+    /// Un-saving runs `WebLibrary.removeSaved`, which deletes the page's local
+    /// snapshots from disk; re-saving means re-fetching, and offline that is
+    /// simply gone. Nothing can undo it, so it asks first. Dropping a recent
+    /// only filters a `UserDefaults` list, so it takes the cheaper guard — see
+    /// `HomeRecentRemovalTransaction` — and stays a single click.
+    var requiresConfirmation: Bool {
+        switch self {
+        case .recent: false
+        case .saved: true
+        }
+    }
+
+    /// Confirm-button wording. Repeating the menu label keeps the dialog's
+    /// consequence identical to the action the user reached for.
+    var confirmLabel: String { label }
+
+    /// Dialog title. It names the row, so a right-click that landed one row off
+    /// is caught here rather than after the offline copy is already gone.
+    func confirmationTitle(for documentTitle: String) -> String {
+        switch self {
+        case .recent: "Remove “\(documentTitle)” from Recent?"
+        case .saved: "Remove “\(documentTitle)” from Saved?"
+        }
+    }
+
+    /// What actually happens, in the terms the user cares about. The reassuring
+    /// half matters as much as the warning: annotations surviving is the reason
+    /// un-saving is a reasonable thing to do at all.
+    var confirmationMessage: String? {
+        switch self {
+        case .recent: nil
+        case .saved:
+            "The offline copy is deleted from this Mac. Highlights and notes are kept, "
+                + "and the page can be saved again next time it is opened."
+        }
+    }
+}
+
+/// A "Remove from Recent" that can be put back, for session-scoped Undo — the
+/// pattern PR #79 introduced for clear-conversation and clear-scratchpad.
+///
+/// Recents are an ordered `UserDefaults` list, so undo is exact: the entry goes
+/// back at the index it held, with the `openedAt` it had. `.saved` has no
+/// counterpart here on purpose — its removal destroys files, which is why it
+/// carries a confirmation instead.
+struct HomeRecentRemovalTransaction: Equatable, Sendable {
+    var entry: RecentDocument
+    var index: Int
 }
 
 @MainActor
@@ -207,14 +260,30 @@ final class HomeSearchStore {
     /// are un-saved (their annotations survive, exactly as the old welcome
     /// screen's "Remove from Saved" did). Library documents are not removable
     /// here — deleting a document's notes belongs to Settings ▸ Storage.
-    func remove(_ item: HomeSearchItem, from target: HomeSearchRemoval) async {
+    /// Returns the transaction needed to undo a `.recent` removal, or nil when
+    /// there is nothing to offer Undo for (a `.saved` removal, or a recents
+    /// entry that was already gone). The caller registers it with the window's
+    /// `UndoManager`; see `WelcomeScreen.registerRecentRemovalUndo`.
+    @discardableResult
+    func remove(
+        _ item: HomeSearchItem, from target: HomeSearchRemoval
+    ) async -> HomeRecentRemovalTransaction? {
+        var transaction: HomeRecentRemovalTransaction?
         switch target {
         case .recent:
+            let path: String
             if case .file(_, let recordedPath) = item.target {
-                _ = RecentFilesService.remove(path: recordedPath)
+                path = recordedPath
             } else {
-                _ = RecentFilesService.remove(path: item.target.openKey)
+                path = item.target.openKey
             }
+            // Read the entry and its position BEFORE the write — that pair is
+            // the whole of what Undo needs to put the row back untouched.
+            if let index = RecentFilesService.getRecent().firstIndex(where: { $0.pdfPath == path }) {
+                transaction = HomeRecentRemovalTransaction(
+                    entry: RecentFilesService.getRecent()[index], index: index)
+            }
+            _ = RecentFilesService.remove(path: path)
         case .saved:
             let url = item.target.openKey
             // Blocking disk work — same off-main hop `WebSessionBackend` uses.
@@ -224,6 +293,29 @@ final class HomeSearchStore {
         }
         if selectedId == item.id { selectedId = nil }
         await load()
+        return transaction
+    }
+
+    /// Put a removed recent back at its original position. Returns false when
+    /// the removal has been overtaken — the user re-opened the document, so it
+    /// is in the list again and there is nothing to restore. The caller uses
+    /// that to stop the undo/redo chain instead of duplicating the row.
+    @discardableResult
+    func undoRecentRemoval(_ transaction: HomeRecentRemovalTransaction) -> Bool {
+        guard RecentFilesService.restore(transaction.entry, at: transaction.index) else {
+            return false
+        }
+        Task { await load() }
+        return true
+    }
+
+    /// Re-apply the removal. Always succeeds against the list as it stands:
+    /// filtering by path is a no-op when the row is already gone.
+    @discardableResult
+    func redoRecentRemoval(_ transaction: HomeRecentRemovalTransaction) -> Bool {
+        _ = RecentFilesService.remove(path: transaction.entry.pdfPath)
+        Task { await load() }
+        return true
     }
 
     /// Retitle a result and re-index so the new name is live everywhere.

--- a/Vellum/Views/Welcome/HomeResultViews.swift
+++ b/Vellum/Views/Welcome/HomeResultViews.swift
@@ -124,7 +124,7 @@ struct HomeResultRow: View {
             if !removals.isEmpty {
                 Divider()
                 ForEach(removals, id: \.removal) { entry in
-                    Button(entry.removal.label, role: .destructive, action: entry.action)
+                    Button(entry.removal.menuLabel, role: .destructive, action: entry.action)
                 }
             }
         }

--- a/Vellum/Views/Welcome/WelcomeScreen.swift
+++ b/Vellum/Views/Welcome/WelcomeScreen.swift
@@ -43,13 +43,19 @@ struct WelcomeScreen: View {
     @State private var confirmingRemoval: PendingRemoval?
     @FocusState private var searchFocused: Bool
 
+    /// Title for the confirmation, held separately and never cleared on
+    /// dismissal: `confirmingRemoval` goes nil the instant the dialog starts
+    /// closing, and reading it for the title (which is evaluated outside
+    /// `presenting:`) would blank the heading mid-animation while the buttons
+    /// and message still render.
+    @State private var confirmingTitle = ""
+
     /// A destructive removal held back until the user confirms it. Carries the
     /// row as well as the action so the dialog can name what it is about to
     /// un-save.
-    private struct PendingRemoval: Identifiable {
+    private struct PendingRemoval {
         let item: HomeSearchItem
         let removal: HomeSearchRemoval
-        var id: String { "\(item.id)|\(removal)" }
     }
 
     private var updateChecker: UpdateChecker { workspace.updateChecker }
@@ -94,6 +100,16 @@ struct WelcomeScreen: View {
             // would fight over first responder.
             if isPaneFocused { searchFocused = true }
         }
+        .onDisappear {
+            // `registerUndo(withTarget:)` does NOT retain its target, and this
+            // screen owns `store` as `@State` — opening a document swaps the
+            // whole view out and deallocates it. Leaving the registration in
+            // place would leave a dead target on the window-wide undo stack,
+            // and "Undo Remove from Recent" sitting in the Edit menu of a
+            // reader that has no recents list on screen. The undo's session is
+            // this screen's lifetime, so it leaves with it.
+            undoManager?.removeAllActions(withTarget: store)
+        }
         // Re-index when the app comes back to the front. The corpus is a
         // snapshot of three on-disk sources, and all three can change while
         // Vellum is in the background — the other pane opens a document, the
@@ -119,7 +135,7 @@ struct WelcomeScreen: View {
                 })
         }
         .confirmationDialog(
-            Text(confirmingRemoval.map { $0.removal.confirmationTitle(for: $0.item.title) } ?? ""),
+            Text(confirmingTitle),
             isPresented: Binding(
                 get: { confirmingRemoval != nil },
                 set: { if !$0 { confirmingRemoval = nil } }),
@@ -127,10 +143,9 @@ struct WelcomeScreen: View {
             presenting: confirmingRemoval
         ) { pending in
             Button(pending.removal.confirmLabel, role: .destructive) {
-                confirmingRemoval = nil
                 performRemoval(pending.item, from: pending.removal)
             }
-            Button("Cancel", role: .cancel) { confirmingRemoval = nil }
+            Button("Cancel", role: .cancel) {}
         } message: { pending in
             if let message = pending.removal.confirmationMessage {
                 Text(message)
@@ -698,14 +713,14 @@ struct WelcomeScreen: View {
         for item: HomeSearchItem
     ) -> [(removal: HomeSearchRemoval, action: () -> Void)] {
         store.removalOptions(for: item).map { removal in
-            // The closure is annotated rather than inferred: a bare
-            // `{ Task { … } }` reads as returning the Task, which makes the
-            // `Task.init` overload set ambiguous.
+            // The closure is annotated rather than inferred so the type checker
+            // resolves its body independently of the surrounding `map`.
             let action: () -> Void = {
                 // Issue #103: neither removal used to stop for anything. The
                 // irreversible one now asks; the reversible one still fires on
                 // the click and offers ⌘Z (see `performRemoval`).
                 if removal.requiresConfirmation {
+                    confirmingTitle = removal.confirmationTitle(for: item.title)
                     confirmingRemoval = PendingRemoval(item: item, removal: removal)
                 } else {
                     performRemoval(item, from: removal)
@@ -718,13 +733,21 @@ struct WelcomeScreen: View {
     /// Do the removal and, when it produced something undoable, put it on the
     /// window's undo stack.
     private func performRemoval(_ item: HomeSearchItem, from removal: HomeSearchRemoval) {
-        Task {
-            let transaction = await store.remove(item, from: removal)
+        switch removal {
+        case .recent:
+            // Registered synchronously, before the reload: `load()` rebuilds the
+            // whole corpus, and a ⌘Z landing during it would pop whatever was on
+            // the window's stack beforehand instead of this removal.
+            let transaction = store.removeFromRecent(item)
             // SwiftUI only supplies `\.undoManager` where the environment
             // supports it; without one the removal simply stands, exactly as it
             // did before. Same fallback as the AI panel and scratchpad.
-            guard let transaction, let undoManager else { return }
-            registerRecentRemovalUndo(transaction, store: store, undoManager: undoManager)
+            if let transaction, let undoManager {
+                registerRecentRemovalUndo(transaction, store: store, undoManager: undoManager)
+            }
+            Task { await store.load() }
+        case .saved:
+            Task { await store.removeFromSaved(item) }
         }
     }
 

--- a/Vellum/Views/Welcome/WelcomeScreen.swift
+++ b/Vellum/Views/Welcome/WelcomeScreen.swift
@@ -29,6 +29,9 @@ struct WelcomeScreen: View {
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.palette) private var palette
     @Environment(\.openSettings) private var openSettings
+    /// Session-scoped Undo for "Remove from Recent" (issue #103), registered
+    /// the same way PR #79 registers clear-conversation and clear-scratchpad.
+    @Environment(\.undoManager) private var undoManager
 
     @State private var store = HomeSearchStore()
     /// First-run hero only. The library layout uses the search field itself for
@@ -36,7 +39,18 @@ struct WelcomeScreen: View {
     @State private var urlInput = ""
     /// The row whose rename sheet is open, if any.
     @State private var renamingItem: HomeSearchItem?
+    /// The removal waiting on its confirmation dialog, if any.
+    @State private var confirmingRemoval: PendingRemoval?
     @FocusState private var searchFocused: Bool
+
+    /// A destructive removal held back until the user confirms it. Carries the
+    /// row as well as the action so the dialog can name what it is about to
+    /// un-save.
+    private struct PendingRemoval: Identifiable {
+        let item: HomeSearchItem
+        let removal: HomeSearchRemoval
+        var id: String { "\(item.id)|\(removal)" }
+    }
 
     private var updateChecker: UpdateChecker { workspace.updateChecker }
 
@@ -103,6 +117,24 @@ struct WelcomeScreen: View {
                 commit: { newTitle in
                     Task { await store.rename(item, to: newTitle) }
                 })
+        }
+        .confirmationDialog(
+            Text(confirmingRemoval.map { $0.removal.confirmationTitle(for: $0.item.title) } ?? ""),
+            isPresented: Binding(
+                get: { confirmingRemoval != nil },
+                set: { if !$0 { confirmingRemoval = nil } }),
+            titleVisibility: .visible,
+            presenting: confirmingRemoval
+        ) { pending in
+            Button(pending.removal.confirmLabel, role: .destructive) {
+                confirmingRemoval = nil
+                performRemoval(pending.item, from: pending.removal)
+            }
+            Button("Cancel", role: .cancel) { confirmingRemoval = nil }
+        } message: { pending in
+            if let message = pending.removal.confirmationMessage {
+                Text(message)
+            }
         }
         .background {
             // ⌘F focuses the search field here. The menu's Find… command and the
@@ -669,8 +701,30 @@ struct WelcomeScreen: View {
             // The closure is annotated rather than inferred: a bare
             // `{ Task { … } }` reads as returning the Task, which makes the
             // `Task.init` overload set ambiguous.
-            let action: () -> Void = { Task { await store.remove(item, from: removal) } }
+            let action: () -> Void = {
+                // Issue #103: neither removal used to stop for anything. The
+                // irreversible one now asks; the reversible one still fires on
+                // the click and offers ⌘Z (see `performRemoval`).
+                if removal.requiresConfirmation {
+                    confirmingRemoval = PendingRemoval(item: item, removal: removal)
+                } else {
+                    performRemoval(item, from: removal)
+                }
+            }
             return (removal, action)
+        }
+    }
+
+    /// Do the removal and, when it produced something undoable, put it on the
+    /// window's undo stack.
+    private func performRemoval(_ item: HomeSearchItem, from removal: HomeSearchRemoval) {
+        Task {
+            let transaction = await store.remove(item, from: removal)
+            // SwiftUI only supplies `\.undoManager` where the environment
+            // supports it; without one the removal simply stands, exactly as it
+            // did before. Same fallback as the AI panel and scratchpad.
+            guard let transaction, let undoManager else { return }
+            registerRecentRemovalUndo(transaction, store: store, undoManager: undoManager)
         }
     }
 
@@ -691,6 +745,38 @@ struct WelcomeScreen: View {
         let paths = panel.urls.map(\.path)
         Task { await appStore.openFiles(paths: paths) }
     }
+}
+
+/// Undo/redo registration for "Remove from Recent", mirroring
+/// `registerConversationUndo` / `registerScratchpadUndo` from PR #79: each step
+/// registers its counterpart, so ⌘Z and ⇧⌘Z alternate for as long as the window
+/// lives. A step that reports `false` — the document was re-opened, so the
+/// removal has been overtaken — registers nothing and ends the chain rather
+/// than duplicating the row.
+@MainActor
+private func registerRecentRemovalUndo(
+    _ transaction: HomeRecentRemovalTransaction,
+    store: HomeSearchStore,
+    undoManager: UndoManager
+) {
+    undoManager.registerUndo(withTarget: store) { target in
+        guard target.undoRecentRemoval(transaction) else { return }
+        registerRecentRemovalRedo(transaction, store: target, undoManager: undoManager)
+    }
+    undoManager.setActionName("Remove from Recent")
+}
+
+@MainActor
+private func registerRecentRemovalRedo(
+    _ transaction: HomeRecentRemovalTransaction,
+    store: HomeSearchStore,
+    undoManager: UndoManager
+) {
+    undoManager.registerUndo(withTarget: store) { target in
+        guard target.redoRecentRemoval(transaction) else { return }
+        registerRecentRemovalUndo(transaction, store: target, undoManager: undoManager)
+    }
+    undoManager.setActionName("Remove from Recent")
 }
 
 #Preview("Hero wordmark") {


### PR DESCRIPTION
Closes #103

## Root cause

On the search-first home screen, `HomeResultRow`'s context menu wires each removal straight to `Task { await store.remove(...) }`. Both "Remove from Recent" and "Remove from Saved" fired on a single click with no confirmation and no undo — the last one-click destructive action left after #79 gave clear-conversation and clear-scratchpad session Undo.

## Fix: per action, on recoverability

The issue offers confirmation **or** Undo. The two removals are not equally recoverable, so they don't get the same guard — and picking one for both would be wrong either way.

**Remove from Saved → confirmation.** It routes to `WebLibrary.removeSaved`, which calls `removeLocalSnapshots`, deleting the page's offline copy. No undo can recreate it. So it asks first, with a `.confirmationDialog` naming the row (a right-click that landed one row off is caught before the snapshot is gone) and a destructive-role confirm button.

**Remove from Recent → Undo, no friction.** It only filters a `UserDefaults` list, and the document is one click from being re-opened. A dialog there would be a tax on a low-stakes action. It keeps its single click and gains session-scoped Undo using #79's `registerUndo`/`setActionName` alternating-chain pattern. `RecentFilesService.restore` puts the entry back with the `openedAt` it had — deliberately not `record`, which prepends and re-stamps, i.e. would claim the document had just been opened.

The gated item is labelled `Remove from Saved…`; the ellipsis is the platform's signal that one of two adjacent items stops to ask, the way Finder distinguishes "Move to Trash" from "Delete Immediately…".

## Reviewer findings

Two adversarial passes. Five real bugs, all fixed.

1. **Use-after-free (P0).** `registerUndo(withTarget:)` does not retain its target, and `HomeSearchStore` is `@State` on `WelcomeScreen`, which `PaneView` tears down the moment a document opens — while the window's `UndoManager` outlives it. Remove a recent, open anything, press ⌘Z, and the handler fires against a freed store. This is exactly where the #79 port broke its own precondition: those targets are `@Environment` stores with *pane* lifetime. Fixed with `.onDisappear { undoManager?.removeAllActions(withTarget: store) }`, which also stops "Undo Remove from Recent" appearing in the Edit menu of a reader with no recents list on screen.
2. **Undo registered too late.** It sat behind `await load()`, a full three-provider corpus rebuild, so a quick ⌘Z popped whatever was on the window's stack beforehand. The recents mutation is now synchronous (`removeFromRecent`) and registers on the spot.
3. **Redo had no overtaken-guard.** Remove → undo → re-open the document → redo deleted the row the user had just read, and a further undo reinstated its stale `openedAt`, silently demoting a real visit down the list. `removeIfUnchanged` refuses unless the row is still the one that was removed.
4. **Stale absolute index.** `record` always prepends, so the list is always newest-first; reinserting at the old index broke that as soon as anything was opened in between — and `prefix(maxRecent)` evicts by *position*, so an unsorted list can drop a newer entry than the ones it keeps. Now inserts by timestamp, and returns false when the cap leaves no room rather than reporting a ⌘Z that visibly did nothing.
5. **Confirmation copy was untrue.** It said the offline copy is deleted "from this Mac", but `removeLocalSnapshots` deletes through `WebICloud.removeItem` and the web store can live in iCloud Drive — so it can leave every device. A confirmation is the one place that must not understate itself.

Also applied: the dialog title no longer blanks mid-dismissal (it was read from the raw optional, outside `presenting:`), the dead `Identifiable` conformance is gone, and a stale comment about `Task.init` ambiguity is corrected. Tests now seed through `restore` with explicit timestamps — seeding via `record` put several entries in the same millisecond, which left every ordering assertion decided by a coin flip.

**Considered and deferred:** one reviewer argued un-saving is ~90% reversible (only `removeLocalSnapshots` is destructive; `record.saved`/`savedAt` are a trivial flip), so it could get confirm *and* undo. That's a real improvement but it changes storage-reclamation semantics, so it belongs in its own issue rather than here.

## Numbers

- 471 XCTest + 158 Swift Testing, 0 failures, 0 compiler warnings (warnings-as-errors on). Base was 471 + 147, so 11 new tests.
- New coverage the reviewers asked for: cap eviction, restore-after-intervening-opens (the ordering bug), redo-after-reopen, LIFO stacked removals, selection clearing, and the cap-swallows-the-undo no-op.

## Not verifiable headlessly

- That the `.confirmationDialog` actually appears, its wording renders as intended, and Escape/outside-click cancel rather than confirm. Only the store-level gating decision is tested; the view-level routing (`.saved` → dialog, `.recent` → straight through) is not.
- That ⌘Z is actually wired to these registrations in a running app, that the Edit menu reads "Undo Remove from Recent", and that `.onDisappear` fires before the store is deallocated. The undo/redo *chain* logic lives in private free functions in `WelcomeScreen.swift` and has no direct coverage — only the store methods it calls do.
- The menu-item ellipsis as rendered.
- Cross-suite test isolation remains imperfect: `RecentFilesService.defaultsOverride` is process-global and three suites install it. This PR's suite now installs and restores it deterministically around each test (and restores the *previous* value rather than nil), but a bundle-wide fix wants its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)