### PR TITLE
Keep the math splitter out of inline code spans (#99)

### DIFF
--- a/Tests/AiMarkdownRenderingTests.swift
+++ b/Tests/AiMarkdownRenderingTests.swift
@@ -501,6 +501,22 @@ final class AiMarkdownRenderingTests: XCTestCase {
                        "matches \\(a\\|b\\) here")
     }
 
+    /// Known residual, pinned so it stays a decision rather than a surprise:
+    /// `plainPreview` unwraps `$$…$$` and strips math delimiters with its own
+    /// regexes, which run before `segments` and have no notion of code spans —
+    /// so a `$$` inside a code span still loses its delimiters in the pill.
+    ///
+    /// Out of scope for #99 and materially different from it: no text is eaten
+    /// and nothing is reordered (the "x" survives), which is the same lossy
+    /// contract this one-line preview already applies to `**`, backticks and
+    /// every other delimiter. The bug #99 is about — the splitter consuming the
+    /// backticks and the prose between two spans — is fixed here, as the test
+    /// above shows.
+    func testPlainPreviewStillStripsDisplayDelimitersInsideCodeSpans() {
+        XCTAssertEqual(MarkdownParser.plainPreview("write `$$x$$` for display"),
+                       "write x for display")
+    }
+
     /// The code spans inside those sub-items must still style as code.
     func testCodeSpansInsideNestedItemsAreMonospaced() {
         guard case .list(let items) = MarkdownParser.parse("- a\n  - `int\\b` for the `int` keyword").first else {

--- a/Tests/AiMarkdownRenderingTests.swift
+++ b/Tests/AiMarkdownRenderingTests.swift
@@ -408,6 +408,99 @@ final class AiMarkdownRenderingTests: XCTestCase {
             "a marker survived into the item text: \(items.map(\.text))")
     }
 
+    // MARK: - Code spans containing math delimiters (#99)
+
+    /// Text and code-intent for every prose run of a line, as the renderers see
+    /// it. Both message renderers consume `InlineMarkdown.pieces` — the SwiftUI
+    /// `MarkdownMessage` and the AppKit `AiAttributedRenderer` — so asserting
+    /// here covers both inline paths at their shared layer.
+    private static func runs(_ line: String) -> [(String, Bool)] {
+        InlineMarkdown.pieces(in: line).flatMap { piece -> [(String, Bool)] in
+            guard case .prose(let attributed) = piece else { return [] }
+            return attributed.runs.map {
+                (String(attributed[$0.range].characters),
+                 $0.inlinePresentationIntent?.contains(.code) ?? false)
+            }
+        }
+    }
+
+    private static func hasMath(_ line: String) -> Bool {
+        InlineMarkdown.pieces(in: line).contains { piece in
+            if case .math = piece { return true }
+            return false
+        }
+    }
+
+    /// The #99 repros. `MathRenderer.segments` runs before the markdown parse,
+    /// so a code span holding a `$` or a `\(…\)` was cut apart before anything
+    /// knew it was code — the span was typeset as an equation and its backticks
+    /// were eaten.
+    func testCodeSpansHoldingMathDelimitersStayCode() {
+        let cases = [
+            ("Use `$1` and `$2` backrefs", ["$1", "$2"]),
+            ("matches `\\(a\\|b\\)` here", ["\\(a\\|b\\)"]),
+            ("write `$$x$$` for display", ["$$x$$"]),
+            ("`a$b` alone", ["a$b"]),
+        ]
+        for (line, spans) in cases {
+            XCTAssertFalse(Self.hasMath(line), "\(line) was typeset as math")
+            let runs = Self.runs(line)
+            for span in spans {
+                XCTAssertTrue(
+                    runs.contains { $0.0 == span && $0.1 },
+                    "\(line): expected code run \(span), got \(runs)")
+            }
+            XCTAssertFalse(
+                runs.contains { $0.0.contains("`") }, "\(line): backticks reached the screen: \(runs)")
+        }
+    }
+
+    /// The guard is code spans, not backticks: real inline math elsewhere on the
+    /// line must still typeset, and a `$` used as currency must still not.
+    func testMathAndCurrencyOutsideCodeSpansAreUnaffected() {
+        XCTAssertTrue(Self.hasMath("`grep` finds $x^2$ fast"))
+        XCTAssertTrue(Self.hasMath("the value $x^2$ appears here"))
+        XCTAssertFalse(Self.hasMath("it cost $5 and $10 today"))
+        XCTAssertFalse(Self.hasMath("`grep` costs $5 and $10"))
+    }
+
+    /// The AppKit renderer specifically: math becomes an `NSTextAttachment`, so
+    /// a code span that is no longer mistaken for math must produce none — and
+    /// its `$` must survive as literal text.
+    func testAppKitRendererDoesNotTypesetCodeSpanDollars() {
+        func attachmentCount(_ source: String) -> Int {
+            let attributed = AiAttributedRenderer.attributedString(
+                for: source, color: .labelColor, secondary: .secondaryLabelColor)
+            var count = 0
+            attributed.enumerateAttribute(
+                .attachment, in: NSRange(location: 0, length: attributed.length)
+            ) { value, _, _ in
+                if value is NSTextAttachment { count += 1 }
+            }
+            return count
+        }
+        let rendered = AiAttributedRenderer.attributedString(
+            for: "Use `$1` and `$2` backrefs", color: .labelColor, secondary: .secondaryLabelColor)
+        XCTAssertTrue(rendered.string.contains("$1"), "got \(rendered.string)")
+        XCTAssertTrue(rendered.string.contains("$2"), "got \(rendered.string)")
+        XCTAssertFalse(rendered.string.contains("`"), "got \(rendered.string)")
+        XCTAssertEqual(attachmentCount("Use `$1` and `$2` backrefs"), 0)
+        // Positive control: real math on the same path still typesets, so the
+        // assertion above is about the code span and not about attachments
+        // having stopped working.
+        XCTAssertGreaterThan(attachmentCount("the value $x^2$ appears"), 0)
+    }
+
+    /// The sidebar pill, quoting and accessibility text go through
+    /// `plainPreview`, which calls `segments` directly — the third caller, and
+    /// the reason #99 is fixed in `MathRenderer` rather than in `InlineMarkdown`.
+    func testPlainPreviewKeepsCodeSpanContentIntact() {
+        XCTAssertEqual(MarkdownParser.plainPreview("Use `$1` and `$2` backrefs"),
+                       "Use $1 and $2 backrefs")
+        XCTAssertEqual(MarkdownParser.plainPreview("matches `\\(a\\|b\\)` here"),
+                       "matches \\(a\\|b\\) here")
+    }
+
     /// The code spans inside those sub-items must still style as code.
     func testCodeSpansInsideNestedItemsAreMonospaced() {
         guard case .list(let items) = MarkdownParser.parse("- a\n  - `int\\b` for the `int` keyword").first else {

--- a/Tests/MarkdownParserTests.swift
+++ b/Tests/MarkdownParserTests.swift
@@ -208,6 +208,35 @@ final class MarkdownParserTests: XCTestCase {
         XCTAssertEqual(MathRenderer.segments(in: line), [.text(line)])
     }
 
+    /// …and the closer half of that check: "\(y\\)" never closes as math,
+    /// because the backslash before ")" is itself escaped.
+    func testSegmentsEscapedParenCloserIsLiteral() {
+        XCTAssertEqual(MathRenderer.segments(in: "\\(y\\\\)"), [.text("\\(y\\\\)")])
+    }
+
+    /// The scanner indexes UTF-16 code units, the same units the math regex
+    /// reports its ranges in, so an astral-plane character ahead of a span must
+    /// not shift the two out of agreement. An emoji is two code units, which is
+    /// exactly the offset that would corrupt the overlap test if either side
+    /// counted Characters instead.
+    func testSegmentsCodeSpanOffsetsSurviveAstralCharacters() {
+        XCTAssertEqual(MathRenderer.codeSpanRanges(in: "😀 `$1` and `$2` tail"),
+                       [NSRange(location: 3, length: 4), NSRange(location: 12, length: 4)])
+        let line = "😀 `$1` and `$2` tail"
+        XCTAssertEqual(MathRenderer.segments(in: line), [.text(line)])
+        // …and real math after an emoji still typesets.
+        XCTAssertTrue(MathRenderer.segments(in: "😀 costs $x^2$ ok").contains(.math("x^2")))
+    }
+
+    /// Backtick runs of differing lengths never pair off, so nothing is a code
+    /// span and the math after them is still found. The failure this guards is
+    /// a scanner that treats any later backtick as a closer and swallows the
+    /// rest of the line.
+    func testSegmentsMismatchedBacktickRunsDoNotHideMath() {
+        XCTAssertTrue(MathRenderer.segments(in: "``a` $x$").contains(.math("x")))
+        XCTAssertTrue(MathRenderer.codeSpanRanges(in: "``a` $x$").isEmpty)
+    }
+
     // MARK: - Segments: MathRenderer.segments(in:)
 
     func testSegmentsCurrencyIsNotMath() {

--- a/Tests/MarkdownParserTests.swift
+++ b/Tests/MarkdownParserTests.swift
@@ -147,6 +147,67 @@ final class MarkdownParserTests: XCTestCase {
             [.paragraph("before"), .math("x"), .paragraph("after")])
     }
 
+    // MARK: - Segments: code spans vs the math splitter (#99)
+
+    /// Repro 1. `segments` runs before any markdown parse, so a code span
+    /// containing `$` was cut apart before anything knew it was code: the `$`
+    /// alternative matched from the first `$` to the second (the span ends on a
+    /// non-space, non-`$`, so the lookarounds are satisfied), capturing
+    /// ``1` and `` and eating both backticks.
+    func testSegmentsCodeSpanWithBackrefsIsNotMath() {
+        let line = "Use `$1` and `$2` backrefs"
+        XCTAssertEqual(MathRenderer.segments(in: line), [.text(line)])
+    }
+
+    /// Repro 2. A POSIX BRE group is very plausible in an answer about sed or
+    /// regex, and it matched the `\(…\)` alternative verbatim.
+    func testSegmentsCodeSpanWithPosixGroupIsNotMath() {
+        let line = "matches `\\(a\\|b\\)` here"
+        XCTAssertEqual(MathRenderer.segments(in: line), [.text(line)])
+    }
+
+    /// The issue's negative: a lone code span holding a `$` stays literal code.
+    func testSegmentsLoneCodeSpanWithDollarStaysText() {
+        XCTAssertEqual(MathRenderer.segments(in: "`a$b`"), [.text("`a$b`")])
+    }
+
+    /// Display-math delimiters inside a code span are just characters. The `$`
+    /// alternative can still find "$x$" within "$$x$$", so this only stays put
+    /// because the code span is carved out first.
+    func testSegmentsCodeSpanWithDisplayMathDelimitersStaysText() {
+        XCTAssertEqual(MathRenderer.segments(in: "write `$$x$$` for display"),
+                       [.text("write `$$x$$` for display")])
+    }
+
+    /// The guard is code spans, not backticks: real math on the same line as an
+    /// unrelated code span must still typeset.
+    func testSegmentsMathOutsideACodeSpanStillTypesets() {
+        let segments = MathRenderer.segments(in: "`grep` finds $x^2$ fast")
+        XCTAssertEqual(segments, [.text("`grep` finds "), .math("x^2"), .text(" fast")])
+    }
+
+    /// CommonMark closes a span on a run of *exactly* the opening length, and an
+    /// unmatched run is literal text — so a stray backtick must not hide the
+    /// math that follows it behind a span that never closes.
+    func testSegmentsUnmatchedBacktickDoesNotSwallowLaterMath() {
+        let segments = MathRenderer.segments(in: "a ` stray tick then $x$")
+        XCTAssertTrue(segments.contains(.math("x")), "got \(segments)")
+    }
+
+    /// A double-backtick span can contain a single backtick, and its contents
+    /// are still off-limits to the math scanner.
+    func testSegmentsDoubleBacktickSpanIsProtected() {
+        XCTAssertEqual(MathRenderer.segments(in: "`` `$1` ``"), [.text("`` `$1` ``")])
+    }
+
+    /// The `\(…\)` branch had no escape handling at all — only the `$` branch
+    /// checked backslash parity — so an escaped delimiter opened a span.
+    func testSegmentsEscapedParenOpenerIsLiteral() {
+        // "\\(not math\\)" — the backslash before "(" is itself escaped.
+        let line = "a \\\\(not math\\\\) b"
+        XCTAssertEqual(MathRenderer.segments(in: line), [.text(line)])
+    }
+
     // MARK: - Segments: MathRenderer.segments(in:)
 
     func testSegmentsCurrencyIsNotMath() {

--- a/Vellum/Views/AI/MathRenderer.swift
+++ b/Vellum/Views/AI/MathRenderer.swift
@@ -132,23 +132,98 @@ enum MathRenderer {
         return count
     }
 
+    /// Ranges of CommonMark inline code spans, backticks included.
+    ///
+    /// CommonMark's rule: a run of N backticks opens a span that closes on the
+    /// next run of *exactly* N. A run with no matching closer is literal text,
+    /// so scanning resumes just past it rather than swallowing the rest of the
+    /// line — that is what keeps a stray backtick from hiding real math behind
+    /// it.
+    ///
+    /// Reported as ranges rather than extracted substrings because the callers
+    /// need the code spans left in place: `InlineMarkdown` hands the whole line
+    /// to Foundation afterwards and wants the backticks still there to style,
+    /// and `plainPreview` strips them itself. All this has to do is tell the
+    /// math scanner which regions to keep its hands off.
+    nonisolated static func codeSpanRanges(in source: String) -> [NSRange] {
+        let backtick = UInt16(UnicodeScalar("`").value)
+        let ns = source as NSString
+        var ranges: [NSRange] = []
+        var index = 0
+        while index < ns.length {
+            guard ns.character(at: index) == backtick else { index += 1; continue }
+            var openLength = 0
+            while index + openLength < ns.length,
+                  ns.character(at: index + openLength) == backtick { openLength += 1 }
+            var search = index + openLength
+            var closer = -1
+            while search < ns.length {
+                guard ns.character(at: search) == backtick else { search += 1; continue }
+                var closeLength = 0
+                while search + closeLength < ns.length,
+                      ns.character(at: search + closeLength) == backtick { closeLength += 1 }
+                if closeLength == openLength { closer = search; break }
+                search += closeLength
+            }
+            guard closer >= 0 else { index += openLength; continue }
+            ranges.append(NSRange(location: index, length: closer + openLength - index))
+            index = closer + openLength
+        }
+        return ranges
+    }
+
     /// Split inline text into prose and math spans. Recognizes `\(...\)` and
     /// single-`$` spans; a `$` span must not butt against whitespace on the
-    /// inside ("$5 and $10" stays currency, "$x^2$" is math). A `$` escaped by
-    /// an odd number of backslashes ("literal \$x$") is left as prose.
+    /// inside ("$5 and $10" stays currency, "$x^2$" is math). A `$` or a `\(`
+    /// escaped by an odd number of backslashes ("literal \$x$") is left as prose.
+    ///
+    /// Code spans are carved out first (#99). This runs *before* any markdown
+    /// parse — `InlineMarkdown.pieces` splits here and only then hands the
+    /// result to Foundation — so without this step a backtick span containing a
+    /// math delimiter was already cut apart by the time anything knew it was
+    /// code. ``Use `$1` and `$2` backrefs`` matched from the first `$` to the
+    /// second and typeset ``1` and `` as an equation, eating both backticks;
+    /// `` `\(a\|b\)` ``, a perfectly ordinary POSIX group, was read as LaTeX.
+    ///
+    /// Fixed here rather than in `InlineMarkdown.pieces` (where #99 suggested
+    /// hanging it off the existing U+FFFC placeholder machinery) because
+    /// `MarkdownParser.plainPreview` calls `segments` directly for the sidebar
+    /// pill, quoting and accessibility text, and carries the identical hazard.
+    /// One owner for "regions the math scanner must not touch" fixes both
+    /// renderers and the plain-text path together; a fix one level up would
+    /// have left the third caller broken.
     nonisolated static func segments(in source: String) -> [MathSegment] {
         guard source.contains("$") || source.contains("\\(") else { return [.text(source)] }
         guard let regex = inlineMathRegex else { return [.text(source)] }
         let ns = source as NSString
+        // Only pay for the code-span scan when a backtick is actually present.
+        let codeSpans = source.contains("`") ? codeSpanRanges(in: source) : []
         var segments: [MathSegment] = []
         var cursor = 0
         for match in regex.matches(in: source, range: NSRange(location: 0, length: ns.length)) {
+            // A match that touches a code span at either end is not math: it
+            // either lives inside one or straddles two, which is how the `$1`/
+            // `$2` backref case swallowed the text between them.
+            if codeSpans.contains(where: { NSIntersectionRange($0, match.range).length > 0 }) {
+                continue
+            }
             let isDollar = match.range(at: 1).location == NSNotFound
+            // Skip when the opening or closing delimiter is escaped; the region
+            // stays unconsumed and folds into the surrounding prose.
             if isDollar {
-                // Skip when the opening or closing `$` is escaped; the region
-                // stays unconsumed and folds into the surrounding prose.
                 let opener = match.range.location
                 let closer = match.range.location + match.range.length - 1
+                if backslashRun(before: opener, in: ns) % 2 == 1
+                    || backslashRun(before: closer, in: ns) % 2 == 1 {
+                    continue
+                }
+            } else {
+                // The `\(…\)` branch had no escape handling at all, so a literal
+                // backslash before the delimiter ("\\(not math\\)") opened a
+                // span. Both delimiters are two characters, so the backslash to
+                // test is the first of the pair and the second-to-last overall.
+                let opener = match.range.location
+                let closer = match.range.location + match.range.length - 2
                 if backslashRun(before: opener, in: ns) % 2 == 1
                     || backslashRun(before: closer, in: ns) % 2 == 1 {
                     continue


### PR DESCRIPTION
Closes #99.

## Root cause

`MathRenderer.segments(in:)` regex-scans a raw line for inline math with no notion of backticks, and it runs *before* any markdown parse — `InlineMarkdown.pieces` splits here and only then hands the result to Foundation. So a code span containing a math delimiter was already cut apart by the time anything knew it was code:

- ``Use `$1` and `$2` backrefs`` — the `$` alternative matched from the first `$` to the second (the span ends on a non-space, non-`$`, so both lookarounds are satisfied), capturing ``1` and `` and typesetting it as an equation. Both backticks were eaten.
- `` `\(a\|b\)` `` — an ordinary POSIX BRE group, very plausible in an answer about `sed` or regex, matched the `\(…\)` alternative and was typeset as LaTeX.

Separately, the `backslashRun` escape guard sat inside `if isDollar`, so the `\(…\)` alternative had no escape handling at all.

## Fix

`MathRenderer.codeSpanRanges(in:)` carves out CommonMark inline code spans first — a run of N backticks closes on the next run of *exactly* N, and an unmatched run is literal text, so scanning resumes just past it rather than swallowing the rest of the line. Any math match intersecting a span is skipped, which also covers what made the first repro so destructive: the match straddled *two* spans.

Ranges are reported rather than substrings extracted, because the callers need the backticks left in place — `InlineMarkdown` hands the whole line to Foundation to style, and `plainPreview` strips them itself.

The `\(…\)` alternative also gets the backslash-parity check the `$` alternative already had.

**Placement.** Fixed in `MathRenderer.segments` rather than in `InlineMarkdown.pieces`, where the issue suggested hanging it off the existing U+FFFC placeholder machinery. `segments` has three callers, not two: `MarkdownParser.plainPreview` calls it directly for the sidebar pill, quoting and accessibility text, and carries the identical hazard (the issue notes this). One owner fixes both renderers *and* the plain-text path together; a fix one level up would have left the third caller broken.

**Both renderers verified, not assumed.** `MarkdownMessage.inlineText` (SwiftUI, line 145) and `AiAttributedRenderer.inline` (AppKit, line 733) both iterate `InlineMarkdown.pieces`, so the shared layer covers both — and the AppKit path is additionally asserted directly, by checking it emits zero `NSTextAttachment`s for the repro line and still emits one for real math.

## Measured behaviour

| input | before | after |
|---|---|---|
| ``Use `$1` and `$2` backrefs`` | math span ``1` and ``, both backticks eaten | one text segment, `$1`/`$2` styled as code |
| `` `\(a\|b\)` `` | typeset as LaTeX | one text segment, styled as code |
| `` `a$b` `` | text (already fine) | text |
| ``write `$$x$$` for display`` | inner `$x$` typeset | one text segment |
| `` `grep` finds $x^2$ fast`` | math `x^2` | math `x^2` (unchanged) |
| `it cost $5 and $10 today` | text (currency) | text (unchanged) |
| `a ` stray tick then $x$` | math `x` | math `x` (unchanged) |
| `\(y\)` | math `y` | math `y` (unchanged) |
| `a \\(not math\\) b` | typeset as LaTeX | text |

`plainPreview` for the first repro goes from eating text to `"Use $1 and $2 backrefs"`.

Edge cases probed against the implementation and confirmed correct: UTF-16 offsets survive astral characters (an emoji ahead of a span yields spans at `{3,4}`/`{12,4}`, and math after an emoji still typesets); mismatched backtick runs never pair off, so `` ``a` $x$ `` finds no span and still typesets; double-backtick spans containing a single backtick are protected; empty/adjacent runs behave.

The added scan is gated behind the existing `$`/`\(` guard *and* a `contains("`")` check, so the streaming hot path — lines with no backtick — pays nothing.

## Review status

**Honest disclosure: the independent reviewer did not complete.** A fresh-context adversarial reviewer was spawned for this branch and was lost to API instability mid-response, having emitted no findings; the Claude Code process then restarted. Rather than leave the work stranded, I ran a disciplined adversarial self-review against the same checklist, and — because reading one's own diff is weak evidence — verified the edge cases *empirically* with a temporary probe harness that printed `segments`, `codeSpanRanges` and `plainPreview` output for 16 adversarial inputs (surrogate pairs, mismatched runs, empty spans, unmatched openers, all four escape-parity permutations). The probe was deleted; every case it validated is now a permanent test in `096d380`.

That self-review found one real residual, now pinned as a documented contract rather than left unknown:

> `plainPreview` unwraps `$$…$$` with its own regex, which runs before `segments` and has no notion of code spans, so ``write `$$x$$` for display`` still previews as `"write x for display"`. Out of scope for #99 and materially different from it: no text is eaten and nothing is reordered, which is the same lossy contract the one-line preview already applies to `**`, backticks and every other delimiter. The #99 symptom — the splitter consuming backticks and the prose between two spans — *is* fixed on that path.

The #96 PR (#123) did get two full independent Opus reviews; this one did not, so it deserves a closer human read than that one.

## Verification

Keychain test guard intact (4 XCTest markers + the UI-testing arg), so tests never touch the real login keychain. Clean build, zero source warnings with warnings-as-errors on. Full suite: **487 XCTest** (471 baseline + 16 new) and **147 Swift Testing**, green.

One run failed on `DocumentDataStoreTests.testRekeyMovesFallbackFolderToStampedKey()` — that is verbatim the known flake filed as #100, unrelated to this diff; the re-run was clean.

Both new behaviours mutation-checked: neutering the code-span overlap guard fails 6 tests across all three surfaces (both renderers and `plainPreview`), and disabling the new `\(…\)` escape parity fails its test — each and only its intended target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Inline code containing `$...$`, `\(...\)`, or `$$...$$` is no longer incorrectly rendered as math.
  - Escaped math delimiters remain visible as literal text.
  - Real math outside code spans continues to render correctly, including after special characters.
  - Currency values using `$` are not misinterpreted as mathematical expressions.
  - Code span previews preserve their content while removing backticks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->