### PR TITLE
iPhone UI stabilization before merge

### DIFF
--- a/Tests/HelpCenterTests.swift
+++ b/Tests/HelpCenterTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import UIKit
 import XCTest
 
@@ -176,5 +177,30 @@ final class HelpTopicContentTests: XCTestCase {
         XCTAssertTrue(
             storage?.footnote?.contains("Vellum Help") ?? false,
             "the walkthrough's closing footnote no longer points at the Help centre")
+    }
+}
+
+@MainActor
+final class HelpCenterDynamicTypeTests: XCTestCase {
+    func testTopicRowsGrowAtTheLargestAccessibilitySize() {
+        let topic = HelpTopic.all[0]
+        let width: CGFloat = 320
+
+        func height(at size: DynamicTypeSize) -> CGFloat {
+            let host = UIHostingController(
+                rootView: HelpTopicRow_iOS(topic: topic)
+                    .environment(\.palette, .light)
+                    .tint(ThemePalette.light.primary)
+                    .dynamicTypeSize(size))
+            host.view.frame = CGRect(x: 0, y: 0, width: width, height: .greatestFiniteMagnitude)
+            return host.sizeThatFits(
+                in: CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
+            ).height
+        }
+
+        XCTAssertGreaterThan(
+            height(at: .accessibility5),
+            height(at: .large),
+            "Help topic text is not responding to the user's Dynamic Type setting")
     }
 }

--- a/Tests/InkPersistenceTests.swift
+++ b/Tests/InkPersistenceTests.swift
@@ -455,6 +455,32 @@ final class InkPersistenceTests: XCTestCase {
             "ink survived a failed write and landed on the retry")
     }
 
+    @MainActor
+    func testInactiveInkOverlayContainerPassesPageTouchesThrough() {
+        let canvas = InkPageCanvas_iOS()
+        canvas.isUserInteractionEnabled = false
+        let container = InkOverlayContainer_iOS(canvas: canvas)
+        container.frame = CGRect(x: 0, y: 0, width: 300, height: 500)
+        container.layoutIfNeeded()
+
+        XCTAssertNil(
+            container.hitTest(CGPoint(x: 150, y: 250), with: nil),
+            "the transparent overlay must not swallow PDFKit text-selection touches")
+    }
+
+    @MainActor
+    func testActiveInkOverlayContainerStillRoutesTouchesToCanvas() {
+        let canvas = InkPageCanvas_iOS()
+        canvas.isUserInteractionEnabled = true
+        let container = InkOverlayContainer_iOS(canvas: canvas)
+        container.frame = CGRect(x: 0, y: 0, width: 300, height: 500)
+        container.layoutIfNeeded()
+
+        let hit = container.hitTest(CGPoint(x: 150, y: 250), with: nil)
+        XCTAssertNotNil(hit, "ink mode must keep delivering page touches to PencilKit")
+        XCTAssertFalse(hit === container, "the wrapper itself never owns a page touch")
+    }
+
     /// The debounce must fire on its own — nothing in the app calls
     /// `flushPendingInk` on a timer, so if the scheduled write never ran, ink
     /// would only ever reach disk via an explicit flush.

--- a/Tests/InspectorTabSwitcherTests.swift
+++ b/Tests/InspectorTabSwitcherTests.swift
@@ -10,8 +10,8 @@ import XCTest
 //
 //   * `maximumWidth` is 560, not 700. 700 pt is over half the width of an 11"
 //     iPad in portrait and nearly the whole of a Split View pane.
-//   * `switcherHeight` is 36, not 30, which makes `headerHeight` 52 rather than
-//     46. A 30 pt segment is well under the 44 pt HIG touch target.
+//   * `switcherHeight` is 44, not 30. The Button itself owns the HIG touch
+//     target; padding around a smaller control does not enlarge its AX frame.
 //
 // Everything else — the 280 floor, the 360 ideal, the three breakpoints, the
 // identifier convention — is shared with main, on purpose: they are the numbers
@@ -78,12 +78,9 @@ final class InspectorTabSwitcherTests: XCTestCase {
         }
     }
 
-    /// The header's height is a TOUCH-TARGET fact on iPad, which is why the
-    /// switcher is 36 pt here and 30 pt on macOS. A 30 pt segment is well under
-    /// the 44 pt HIG minimum; 36 pt of control inside 8 pt of vertical padding
-    /// gives a 52 pt row, and the segment picks up the rest of its reach from
-    /// the `.contentShape(Rectangle())` inside its label — which is what makes
-    /// the whole segment tappable rather than just the glyph.
+    /// The header's height is a TOUCH-TARGET fact on iOS. The segment itself is
+    /// 44pt; the surrounding padding positions it but does not count toward the
+    /// Button's accessibility frame.
     ///
     /// (Main names this `…IsTheStripTheCatcherMustCover` because there the
     /// number is a drop-routing fact: `SidebarDropRoutingTests` aims at the
@@ -91,9 +88,9 @@ final class InspectorTabSwitcherTests: XCTestCase {
     /// so there is no catcher this number serves and the name would send the
     /// next reader looking for one that does not exist.)
     func testHeaderHeightMatchesTheSwitcherPlusItsInset() {
-        XCTAssertEqual(InspectorLayout.switcherHeight, 36)
+        XCTAssertEqual(InspectorLayout.switcherHeight, 44)
         XCTAssertEqual(InspectorLayout.switcherVerticalPadding, 8)
-        XCTAssertEqual(InspectorLayout.headerHeight, 52)
+        XCTAssertEqual(InspectorLayout.headerHeight, 60)
         // Stated as the relationship too, so a padding change cannot leave the
         // two literals above quietly inconsistent.
         XCTAssertEqual(

--- a/Tests/PhoneInspectorTests.swift
+++ b/Tests/PhoneInspectorTests.swift
@@ -116,6 +116,26 @@ struct PhoneInspectorTests {
         #expect(fixture.shell.inspectorTab == .scratchpad)
     }
 
+    @Test(
+        "Selecting a tab changes only the visible panel",
+        .bug("https://github.com/ayushdeolasee/Vellum/issues/185"))
+    func tabSelectionIsIndependentOfPresentation() async throws {
+        let fixture = InspectorFixture()
+        try await fixture.openPdf()
+
+        fixture.shell.selectInspectorTab(.ai)
+        #expect(fixture.shell.inspectorTab == .ai)
+        #expect(fixture.shell.inspectorPresented == false)
+
+        fixture.shell.setInspectorPresented(true)
+
+        for tab in WorkspaceStore.SidebarTab.allCases {
+            fixture.shell.selectInspectorTab(tab)
+            #expect(fixture.shell.inspectorTab == tab)
+            #expect(fixture.shell.inspectorPresented)
+        }
+    }
+
     @Test("SwiftUI's dismissal write-back on the way to Home preserves the chosen panel")
     func dismissalWriteBackIsIgnoredOffTheReader() async throws {
         let fixture = InspectorFixture()

--- a/Tests/PhoneShellStateTests.swift
+++ b/Tests/PhoneShellStateTests.swift
@@ -1,6 +1,8 @@
 #if os(iOS)
 import Foundation
+import SwiftUI
 import Testing
+import UIKit
 
 @testable import Vellum
 
@@ -90,22 +92,24 @@ struct PhoneShellStateTests {
         #expect(shell.switcherPresented == false)
     }
 
-    @Test("Chrome comes back visible on every arrival at the reader")
+    @Test(
+        "Chrome has explicit hide and reveal actions and resets on reader arrival",
+        .bug("https://github.com/ayushdeolasee/Vellum/issues/187"))
     func chromeResetsVisibleOnEveryRouteChangeToReader() async throws {
         let (shell, app) = try await makeShell()
         await app.openFile(path: "/tmp/phone-chrome.pdf")
         shell.didOpenDocument()
         #expect(shell.chromeVisible)
 
-        shell.toggleChrome()
+        shell.hideChrome()
         #expect(shell.chromeVisible == false)
-        shell.setChrome(true)
+        shell.showChrome()
         #expect(shell.chromeVisible)
         shell.setChrome(false)
 
         // Immersive is per-visit, not a preference: arriving at a document with
-        // no chrome leaves no visible way back to Home, and tap-to-reveal is
-        // not discoverable.
+        // no chrome leaves only the compact reveal handle and no visible way
+        // back to Home.
         shell.showHome()
         shell.showReader()
         #expect(shell.chromeVisible)
@@ -230,6 +234,24 @@ struct PhoneShellStateTests {
         let workspace = makeWorkspace()
         let shell = PhoneShellStore(workspace: workspace)
         return (shell, workspace.focusedPane.app)
+    }
+}
+
+@MainActor
+@Suite("Phone reader chrome hit testing")
+struct PhoneReaderChromeHitTestingTests {
+    @Test("The immersive reveal control only owns its visible button")
+    func revealControlLeavesTheDocumentTouchable() {
+        let host = UIHostingController(rootView: ChromeRevealControl_iOS(
+            isActive: true,
+            chromeVisible: false,
+            action: {}))
+        host.loadViewIfNeeded()
+        host.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        host.view.layoutIfNeeded()
+
+        #expect(host.view.hitTest(CGPoint(x: 100, y: 422), with: nil) == nil)
+        #expect(host.view.hitTest(CGPoint(x: 352, y: 422), with: nil) != nil)
     }
 }
 

--- a/Tests/PhoneShellStateTests.swift
+++ b/Tests/PhoneShellStateTests.swift
@@ -1,6 +1,5 @@
 #if os(iOS)
 import Foundation
-import SwiftUI
 import Testing
 import UIKit
 
@@ -81,43 +80,152 @@ struct PhoneShellStateTests {
         await app.openFile(path: "/tmp/phone-switcher.pdf")
         shell.didOpenDocument()
 
-        shell.switcherPresented = true
+        shell.presentSwitcher()
         shell.didOpenDocument()
         #expect(shell.switcherPresented == false)
 
         // And leaving for Home closes it too: a full-screen cover left up
         // would stack over the screen that replaced the one it covered.
-        shell.switcherPresented = true
+        shell.presentSwitcher()
         shell.showHome()
         #expect(shell.switcherPresented == false)
+
+        // Plain Done/system dismissal is also a fresh reader arrival.
+        shell.showReader()
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 20, sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.ended)
+        shell.presentSwitcher()
+        shell.setSwitcherPresented(false)
+        #expect(shell.chromeVisible)
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 8, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "switcher return cleared partial travel")
+    }
+
+    @Test("A document tap toggles bars while blocked interactions do not")
+    func documentTapTogglesChrome() async throws {
+        let (shell, app) = try await makeShell()
+        await app.openFile(path: "/tmp/phone-tap.pdf")
+        shell.didOpenDocument()
+
+        shell.handleReaderScroll(.tapped(sourceInteractionBlocked: false))
+        #expect(!shell.chromeVisible)
+        shell.handleReaderScroll(.tapped(sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible)
+
+        shell.handleReaderScroll(.tapped(sourceInteractionBlocked: true))
+        #expect(shell.chromeVisible, "selection and note interactions keep their chrome state")
     }
 
     @Test(
-        "Chrome has explicit hide and reveal actions and resets on reader arrival",
-        .bug("https://github.com/ayushdeolasee/Vellum/issues/187"))
-    func chromeResetsVisibleOnEveryRouteChangeToReader() async throws {
+        "Direct later/reverse travel hides and reveals both bars at 28 points",
+        .bug("https://github.com/ayushdeolasee/Vellum/issues/192"))
+    func scrollTravelDrivesChromeAtThreshold() async throws {
         let (shell, app) = try await makeShell()
         await app.openFile(path: "/tmp/phone-chrome.pdf")
         shell.didOpenDocument()
-        #expect(shell.chromeVisible)
 
-        shell.hideChrome()
-        #expect(shell.chromeVisible == false)
-        shell.showChrome()
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 27, sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.ended)
         #expect(shell.chromeVisible)
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 1, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible == false, "short direct pans accumulate")
+        shell.handleReaderScroll(.ended)
+        #expect(shell.chromeVisible == false, "hidden controls remain hidden at rest")
+
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: -28, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible)
+    }
+
+    @Test("Tiny reversals are jitter; deliberate direction changes reset accumulated travel")
+    func chromeTravelHandlesDirectionChanges() async throws {
+        let (shell, app) = try await makeShell()
+        await app.openFile(path: "/tmp/phone-direction.pdf")
+        shell.didOpenDocument()
+
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 20, sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: -2, sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 8, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible == false)
+
+        shell.showReader()
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 20, sourceInteractionBlocked: false))
+        for _ in 0..<4 {
+            shell.handleReaderScroll(.changed(deltaY: -1, sourceInteractionBlocked: false))
+        }
+        shell.handleReaderScroll(.changed(deltaY: 24, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "repeated tiny samples eventually form a real reversal")
+    }
+
+    @Test("PDFKit's document responder is selection, not keyboard input")
+    func pdfDocumentTextInputDoesNotFreezeChrome() {
+        let pdfView = VellumPDFView()
+        let pdfDocumentResponder = UITextView()
+        pdfView.addSubview(pdfDocumentResponder)
+
+        #expect(PhoneShellStore.isPDFDocumentSurfaceResponder(pdfDocumentResponder))
+        #expect(!PhoneShellStore.isPDFDocumentSurfaceResponder(UITextView()))
+    }
+
+    @Test("A blocked interaction freezes its whole pan and always-show prevents hiding")
+    func safeguardsFreezeAutomaticChrome() async throws {
+        let (shell, app) = try await makeShell()
+        await app.openFile(path: "/tmp/phone-safeguards.pdf")
+        shell.didOpenDocument()
+
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: true))
+        shell.handleReaderScroll(.changed(deltaY: 100, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "selection/note work owns the complete gesture")
+        shell.handleReaderScroll(.ended)
+
+        shell.setChrome(false)
+        app.showFind()
+        shell.findPresentationChanged(isVisible: true)
+        #expect(shell.chromeVisible, "Find cannot open inside invisible chrome")
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 100, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "Find freezes automatic chrome")
+        shell.handleReaderScroll(.ended)
+        app.hideFind()
+
+        app.setMode(.note)
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 100, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "sticky-note placement freezes automatic chrome")
+        shell.handleReaderScroll(.ended)
+        app.setMode(.view)
+
+        shell.updateAlwaysShowReaderControls(true)
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 100, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible)
+        shell.handleReaderScroll(.tapped(sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "always-show also blocks tap-to-hide")
+    }
+
+    @Test("Every reader navigation arrival restores controls and clears partial travel")
+    func chromeResetsVisibleOnEveryRouteChangeToReader() async throws {
+        let (shell, app) = try await makeShell()
+        await app.openFile(path: "/tmp/phone-arrival.pdf")
+        shell.didOpenDocument()
         shell.setChrome(false)
 
-        // Immersive is per-visit, not a preference: arriving at a document with
-        // no chrome leaves only the compact reveal handle and no visible way
-        // back to Home.
         shell.showHome()
         shell.showReader()
         #expect(shell.chromeVisible)
-
-        shell.setChrome(false)
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 20, sourceInteractionBlocked: false))
         shell.showHome()
         shell.didOpenDocument()
-        #expect(shell.chromeVisible)
+        shell.handleReaderScroll(.began(sourceInteractionBlocked: false))
+        shell.handleReaderScroll(.changed(deltaY: 8, sourceInteractionBlocked: false))
+        #expect(shell.chromeVisible, "arrival discarded the previous visit’s partial travel")
     }
 
     // MARK: - The inspector (D2 / D3)
@@ -234,24 +342,6 @@ struct PhoneShellStateTests {
         let workspace = makeWorkspace()
         let shell = PhoneShellStore(workspace: workspace)
         return (shell, workspace.focusedPane.app)
-    }
-}
-
-@MainActor
-@Suite("Phone reader chrome hit testing")
-struct PhoneReaderChromeHitTestingTests {
-    @Test("The immersive reveal control only owns its visible button")
-    func revealControlLeavesTheDocumentTouchable() {
-        let host = UIHostingController(rootView: ChromeRevealControl_iOS(
-            isActive: true,
-            chromeVisible: false,
-            action: {}))
-        host.loadViewIfNeeded()
-        host.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
-        host.view.layoutIfNeeded()
-
-        #expect(host.view.hitTest(CGPoint(x: 100, y: 422), with: nil) == nil)
-        #expect(host.view.hitTest(CGPoint(x: 352, y: 422), with: nil) != nil)
     }
 }
 

--- a/Tests/PhoneTabCardTests.swift
+++ b/Tests/PhoneTabCardTests.swift
@@ -1,6 +1,8 @@
 #if os(iOS)
 import Foundation
+import SwiftUI
 import Testing
+import UIKit
 
 @testable import Vellum
 
@@ -126,22 +128,44 @@ struct PhoneTabCardTests {
                 == "example.com/post")
     }
 
+    @Test("Repeated instances of one source receive distinct, non-persisted ordinals")
+    func duplicateSourcesAreDistinguishable() {
+        let sharedURL = "https://example.com/post"
+        let tabs = [
+            tab(id: "first", document: web(url: sharedURL, title: "A Post")),
+            tab(id: "other", document: web(url: "https://example.com/other", title: "A Post")),
+            tab(id: "second", document: web(url: sharedURL, title: "A Post")),
+        ]
+
+        let cards = PhoneTabCardBuilder.cards(
+            tabs: tabs, activeTabId: "first", isResident: { _ in false })
+
+        #expect(cards.map(\.duplicateLabel) == ["Duplicate 1 of 2", nil, "Duplicate 2 of 2"])
+        #expect(cards[0].title == cards[2].title)
+        #expect(cards[0].subtitle == cards[2].subtitle)
+    }
+
     @Test("The page label appears only for PDFs whose page count is known")
     func pageLabelIsPdfOnlyAndOnlyWhenKnown() {
         var pdfTab = tab(id: "1", document: pdf(path: "/docs/A.pdf", title: "A"))
         pdfTab.currentPage = 7
         pdfTab.numPages = 210
         #expect(PhoneTabCardBuilder.pageLabel(for: pdfTab) == "7 / 210")
+        #expect(PhoneTabCardBuilder.previewPageNumber(for: pdfTab) == 7)
+        #expect(PhoneTabCardBuilder.thumbnailPath(for: pdfTab) == "/docs/A.pdf")
 
         // Mid-open: "1 / 0" is a number that is simply wrong.
         var opening = pdfTab
         opening.numPages = 0
         #expect(PhoneTabCardBuilder.pageLabel(for: opening) == nil)
+        #expect(PhoneTabCardBuilder.previewPageNumber(for: opening) == nil)
 
         // A webpage has no pages.
         var webTab = tab(id: "2", document: web(url: "https://example.com/post"))
         webTab.numPages = 3
         #expect(PhoneTabCardBuilder.pageLabel(for: webTab) == nil)
+        #expect(PhoneTabCardBuilder.previewPageNumber(for: webTab) == nil)
+        #expect(PhoneTabCardBuilder.thumbnailPath(for: webTab) == nil)
 
         #expect(PhoneTabCardBuilder.pageLabel(for: tab(id: "3", document: nil)) == nil)
     }
@@ -194,6 +218,35 @@ struct PhoneTabCardTests {
         #expect(cards.allSatisfy { !$0.isResident })
     }
 
+    @Test("Tab card labels grow rather than staying tiny at accessibility sizes")
+    func cardLabelsRespondToDynamicType() throws {
+        let card = try #require(
+            PhoneTabCardBuilder.cards(
+                tabs: [tab(
+                    id: "dynamic-type",
+                    document: pdf(
+                        path: "/docs/a-long-source-name.pdf",
+                        title: "A deliberately long document title for layout"))],
+                activeTabId: "dynamic-type",
+                isResident: { _ in false })
+                .first)
+
+        let normal = cardHeight(card, dynamicTypeSize: .large)
+        let accessible = cardHeight(card, dynamicTypeSize: .accessibility5)
+        #expect(
+            accessible > normal,
+            "tab card labels are not responding to the user's Dynamic Type setting")
+    }
+
+    @Test("Accessibility text switches the tab grid to one readable column")
+    func accessibilityLayoutUsesOneColumn() {
+        #expect(PhoneTabSwitcherLayout.columnCount(for: .large) == 2)
+        #expect(PhoneTabSwitcherLayout.columnCount(for: .accessibility1) == 1)
+        #expect(PhoneTabSwitcherLayout.columnCount(for: .accessibility5) == 1)
+        #expect(PhoneTabSwitcherLayout.accessibilityPreviewHeight <= 160)
+        #expect(PhoneTabSwitcherLayout.minimumBarHeight >= PhoneChromeLayout.buttonSide)
+    }
+
     // MARK: - Fixtures
 
     private func tab(id: String, document: DocumentInfo?) -> PdfTab {
@@ -215,6 +268,26 @@ struct PhoneTabCardTests {
 
     private func web(url: String, title: String? = nil) -> DocumentInfo {
         DocumentInfo(kind: .web, pdfPath: url, title: title, pageCount: nil, lastPage: nil)
+    }
+
+    private func cardHeight(
+        _ card: PhoneTabCard,
+        dynamicTypeSize: DynamicTypeSize
+    ) -> CGFloat {
+        let width: CGFloat = 336
+        let host = UIHostingController(
+            rootView: PhoneTabCardView(
+                card: card,
+                palette: .light,
+                thumbnailRevision: 0,
+                loadThumbnail: { nil },
+                open: {},
+                close: {})
+                .dynamicTypeSize(dynamicTypeSize))
+        host.view.frame = CGRect(x: 0, y: 0, width: width, height: .greatestFiniteMagnitude)
+        return host.sizeThatFits(
+            in: CGSize(width: width, height: UIView.layoutFittingCompressedSize.height)
+        ).height
     }
 }
 #endif

--- a/Tests/SettingsNavigationTests.swift
+++ b/Tests/SettingsNavigationTests.swift
@@ -20,6 +20,15 @@ final class SettingsNavigationTests: XCTestCase {
         XCTAssertEqual(workspace.settingsSection, .storage)
     }
 
+    #if os(iOS)
+    func testPhoneSettingsRoutesStorageAndIntegrationsThroughActionableMoreRows() {
+        XCTAssertEqual(SettingsPhoneTab(section: .storage), .more)
+        XCTAssertEqual(SettingsPhoneTab(section: .integrations), .more)
+        XCTAssertEqual(SettingsNavigationDestination(section: .storage), .storage)
+        XCTAssertEqual(SettingsNavigationDestination(section: .integrations), .integrations)
+    }
+    #endif
+
     // One group from main's copy of this file is deliberately absent.
     //
     // `testUpdateCheckerIsWorkspaceOwnedAndAutomaticCheckIsClaimedOnce` is a

--- a/Tests/WalkthroughLayoutTests.swift
+++ b/Tests/WalkthroughLayoutTests.swift
@@ -1,5 +1,5 @@
-import UIKit
 import SwiftUI
+import UIKit
 import XCTest
 
 @testable import Vellum
@@ -9,9 +9,8 @@ import XCTest
 // The sheet sizes itself to its tallest page and scrolls if it ever cannot, but
 // both of those are easy to undo by accident — pinning the frame back to a
 // constant, or adding copy that pushes the tallest page past the maxHeight
-// backstop. The invariant that actually matters to a reader is simply that no
-// page's content is taller than the space the sheet gives it, because anything
-// that does not fit is silently cut off rather than announced.
+// backstop. At the default text size every page should fit without scrolling;
+// at accessibility sizes the sheet stays bounded and its page area scrolls.
 //
 // Both sides are measured for real, off-screen: a UIHostingController that is
 // never added to a window is never visible and never takes focus, so this runs
@@ -20,8 +19,8 @@ import XCTest
 // re-derives a height from padding and font constants — an earlier version of
 // this file mirrored a dozen of them, and the moment the title bar gained a
 // close button the mirror was two points wrong and the test failed pointing at
-// the copy rather than at the chrome. The sheet now names its own geometry
-// (`WalkthroughSheet_iOS.chromeHeight` and friends) and the page body is a real
+// the copy rather than at the chrome. The sheet now names its minimum chrome
+// geometry and the page body is a real
 // view (`WalkthroughPageBody`) that can be hosted directly, so there is exactly
 // one definition of every number involved.
 @MainActor
@@ -72,24 +71,39 @@ final class WalkthroughLayoutTests: XCTestCase {
         measure(
             WalkthroughSheet_iOS()
                 .environment(\.palette, .light)
-                .tint(ThemePalette.light.primary),
+                .tint(ThemePalette.light.primary)
+                .dynamicTypeSize(.large),
             width: WalkthroughSheet_iOS.sheetWidth)
     }
 
-    /// Vertical space the sheet actually hands the page body.
+    /// Vertical space available before the scrolling backstop is needed at the
+    /// default text size. The chrome may grow at accessibility sizes; overflow
+    /// then remains inside `pageContent`'s ScrollView.
     private func availableHeight() -> CGFloat {
-        measuredSheetHeight() - WalkthroughSheet_iOS.chromeHeight
+        WalkthroughSheet_iOS.maxSheetHeight - minimumChromeHeight
+    }
+
+    private var minimumChromeHeight: CGFloat {
+        WalkthroughSheet_iOS.minimumTitleBarHeight
+            + WalkthroughSheet_iOS.minimumFooterHeight
+            + WalkthroughSheet_iOS.dividerHeight * 2
     }
 
     /// Height one page's real content needs at the sheet's width, wrapped by
     /// SwiftUI rather than approximated.
-    private func requiredHeight(of page: WalkthroughPage) -> CGFloat {
-        measure(
+    private func requiredHeight(
+        of page: WalkthroughPage,
+        width: CGFloat? = nil,
+        dynamicTypeSize: DynamicTypeSize = .large
+    ) -> CGFloat {
+        let width = width ?? pageWidth
+        return measure(
             WalkthroughPageBody(page: page)
                 .environment(\.palette, .light)
                 .tint(ThemePalette.light.primary)
-                .frame(width: pageWidth),
-            width: pageWidth)
+                .dynamicTypeSize(dynamicTypeSize)
+                .frame(width: width),
+            width: width)
     }
 
     private func tallestPage() -> (id: String, height: CGFloat) {
@@ -121,14 +135,14 @@ final class WalkthroughLayoutTests: XCTestCase {
     /// copy disagree — which is the state the original fixed 460pt frame was in.
     func testSheetHeightTracksTheTallestPage() {
         let tallest = tallestPage()
-        let expected = tallest.height + WalkthroughSheet_iOS.chromeHeight
+        let expected = tallest.height + minimumChromeHeight
         let measured = measuredSheetHeight()
 
         XCTAssertEqual(
             measured, expected, accuracy: 1,
             """
             The sheet resolved to \(Int(measured))pt but its tallest page ("\(tallest.id)", \
-            \(Int(tallest.height))pt) plus \(Int(WalkthroughSheet_iOS.chromeHeight))pt of chrome \
+            \(Int(tallest.height))pt) plus \(Int(minimumChromeHeight))pt of chrome \
             wants \(Int(expected))pt. The sheet should size to its content, not to a constant.
             """)
     }
@@ -139,24 +153,23 @@ final class WalkthroughLayoutTests: XCTestCase {
     func testTallestPageFitsUnderTheBackstopWithoutScrolling() {
         let tallest = tallestPage()
         XCTAssertLessThan(
-            tallest.height + WalkthroughSheet_iOS.chromeHeight, WalkthroughSheet_iOS.maxSheetHeight,
+            tallest.height + minimumChromeHeight, WalkthroughSheet_iOS.maxSheetHeight,
             """
             The tallest page ("\(tallest.id)") plus chrome now needs \
-            \(Int(tallest.height + WalkthroughSheet_iOS.chromeHeight))pt, at or past the \
+            \(Int(tallest.height + minimumChromeHeight))pt, at or past the \
             \(Int(WalkthroughSheet_iOS.maxSheetHeight))pt backstop, so the walkthrough would open \
             already scrolling. Shorten the copy or raise the backstop deliberately.
             """)
     }
 
-    /// The chrome bars are pinned, not intrinsically sized, so the space left
-    /// for a page is exactly derivable. If someone swaps a `.frame(height:)`
-    /// back for padding, the page area silently changes size and the two tests
-    /// above start failing for a reason that points at the wrong file.
+    /// At the default text size both adaptive bars should settle at their named
+    /// minimums. Accessibility sizes are allowed to grow them and are covered
+    /// separately below.
     func testChromeHeightIsTheSheetMinusItsTallestPage() {
         let tallest = tallestPage()
         XCTAssertEqual(
             measuredSheetHeight() - tallest.height,
-            WalkthroughSheet_iOS.chromeHeight,
+            minimumChromeHeight,
             accuracy: 1,
             "the title bar and footer no longer measure their declared heights")
     }
@@ -179,5 +192,46 @@ final class WalkthroughLayoutTests: XCTestCase {
             measured.width,
             phoneWidth + 0.5,
             "the only allowed overage is one physical-pixel rounding step")
+    }
+
+    func testLargestAccessibilitySizeStaysInsideAPhoneAndScrollsItsPageArea() {
+        let phoneSize = CGSize(width: 368, height: 640)
+        let host = UIHostingController(
+            rootView: WalkthroughSheet_iOS()
+                .environment(\.palette, .light)
+                .tint(ThemePalette.light.primary)
+                .dynamicTypeSize(.accessibility5))
+        host.view.frame = CGRect(origin: .zero, size: phoneSize)
+        let measured = host.sizeThatFits(in: phoneSize)
+
+        XCTAssertLessThanOrEqual(measured.width, phoneSize.width + 0.5)
+        XCTAssertLessThanOrEqual(measured.height, phoneSize.height + 0.5)
+
+        let page = WalkthroughPage.all[0]
+        let normal = requiredHeight(of: page, width: phoneSize.width, dynamicTypeSize: .large)
+        let accessible = requiredHeight(
+            of: page, width: phoneSize.width, dynamicTypeSize: .accessibility5)
+        XCTAssertGreaterThan(
+            accessible, normal,
+            "walkthrough copy is not responding to the user's Dynamic Type setting")
+    }
+
+    func testCompactLandscapeKeepsPersistentChromeInsideTheScreen() {
+        let landscapeSize = CGSize(width: 720, height: 320)
+        let host = UIHostingController(
+            rootView: WalkthroughSheet_iOS()
+                .environment(\.palette, .light)
+                .environment(\.verticalSizeClass, .compact)
+                .tint(ThemePalette.light.primary)
+                .dynamicTypeSize(.large))
+        host.view.frame = CGRect(origin: .zero, size: landscapeSize)
+
+        let measured = host.sizeThatFits(in: landscapeSize)
+        XCTAssertLessThanOrEqual(measured.width, landscapeSize.width + 0.5)
+        XCTAssertLessThanOrEqual(measured.height, landscapeSize.height + 0.5)
+    }
+
+    func testEveryWalkthroughControlKeepsTheTouchTargetFloor() {
+        XCTAssertGreaterThanOrEqual(WalkthroughSheet_iOS.controlSide, 44)
     }
 }

--- a/Vellum/Platform/iOS/AiPanel_iOS.swift
+++ b/Vellum/Platform/iOS/AiPanel_iOS.swift
@@ -201,7 +201,7 @@ struct AiPanel_iOS: View {
                 .font(.system(size: 15))
                 .foregroundStyle(active ? palette.primary : palette.mutedForeground)
                 .opacity(disabled ? 0.4 : 1)
-                .frame(width: 36, height: 36)
+                .frame(width: 48, height: 48)
                 .background {
                     if active { Circle().fill(palette.primary.opacity(0.16)) }
                 }
@@ -761,18 +761,17 @@ struct AiPanel_iOS: View {
                     perform: handleAttachmentDrop
                 )
 
-            Button(action: submit) {
-                Image(systemName: "paperplane.fill")
-                    .font(.system(size: 15))
-                    .frame(width: 40, height: 40)
-                    .background(.tint, in: RoundedRectangle(cornerRadius: Radius.lg))
-                    .foregroundStyle(palette.primaryForeground)
-            }
-            .buttonStyle(.plain)
-            .disabled(!canSend)
-            .opacity(canSend ? 1 : 0.4)
-            .accessibilityLabel("Send message")
-            .accessibilityIdentifier("aiPanel.send")
+            Button("Send message", systemImage: "paperplane.fill", action: submit)
+                .labelStyle(.iconOnly)
+                .font(.system(size: 15))
+                .frame(width: 48, height: 48)
+                .background(.tint, in: RoundedRectangle(cornerRadius: Radius.lg))
+                .foregroundStyle(palette.primaryForeground)
+                .buttonStyle(.plain)
+                .disabled(!canSend)
+                .opacity(canSend ? 1 : 0.4)
+                .accessibilityLabel("Send message")
+                .accessibilityIdentifier("aiPanel.send")
         }
     }
 
@@ -817,7 +816,7 @@ struct AiPanel_iOS: View {
             Image(systemName: "plus")
                 .font(.system(size: 15))
                 .foregroundStyle(palette.mutedForeground)
-                .frame(width: 40, height: 40)
+                .frame(width: 48, height: 48)
                 .contentShape(RoundedRectangle(cornerRadius: Radius.md))
         }
         .menuStyle(.button)

--- a/Vellum/Platform/iOS/ChromeTapCatcher_iOS.swift
+++ b/Vellum/Platform/iOS/ChromeTapCatcher_iOS.swift
@@ -1,35 +1,288 @@
 #if os(iOS)
 import SwiftUI
+import UIKit
 
-/// The explicit way back from immersive reading.
+/// A normalized direct document interaction from PDFKit/WebKit. Scroll changes
+/// are accepted only while the native pan is active, so programmatic offsets
+/// never produce one; taps come from a simultaneous, non-cancelling recognizer.
+enum ReaderChromeScrollEvent {
+    case tapped(sourceInteractionBlocked: Bool)
+    case began(sourceInteractionBlocked: Bool)
+    case changed(deltaY: CGFloat, sourceInteractionBlocked: Bool)
+    /// A normal finger lift. Policy progress survives so short direct pans can
+    /// accumulate toward the same threshold.
+    case ended
+    /// Invalidates accumulated travel (pinch, horizontal pan, or bounce).
+    case reset
+}
+
+/// The optional phone-shell callback carried through the SwiftUI environment.
+/// It is absent under the iPad shell, so the shared viewers retain their
+/// existing behavior without an idiom check or a second viewer implementation.
+struct ReaderChromeScrollAction: @unchecked Sendable {
+    var handler: (@MainActor (ReaderChromeScrollEvent) -> Void)?
+
+    @MainActor
+    func callAsFunction(_ event: ReaderChromeScrollEvent) {
+        handler?(event)
+    }
+}
+
+private struct ReaderChromeScrollActionKey: EnvironmentKey {
+    static let defaultValue = ReaderChromeScrollAction()
+}
+
+extension EnvironmentValues {
+    var readerChromeScrollAction: ReaderChromeScrollAction {
+        get { self[ReaderChromeScrollActionKey.self] }
+        set { self[ReaderChromeScrollActionKey.self] = newValue }
+    }
+}
+
+/// Persistent preference shared by the Settings toggle and the phone shell.
+enum ReaderControlPreferences {
+    static let alwaysShowReaderControlsKey = "alwaysShowReaderControls"
+}
+
+/// Observes the native scroll view's own pan and adds the phone reader's
+/// non-cancelling single-tap recognizer. The tap recognizes simultaneously with
+/// document gestures and waits for native multi-taps to fail, so double-tap
+/// zoom still wins; links and selection receive the same touch even though a
+/// completed single tap now also toggles the reader bars.
 ///
-/// This replaces the old window-wide single-tap recognizer. A reader tap is
-/// already meaningful to PDFKit and WebKit (links, selection, zoom and focus),
-/// so it must never carry a second, unrelated chrome action. A small trailing
-/// handle is discoverable, has one unambiguous result, and stays clear of both
-/// vertical scrolling and the system's bottom-edge Home gesture.
-struct ChromeRevealControl_iOS: View {
-    var isActive: Bool
-    var chromeVisible: Bool
-    var action: () -> Void
+/// Content-offset KVO supplies movement only while that native pan is actively
+/// `.began`/`.changed`. This avoids PDFKit target-order differences while still
+/// excluding deceleration, restored positions, page/annotation jumps, Find
+/// results, and every other app-driven offset change.
+@MainActor
+final class ReaderChromeNativeScrollObserver: NSObject, UIGestureRecognizerDelegate {
+    private weak var scrollView: UIScrollView?
+    private var tapRecognizer: UITapGestureRecognizer?
+    private var tapSourceInteractionBlocked = false
+    private var action = ReaderChromeScrollAction()
+    private var sourceInteractionBlocked: @MainActor () -> Bool = { false }
+    private var previousOffset = CGPoint.zero
+    private var previousTranslation = CGPoint.zero
+    private var suppressUntilNextPan = false
+    private var panIsActive = false
+    private var offsetObservation: NSKeyValueObservation?
 
-    var body: some View {
-        if isActive && !chromeVisible {
-            Button("Show reader controls", systemImage: "slider.horizontal.3", action: action)
-                .labelStyle(.iconOnly)
-                .font(.title3.weight(.medium))
-                .frame(
-                    width: PhoneChromeLayout.buttonSide,
-                    height: PhoneChromeLayout.buttonSide)
-                .foregroundStyle(.primary)
-                .glassEffect(.regular, in: .capsule)
-                .contentShape(Rectangle())
-                .buttonStyle(.plain)
-                .accessibilityLabel("Show reader controls")
-                .accessibilityIdentifier("phone.reader.showChrome")
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
-                .padding(.trailing, PhoneChromeLayout.edgeInset)
+    func configure(
+        scrollView: UIScrollView,
+        action: ReaderChromeScrollAction,
+        sourceInteractionBlocked: @escaping @MainActor () -> Bool
+    ) {
+        self.action = action
+        self.sourceInteractionBlocked = sourceInteractionBlocked
+        // The iPad shell leaves the environment action empty. Do not even add
+        // a target there: shared viewer behavior stays byte-for-byte native.
+        guard action.handler != nil else {
+            detach()
+            return
         }
+        if self.scrollView === scrollView { return }
+        detach()
+        self.scrollView = scrollView
+        scrollView.panGestureRecognizer.addTarget(self, action: #selector(panChanged(_:)))
+        scrollView.pinchGestureRecognizer?.addTarget(self, action: #selector(pinchChanged(_:)))
+        installTapRecognizer(on: scrollView)
+        offsetObservation = scrollView.observe(\.contentOffset, options: [.new]) {
+            [weak self] scrollView, _ in
+            MainActor.assumeIsolated {
+                self?.contentOffsetChanged(in: scrollView)
+            }
+        }
+    }
+
+    func detach() {
+        scrollView?.panGestureRecognizer.removeTarget(self, action: #selector(panChanged(_:)))
+        scrollView?.pinchGestureRecognizer?.removeTarget(self, action: #selector(pinchChanged(_:)))
+        if let tapRecognizer {
+            tapRecognizer.view?.removeGestureRecognizer(tapRecognizer)
+        }
+        tapRecognizer = nil
+        tapSourceInteractionBlocked = false
+        offsetObservation?.invalidate()
+        offsetObservation = nil
+        scrollView = nil
+        panIsActive = false
+        // Viewer teardown is lifecycle, not document movement. The shell owns
+        // navigation resets; an inactive tab must never reset the active tab's
+        // in-flight policy state.
+    }
+
+    private func installTapRecognizer(on scrollView: UIScrollView) {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(documentTapped(_:)))
+        tap.cancelsTouchesInView = false
+        tap.delaysTouchesBegan = false
+        tap.delaysTouchesEnded = false
+        tap.delegate = self
+        scrollView.addGestureRecognizer(tap)
+        tapRecognizer = tap
+    }
+
+    @objc private func documentTapped(_ tap: UITapGestureRecognizer) {
+        guard tap.state == .ended else { return }
+        action(.tapped(sourceInteractionBlocked: tapSourceInteractionBlocked))
+        tapSourceInteractionBlocked = false
+    }
+
+    /// Snapshot interaction state before PDFKit/WebKit receives the touch.
+    /// Their own simultaneous tap handlers can clear a selection before our
+    /// recognizer reaches `.ended`; using the end-state would let that same
+    /// selection-dismissal tap also hide the reader bars.
+    nonisolated func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive touch: UITouch
+    ) -> Bool {
+        MainActor.assumeIsolated {
+            tapSourceInteractionBlocked = sourceInteractionBlocked()
+        }
+        return true
+    }
+
+    nonisolated func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        true
+    }
+
+    /// UIKit asks this dynamically when recognizers compete, including native
+    /// recognizers installed lazily or attached above the scroll view. Waiting
+    /// for every same-finger-count multi-tap prevents a double-tap zoom or word
+    /// selection from also completing our single-tap chrome toggle.
+    nonisolated func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        MainActor.assumeIsolated {
+            guard let tap = gestureRecognizer as? UITapGestureRecognizer,
+                  let competingTap = otherGestureRecognizer as? UITapGestureRecognizer
+            else { return false }
+            return tap.numberOfTouchesRequired == competingTap.numberOfTouchesRequired
+                && competingTap.numberOfTapsRequired > tap.numberOfTapsRequired
+        }
+    }
+
+    /// A centered pinch can change zoom without moving contentOffset or starting
+    /// the scroll view's pan recognizer. Listen to the pinch directly so it
+    /// always invalidates partial reading travel from an earlier short pan.
+    @objc private func pinchChanged(_ pinch: UIPinchGestureRecognizer) {
+        guard pinch.state == .began else { return }
+        suppressUntilNextPan = true
+        action(.reset)
+    }
+
+    @objc private func panChanged(_ pan: UIPanGestureRecognizer) {
+        guard let scrollView else { return }
+
+        switch pan.state {
+        case .began:
+            suppressUntilNextPan = false
+            panIsActive = true
+            previousOffset = scrollView.contentOffset
+            previousTranslation = pan.translation(in: scrollView)
+            action(.began(sourceInteractionBlocked: sourceInteractionBlocked()))
+
+        case .changed:
+            // Movement is sampled by content-offset KVO below. PDFKit can run
+            // added pan targets before applying its offset; KVO always runs
+            // after the offset has actually changed. Invalidation cannot wait
+            // for KVO, though: a horizontal pan may move no contentOffset at
+            // all, and must still clear travel left by an earlier short pan.
+            let translation = pan.translation(in: scrollView)
+            let fingerDelta = CGPoint(
+                x: translation.x - previousTranslation.x,
+                y: translation.y - previousTranslation.y)
+            if !suppressUntilNextPan,
+               (scrollView.isZooming || isPinching(scrollView)
+                || abs(fingerDelta.x) > abs(fingerDelta.y)) {
+                suppressCurrentPan()
+            }
+
+        case .ended:
+            panIsActive = false
+            action(.ended)
+
+        case .cancelled, .failed:
+            panIsActive = false
+            action(.reset)
+
+        case .possible:
+            break
+
+        @unknown default:
+            panIsActive = false
+            action(.reset)
+        }
+    }
+
+    private func contentOffsetChanged(in scrollView: UIScrollView) {
+        let pan = scrollView.panGestureRecognizer
+        guard panIsActive,
+              !suppressUntilNextPan,
+              pan.state == .began || pan.state == .changed else { return }
+
+        let offset = scrollView.contentOffset
+        let translation = pan.translation(in: scrollView)
+        defer {
+            previousOffset = offset
+            previousTranslation = translation
+        }
+
+        // A pinch can move contentOffset as PDFKit/WebKit keeps the focal point
+        // under the fingers. It is zoom geometry, not reading travel.
+        if scrollView.isZooming || isPinching(scrollView) {
+            suppressCurrentPan()
+            return
+        }
+
+        let fingerDelta = CGPoint(
+            x: translation.x - previousTranslation.x,
+            y: translation.y - previousTranslation.y)
+        // Horizontal pans can carry a small vertical wobble. Reject the whole
+        // pan whenever horizontal finger travel dominates a moving sample.
+        guard abs(fingerDelta.y) >= abs(fingerDelta.x) else {
+            suppressCurrentPan()
+            return
+        }
+
+        let deltaY = offset.y - previousOffset.y
+        guard abs(deltaY) > 0.01,
+              isInsideScrollableRange(previousOffset.y, in: scrollView),
+              isInsideScrollableRange(offset.y, in: scrollView)
+        else {
+            if !isInsideScrollableRange(offset.y, in: scrollView) {
+                suppressCurrentPan()
+            }
+            return
+        }
+
+        action(.changed(
+            deltaY: deltaY,
+            sourceInteractionBlocked: sourceInteractionBlocked()))
+    }
+
+    private func suppressCurrentPan() {
+        suppressUntilNextPan = true
+        action(.reset)
+    }
+
+    private func isPinching(_ scrollView: UIScrollView) -> Bool {
+        guard let state = scrollView.pinchGestureRecognizer?.state else { return false }
+        return state == .began || state == .changed
+    }
+
+    private func isInsideScrollableRange(_ offsetY: CGFloat, in scrollView: UIScrollView) -> Bool {
+        let minimum = -scrollView.adjustedContentInset.top
+        let maximum = max(
+            minimum,
+            scrollView.contentSize.height - scrollView.bounds.height
+                + scrollView.adjustedContentInset.bottom)
+        // Half a point absorbs PDFKit/WebKit's subpixel settling at the edge
+        // without admitting visible rubber-band movement.
+        return offsetY >= minimum - 0.5 && offsetY <= maximum + 0.5
     }
 }
 #endif

--- a/Vellum/Platform/iOS/ChromeTapCatcher_iOS.swift
+++ b/Vellum/Platform/iOS/ChromeTapCatcher_iOS.swift
@@ -1,175 +1,35 @@
 #if os(iOS)
-import PDFKit
 import SwiftUI
-import UIKit
 
-/// Tap-to-toggle for the phone reader's immersive mode (#153 P5).
+/// The explicit way back from immersive reading.
 ///
-/// ## Why this is UIKit and not `.simultaneousGesture(TapGesture())`
-///
-/// The reader hosts a `PDFView` (or a `WKWebView`), each of which brings its own
-/// recognizers: single-tap for selection dismissal and link activation,
-/// double-tap for zoom, long-press for the selection loupe. A SwiftUI
-/// `simultaneousGesture` attached above them competes for those touches — most
-/// visibly with PDFKit's double-tap zoom, where the first tap of a double-tap
-/// toggles the chrome before the second arrives, so a zoom gesture flashes the
-/// toolbar. The prototype did exactly that; it is not what ships.
-///
-/// So this is modelled on `PaneFocusUIView` (`PaneView_iOS.swift`), the same
-/// trick the iPad uses to notice a touch without consuming it:
-///
-///   * the recognizer is installed on the **window**, not on this view, so this
-///     view can stay `isUserInteractionEnabled = false` and never sit between
-///     the reader's finger and the document. A view that hit-tested would have
-///     to swallow the touch to see it;
-///   * `cancelsTouchesInView = false` and `delaysTouchesBegan/Ended = false`, so
-///     every other recognizer and every hosted control still receives the same
-///     touch, on time;
-///   * the delegate recognizes simultaneously with everything;
-///   * and it explicitly `require(toFail:)`s any multi-tap recognizer found on
-///     a hosted `PDFView`, which is the one relationship that cannot be
-///     expressed by permissiveness alone: without it, tap #1 of a double-tap
-///     fires this before PDFKit's zoom recognizer has had its chance.
-///
-/// The view itself is only a geometry probe: it reports the reader's bounds and
-/// safe-area insets so the tap can be attributed.
-struct ChromeTapCatcher_iOS: UIViewRepresentable {
-    /// Whether taps should toggle at all. False while the reader is not the
-    /// route on screen or a full-screen presentation is over it.
+/// This replaces the old window-wide single-tap recognizer. A reader tap is
+/// already meaningful to PDFKit and WebKit (links, selection, zoom and focus),
+/// so it must never carry a second, unrelated chrome action. A small trailing
+/// handle is discoverable, has one unambiguous result, and stays clear of both
+/// vertical scrolling and the system's bottom-edge Home gesture.
+struct ChromeRevealControl_iOS: View {
     var isActive: Bool
-    /// Whether the chrome is currently showing — decides whether the bar bands
-    /// below are live.
     var chromeVisible: Bool
     var action: () -> Void
 
-    func makeUIView(context: Context) -> ChromeTapCatcherUIView {
-        ChromeTapCatcherUIView(action: action, isActive: isActive, chromeVisible: chromeVisible)
-    }
-
-    func updateUIView(_ uiView: ChromeTapCatcherUIView, context: Context) {
-        uiView.action = action
-        uiView.isActive = isActive
-        uiView.chromeVisible = chromeVisible
-        // The hosted PDFView is created after this view is (the live-tab stack
-        // builds a host per tab, and a warm tab re-parents), so the failure
-        // requirement cannot be a one-shot at `didMoveToWindow`.
-        uiView.linkToContentDoubleTaps()
-    }
-}
-
-final class ChromeTapCatcherUIView: UIView, UIGestureRecognizerDelegate {
-    var action: () -> Void
-    var isActive: Bool
-    var chromeVisible: Bool
-
-    private var recognizer: UITapGestureRecognizer?
-    /// Recognizers already made to precede ours. Identity-keyed so re-running
-    /// the link pass is idempotent and does not rebuild the relationships on
-    /// every SwiftUI update.
-    private var linked = Set<ObjectIdentifier>()
-
-    init(action: @escaping () -> Void, isActive: Bool, chromeVisible: Bool) {
-        self.action = action
-        self.isActive = isActive
-        self.chromeVisible = chromeVisible
-        super.init(frame: .zero)
-        // Never in the touch path: the recognizer lives on the window and this
-        // view exists to be measured, not to be hit.
-        isUserInteractionEnabled = false
-        backgroundColor = .clear
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
-        if let recognizer {
-            recognizer.view?.removeGestureRecognizer(recognizer)
-            self.recognizer = nil
-            linked.removeAll()
+    var body: some View {
+        if isActive && !chromeVisible {
+            Button("Show reader controls", systemImage: "slider.horizontal.3", action: action)
+                .labelStyle(.iconOnly)
+                .font(.title3.weight(.medium))
+                .frame(
+                    width: PhoneChromeLayout.buttonSide,
+                    height: PhoneChromeLayout.buttonSide)
+                .foregroundStyle(.primary)
+                .glassEffect(.regular, in: .capsule)
+                .contentShape(Rectangle())
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show reader controls")
+                .accessibilityIdentifier("phone.reader.showChrome")
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
+                .padding(.trailing, PhoneChromeLayout.edgeInset)
         }
-        guard let window else { return }
-        let tap = UITapGestureRecognizer(target: self, action: #selector(tapped(_:)))
-        tap.numberOfTapsRequired = 1
-        tap.cancelsTouchesInView = false
-        tap.delaysTouchesBegan = false
-        tap.delaysTouchesEnded = false
-        tap.delegate = self
-        window.addGestureRecognizer(tap)
-        recognizer = tap
-        linkToContentDoubleTaps()
-    }
-
-    @objc private func tapped(_ gesture: UITapGestureRecognizer) {
-        guard gesture.state == .ended, isActive, window != nil else { return }
-        let location = gesture.location(in: self)
-        guard bounds.contains(location), !isInChromeBand(location) else { return }
-        action()
-    }
-
-    /// Whether a point lands where the chrome's bars are.
-    ///
-    /// The recognizer sees every tap in the window, including the ones a chrome
-    /// button is about to handle (`cancelsTouchesInView = false` cuts both
-    /// ways). Without this, tapping Bookmark would fire the bookmark AND hide
-    /// the chrome that contains it. Geometry rather than view-tree sniffing:
-    /// the bands come straight from `PhoneChromeLayout` plus the live safe-area
-    /// insets, so they cannot drift from the bars they describe, and they are
-    /// empty while the chrome is hidden — which is when a tap anywhere must
-    /// bring it back.
-    private func isInChromeBand(_ point: CGPoint) -> Bool {
-        guard chromeVisible else { return false }
-        let insets = safeAreaInsets
-        let topBand = insets.top + PhoneChromeLayout.barHeight
-        let bottomBand = bounds.height - insets.bottom - PhoneChromeLayout.barHeight
-        return point.y <= topBand || point.y >= bottomBand
-    }
-
-    /// Make our tap wait for — and lose to — any multi-tap recognizer on a
-    /// hosted `PDFView`. Idempotent; safe to call on every update.
-    func linkToContentDoubleTaps() {
-        guard let recognizer, let window else { return }
-        for candidate in Self.multiTapRecognizers(in: window) {
-            let key = ObjectIdentifier(candidate)
-            guard !linked.contains(key) else { continue }
-            linked.insert(key)
-            recognizer.require(toFail: candidate)
-        }
-    }
-
-    /// Every ≥2-tap recognizer attached to a `PDFView` in this hierarchy —
-    /// PDFKit's zoom gesture lives on the view's internal scroll view, not on
-    /// the `PDFView` itself, so the walk goes all the way down rather than
-    /// reading `pdfView.gestureRecognizers`.
-    private static func multiTapRecognizers(in root: UIView) -> [UIGestureRecognizer] {
-        var found: [UIGestureRecognizer] = []
-        var stack: [(view: UIView, insidePdf: Bool)] = [(root, root is PDFView)]
-        while let (view, insidePdf) = stack.popLast() {
-            if insidePdf {
-                for gesture in view.gestureRecognizers ?? [] {
-                    guard let tap = gesture as? UITapGestureRecognizer,
-                          tap.numberOfTapsRequired >= 2 else { continue }
-                    found.append(tap)
-                }
-            }
-            for subview in view.subviews {
-                stack.append((subview, insidePdf || subview is PDFView))
-            }
-        }
-        return found
-    }
-
-    // Recognize alongside everything: PDFKit's selection and link taps, WebKit's
-    // click synthesis, the scroll views' pans. This recognizer observes, it does
-    // not arbitrate.
-    func gestureRecognizer(
-        _ gestureRecognizer: UIGestureRecognizer,
-        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
-    ) -> Bool {
-        true
     }
 }
 #endif

--- a/Vellum/Platform/iOS/HelpCenterView_iOS.swift
+++ b/Vellum/Platform/iOS/HelpCenterView_iOS.swift
@@ -69,7 +69,7 @@ struct HelpCenterView_iOS: View {
                 // thing that would make the search feel slow.
                 LazyVStack(alignment: .leading, spacing: 10) {
                     ForEach(results) { topic in
-                        row(topic)
+                        HelpTopicRow_iOS(topic: topic)
                     }
                 }
                 .padding(20)
@@ -78,35 +78,54 @@ struct HelpCenterView_iOS: View {
         }
     }
 
-    private func row(_ topic: HelpTopic) -> some View {
+    private func openWalkthrough() {
+        pendingWalkthrough = true
+        dismiss()
+    }
+}
+
+/// A single measurable row so focused layout tests can verify that Help really
+/// grows with Dynamic Type without presenting the entire navigation sheet.
+struct HelpTopicRow_iOS: View {
+    let topic: HelpTopic
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: topic.symbol)
-                .font(.system(size: 14))
+                .font(.body)
                 .foregroundStyle(.tint)
                 // Same fixed gutter as the walkthrough's bullets, so titles
                 // line up down the list whatever each symbol's width is.
-                .frame(width: 18, alignment: .center)
+                .frame(minWidth: 24, alignment: .center)
                 .padding(.top, 1)
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(topic.title)
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(palette.foreground)
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        topicTitle(topic)
 
-                    if let shortcut = topic.shortcut {
-                        Keycap(keys: shortcut)
+                        if let shortcut = topic.shortcut {
+                            HelpKeycap(keys: shortcut)
+                        }
+
+                        Spacer(minLength: 0)
                     }
 
-                    Spacer(minLength: 0)
+                    VStack(alignment: .leading, spacing: 6) {
+                        topicTitle(topic)
+                        if let shortcut = topic.shortcut {
+                            HelpKeycap(keys: shortcut)
+                        }
+                    }
                 }
 
                 Text(topic.summary)
-                    .font(.system(size: 12))
+                    .font(.body)
                     .foregroundStyle(palette.mutedForeground)
                     .fixedSize(horizontal: false, vertical: true)
-                    .lineSpacing(2)
             }
         }
         .padding(14)
@@ -123,9 +142,35 @@ struct HelpCenterView_iOS: View {
         .accessibilityIdentifier("help.topic.\(topic.id)")
     }
 
-    private func openWalkthrough() {
-        pendingWalkthrough = true
-        dismiss()
+    private func topicTitle(_ topic: HelpTopic) -> some View {
+        Text(topic.title)
+            .font(.headline)
+            .foregroundStyle(palette.foreground)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// The shared keycap has a fixed desktop-oriented point size. Help uses this
+/// semantic version so the shortcut remains legible and can move under its
+/// title when accessibility text no longer fits on one line.
+private struct HelpKeycap: View {
+    let keys: String
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Text(keys)
+            .font(.caption.monospaced())
+            .foregroundStyle(palette.foreground)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(palette.muted, in: RoundedRectangle(cornerRadius: Radius.sm))
+            .overlay {
+                RoundedRectangle(cornerRadius: Radius.sm)
+                    .strokeBorder(palette.borderStrong)
+            }
+            .accessibilityElement()
+            .accessibilityLabel("Keyboard shortcut \(keys)")
     }
 }
 #endif

--- a/Vellum/Platform/iOS/HomeResultViews_iOS.swift
+++ b/Vellum/Platform/iOS/HomeResultViews_iOS.swift
@@ -74,6 +74,7 @@ struct HomeResultRow: View {
     let removals: [(removal: HomeSearchRemoval, action: () -> Void)]
 
     @Environment(\.palette) private var palette
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         Button(action: open) {
@@ -81,26 +82,42 @@ struct HomeResultRow: View {
                 icon
 
                 VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
+                    if dynamicTypeSize.isAccessibilitySize {
                         Text(item.title)
-                            .font(.system(size: 14, weight: .medium))
+                            .font(.subheadline.weight(.medium))
                             .foregroundStyle(palette.foreground)
-                            .lineLimit(1)
+                            .lineLimit(3)
                             .truncationMode(.middle)
                         HomeBadgeStrip(badges: item.badges)
+                    } else {
+                        HStack(spacing: 6) {
+                            Text(item.title)
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(palette.foreground)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            HomeBadgeStrip(badges: item.badges)
+                        }
                     }
                     Text(item.subtitle)
-                        .font(.system(size: 12))
+                        .font(.footnote)
                         .foregroundStyle(palette.mutedForeground)
-                        .lineLimit(1)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
                         .truncationMode(.middle)
+
+                    if dynamicTypeSize.isAccessibilitySize, !item.detail.isEmpty {
+                        Text(item.detail)
+                            .font(.footnote)
+                            .monospacedDigit()
+                            .foregroundStyle(palette.mutedForeground)
+                    }
                 }
 
                 Spacer(minLength: 12)
 
-                if !item.detail.isEmpty {
+                if !dynamicTypeSize.isAccessibilitySize, !item.detail.isEmpty {
                     Text(item.detail)
-                        .font(.system(size: 12))
+                        .font(.footnote)
                         .monospacedDigit()
                         .foregroundStyle(palette.mutedForeground)
                         .lineLimit(1)
@@ -197,7 +214,7 @@ struct HomeBadgeStrip: View {
     ) -> some View {
         if badges.contains(flag) {
             Image(systemName: symbol)
-                .font(.system(size: 10))
+                .font(.caption2)
                 .foregroundStyle(tint ?? palette.mutedForeground)
                 .accessibilityLabel(help)
         }
@@ -215,6 +232,7 @@ struct HomeLinkActionRow: View {
     let open: () -> Void
 
     @Environment(\.palette) private var palette
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         Button(action: open) {
@@ -229,12 +247,12 @@ struct HomeLinkActionRow: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Open this webpage")
-                        .font(.system(size: 14, weight: .medium))
+                        .font(.subheadline.weight(.medium))
                         .foregroundStyle(palette.foreground)
                     Text(url)
-                        .font(.system(size: 12))
+                        .font(.footnote)
                         .foregroundStyle(palette.mutedForeground)
-                        .lineLimit(1)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
                         .truncationMode(.middle)
                 }
 
@@ -244,8 +262,10 @@ struct HomeLinkActionRow: View {
                 // Hidden from VoiceOver: this row is a single button whose
                 // label already says what ↩ does, and `Keycap` would otherwise
                 // add a second "Keyboard shortcut" element inside it.
-                Keycap(keys: "↩")
-                    .accessibilityHidden(true)
+                if !dynamicTypeSize.isAccessibilitySize {
+                    Keycap(keys: "↩")
+                        .accessibilityHidden(true)
+                }
             }
             .padding(.horizontal, HomeLayout.rowInset)
             .padding(.vertical, 8)
@@ -272,13 +292,13 @@ struct HomeSectionHeader: View {
     var body: some View {
         HStack(spacing: 6) {
             Image(systemName: section.systemImage)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.caption.weight(.semibold))
             Text(section.title)
-                .font(.system(size: 11, weight: .semibold))
+                .font(.caption.weight(.semibold))
                 .textCase(.uppercase)
                 .kerning(0.4)
             Text("\(count)")
-                .font(.system(size: 11, weight: .medium))
+                .font(.caption.weight(.medium))
                 .monospacedDigit()
                 .foregroundStyle(palette.mutedForeground.opacity(0.7))
             Spacer(minLength: 0)
@@ -309,16 +329,18 @@ struct HomeFilterChip: View {
     var body: some View {
         Button(action: action) {
             Text(label)
-                .font(.system(size: 12, weight: .medium))
+                .font(.caption.weight(.medium))
                 .foregroundStyle(
                     SelectionStyle.foreground(palette, selected: isSelected, hovering: false))
-                .padding(.horizontal, 12)
-                // 26pt is a mouse target; 32 is the smallest that is honest on
-                // a touch screen without making the chip row look like buttons.
-                .frame(height: 32)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 7)
                 .selectionSurface(
                     selected: isSelected, hovering: false, in: Capsule(), palette: palette)
-                .contentShape(Capsule())
+                // The capsule stays visually compact; the transparent outer
+                // frame supplies the full touch target.
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)

--- a/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
+++ b/Vellum/Platform/iOS/InkOverlayProvider_iOS.swift
@@ -63,6 +63,16 @@ final class InkOverlayContainer_iOS: UIView {
     @available(*, unavailable)
     required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
 
+    /// PDFKit installs this container directly over the page. While ink mode is
+    /// off, `applyPolicy` disables the canvas so text selection belongs to the
+    /// PDFView underneath; a plain transparent UIView would still hit-test as
+    /// itself and swallow those page touches. Only return a descendant hit —
+    /// never the otherwise-empty wrapper.
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hit = super.hitTest(point, with: event)
+        return hit === self ? nil : hit
+    }
+
     override func layoutSubviews() {
         super.layoutSubviews()
         let k = max(canvas.superSample, 1)

--- a/Vellum/Platform/iOS/PdfChrome_iOS.swift
+++ b/Vellum/Platform/iOS/PdfChrome_iOS.swift
@@ -541,6 +541,7 @@ struct GlassToolButton: View {
     let label: String
     var active = false
     var tint: Color? = nil
+    var disabled = false
     let action: () -> Void
 
     @Environment(\.palette) private var palette
@@ -578,6 +579,8 @@ struct GlassToolButton: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(ToolbarPressStyle())
+        .disabled(disabled)
+        .opacity(disabled ? 0.35 : 1)
         .accessibilityLabel(label)
         .accessibilityAddTraits(active ? [.isButton, .isSelected] : .isButton)
     }
@@ -959,12 +962,22 @@ private struct TabOverview_iOS: View {
 // MARK: - Sidebar content (hosted by the adaptive inspector)
 
 struct SidebarContent_iOS: View {
+    enum Presentation: Equatable {
+        case column
+        case phoneSheet
+    }
+
     /// The focused pane's ink controller, from the registry — nil only in the
     /// instant before that pane has appeared, so the Handwriting section just
     /// skips rendering rather than holding a stale controller.
     var ink: InkController_iOS?
+    var presentation: Presentation = .column
+    var onTabSelected: ((WorkspaceStore.SidebarTab) -> Void)? = nil
 
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(AppStore.self) private var app
+    @Environment(AnnotationStore.self) private var annotations
+    @Environment(ScratchpadStore.self) private var scratchpad
     @Environment(\.palette) private var palette
 
     // "Has this tab ever been revealed?" latches. The sidebar is open by
@@ -991,11 +1004,12 @@ struct SidebarContent_iOS: View {
     @State private var hasShownScratchpad = false
 
     var body: some View {
+        let handwritingPages = pagesWithHandwriting()
         VStack(spacing: 0) {
-            InspectorTabSwitcher(selection: Binding(
-                get: { workspace.sidebarTab },
-                set: { workspace.sidebarTab = $0 }
-            ))
+            InspectorTabSwitcher(
+                selection: Binding(
+                    get: { workspace.sidebarTab },
+                    set: { selectTab($0) }))
             .padding(.horizontal, InspectorLayout.switcherHorizontalPadding)
             .padding(.vertical, InspectorLayout.switcherVerticalPadding)
             Divider()
@@ -1014,18 +1028,51 @@ struct SidebarContent_iOS: View {
             // bodies are what dragged WebKit and the AI renderer into launch.
             ZStack {
                 panel(.annotations) {
-                    VStack(spacing: 0) {
-                        if let ink {
-                            InkPagesSection_iOS(ink: ink)
+                    if presentation == .phoneSheet,
+                       annotations.annotations.isEmpty,
+                       handwritingPages.isEmpty {
+                        ContentUnavailableView {
+                            Label("No annotations yet", systemImage: "highlighter")
+                        } description: {
+                            Text("Select text to highlight it, or start a sticky note on the page.")
+                        } actions: {
+                            Button("Start a sticky note", systemImage: "note.text") {
+                                app.setMode(.note)
+                                workspace.setInspectorPresented(false)
+                            }
+                            .frame(minHeight: 44)
+                            .contentShape(Rectangle())
                         }
-                        AnnotationSidebar()
+                        .accessibilityIdentifier("phone.inspector.annotations.empty")
+                    } else {
+                        VStack(spacing: 0) {
+                            InkPagesSection_iOS(pages: handwritingPages)
+                            AnnotationSidebar()
+                        }
                     }
                 }
                 if hasShownAi {
                     panel(.ai) { AiPanel_iOS() }
                 }
                 if hasShownScratchpad {
-                    panel(.scratchpad) { ScratchpadPanel() }
+                    panel(.scratchpad) {
+                        ScratchpadPanel()
+                            .overlay {
+                                if presentation == .phoneSheet,
+                                   scratchpad.text.trimmingCharacters(
+                                    in: .whitespacesAndNewlines
+                                   ).isEmpty {
+                                    ContentUnavailableView(
+                                        "Start a scratchpad",
+                                        systemImage: "note.text",
+                                        description: Text(
+                                            "Tap anywhere to keep free-form notes with this document."
+                                        ))
+                                    .allowsHitTesting(false)
+                                    .accessibilityIdentifier("phone.inspector.scratchpad.empty")
+                                }
+                            }
+                    }
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -1047,6 +1094,44 @@ struct SidebarContent_iOS: View {
             }
         }
         .background(palette.surface)
+    }
+
+    /// Mounts a lazy panel in the same update that selects it, then forwards
+    /// the phone-specific selection action. This avoids a transient blank panel
+    /// and keeps tab selection independent from sheet presentation.
+    private func selectTab(_ tab: WorkspaceStore.SidebarTab) {
+        switch tab {
+        case .annotations:
+            break
+        case .ai:
+            hasShownAi = true
+        case .scratchpad:
+            hasShownScratchpad = true
+        }
+        if let onTabSelected {
+            onTabSelected(tab)
+        } else {
+            workspace.sidebarTab = tab
+        }
+    }
+
+    /// Derive the handwriting summary once per body evaluation. The previous
+    /// empty-state check and section each walked every PDF page independently.
+    private func pagesWithHandwriting() -> [Int] {
+        guard let ink,
+              app.document?.kind == .pdf,
+              let document = ink.pdfController?.document
+        else { return [] }
+
+        _ = ink.drawingVersion
+        return (0..<document.pageCount).compactMap { index in
+            let pageNumber = index + 1
+            if let hasStrokes = ink.inkProvider.cachedStrokes(forPage: pageNumber) {
+                return hasStrokes ? pageNumber : nil
+            }
+            guard let page = document.page(at: index) else { return nil }
+            return PdfInk.hasInk(on: page) ? pageNumber : nil
+        }
     }
 
     /// Wraps a sidebar panel so only the active tab is visible, hit-testable,
@@ -1071,34 +1156,16 @@ struct SidebarContent_iOS: View {
 /// as native /Ink in the PDF), so this section derives straight from the
 /// display document.
 private struct InkPagesSection_iOS: View {
-    var ink: InkController_iOS
+    var pages: [Int]
 
     @Environment(AppStore.self) private var appStore
     @Environment(\.palette) private var palette
 
-    private var pagesWithInk: [Int] {
-        // drawingVersion ties this computed list to live stroke edits.
-        _ = ink.drawingVersion
-        guard appStore.document?.kind == .pdf,
-              let document = ink.pdfController?.document else { return [] }
-        return (0..<document.pageCount).compactMap { index in
-            let pageNumber = index + 1
-            // A cached canvas is the live source of truth for its page; only fall
-            // back to the display document's native ink when no canvas exists yet.
-            if let hasStrokes = ink.inkProvider.cachedStrokes(forPage: pageNumber) {
-                return hasStrokes ? pageNumber : nil
-            }
-            guard let page = document.page(at: index) else { return nil }
-            return PdfInk.hasInk(on: page) ? pageNumber : nil
-        }
-    }
-
     var body: some View {
-        let pages = pagesWithInk
         if !pages.isEmpty {
             VStack(alignment: .leading, spacing: 4) {
                 Text("Handwriting")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.caption.bold())
                     .foregroundStyle(palette.mutedForeground)
                     .textCase(.uppercase)
                     .padding(.horizontal, 4)
@@ -1113,12 +1180,12 @@ private struct InkPagesSection_iOS: View {
                                         .font(.system(size: 11))
                                         .foregroundStyle(palette.primary)
                                     Text("p. \(page)")
-                                        .font(.system(size: 13, weight: .medium))
+                                        .font(.caption.weight(.medium))
                                         .monospacedDigit()
                                         .foregroundStyle(palette.foreground)
                                 }
                                 .padding(.horizontal, 12)
-                                .frame(height: 34)
+                                .frame(minWidth: 44, minHeight: 44)
                                 .background(palette.muted, in: Capsule())
                                 .overlay(Capsule().strokeBorder(palette.border))
                                 .contentShape(Capsule())

--- a/Vellum/Platform/iOS/PdfKitView_iOS.swift
+++ b/Vellum/Platform/iOS/PdfKitView_iOS.swift
@@ -176,6 +176,26 @@ final class VellumPDFView: PDFView, VellumShortcutResponder {
     }
 }
 
+/// Vellum's empty-page note recognizer participates in a failure relationship
+/// with PDFKit's native text-selection recognizers. Rejecting a text touch from
+/// `UIGestureRecognizerDelegate.shouldReceive` is not enough for that setup:
+/// the recognizer can remain `.possible`, leaving every native recognizer that
+/// requires it to fail waiting until the finger lifts. Failing synchronously in
+/// `touchesBegan` releases PDFKit immediately, so long-press-and-drag selection
+/// starts normally while empty-area presses still wait for the note gesture.
+private final class EmptyAreaLongPressRecognizer: UILongPressGestureRecognizer {
+    var shouldReceiveTouch: ((UITouch) -> Bool)?
+
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+        guard let touch = touches.first,
+              shouldReceiveTouch?(touch) ?? true else {
+            state = .failed
+            return
+        }
+        super.touchesBegan(touches, with: event)
+    }
+}
+
 struct PdfKitView_iOS: UIViewRepresentable {
     let controller: PdfViewerControlleriOS
     let document: PDFDocument
@@ -188,6 +208,7 @@ struct PdfKitView_iOS: UIViewRepresentable {
     @Environment(AppStore.self) private var app
     @Environment(WorkspaceStore.self) private var workspace
     @Environment(\.palette) private var palette
+    @Environment(\.readerChromeScrollAction) private var readerChromeScrollAction
     /// `.fitWidth` only under the compact phone shell; `.free` everywhere else,
     /// including an iPad in Slide Over. See `RootShell_iOS`.
     @Environment(\.pdfZoomMode) private var zoomMode
@@ -195,6 +216,8 @@ struct PdfKitView_iOS: UIViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator(controller: controller, ink: ink) }
 
     func makeUIView(context: Context) -> PDFView {
+        context.coordinator.updateChromeScrollAction(
+            isActive ? readerChromeScrollAction : ReaderChromeScrollAction())
         // Live tabs: the PDFView belongs to the tab's `LiveTabRuntime` and
         // outlives this host, so a remount (tab dragged to another pane, a warm
         // tab coming back, or two hosts transiently claiming one tab during
@@ -248,6 +271,8 @@ struct PdfKitView_iOS: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: PDFView, context: Context) {
+        context.coordinator.updateChromeScrollAction(
+            isActive ? readerChromeScrollAction : ReaderChromeScrollAction())
         uiView.backgroundColor = UIColor(palette.well)
         // Both of these also cover the adopted-view path in `makeUIView`, where
         // a tab that moved between panes or shells has to be told which pane's
@@ -301,10 +326,18 @@ struct PdfKitView_iOS: UIViewRepresentable {
         private weak var scrollView: UIScrollView?
         private var observers: [NSObjectProtocol] = []
         private var offsetObservation: NSKeyValueObservation?
+        private let chromeScrollObserver = ReaderChromeNativeScrollObserver()
+        private var readerChromeScrollAction = ReaderChromeScrollAction()
 
         init(controller: PdfViewerControlleriOS, ink: InkController_iOS) {
             self.controller = controller
             self.ink = ink
+        }
+
+        func updateChromeScrollAction(_ action: ReaderChromeScrollAction) {
+            readerChromeScrollAction = action
+            guard let scrollView else { return }
+            configureChromeObserver(for: scrollView)
         }
 
         func attach(to view: PDFView) {
@@ -319,13 +352,20 @@ struct PdfKitView_iOS: UIViewRepresentable {
             tap.delegate = self
             view.addGestureRecognizer(tap)
 
-            // Receives only empty-area presses (shouldReceive gate) and cancels
-            // the touch when it fires, so PDFView's native long-press can't
-            // snap-select the nearest word underneath the "Add note here" pill.
-            let longPress = UILongPressGestureRecognizer(target: self, action: #selector(longPressed(_:)))
+            // Receives only empty-area presses (the subclass fails immediately
+            // on text) and cancels the touch when it fires, so PDFView's native
+            // long-press can't snap-select the nearest word underneath the
+            // "Add note here" pill.
+            let longPress = EmptyAreaLongPressRecognizer(
+                target: self, action: #selector(longPressed(_:)))
             longPress.minimumPressDuration = 0.35
             longPress.cancelsTouchesInView = true
             longPress.delegate = self
+            longPress.shouldReceiveTouch = { [weak self, weak view] touch in
+                guard let self, let view else { return false }
+                return self.controller.isEmptyPageArea(
+                    atTopLeft: touch.location(in: view))
+            }
             view.addGestureRecognizer(longPress)
             noteLongPress = longPress
 
@@ -387,10 +427,12 @@ struct PdfKitView_iOS: UIViewRepresentable {
 
         private func observeScroll(_ scroll: UIScrollView) {
             scrollView = scroll
+            configureChromeObserver(for: scroll)
             // Make PDFKit's internal long-presses (nearest-word selection) wait
-            // for ours to fail. On text presses ours never receives the touch
-            // (shouldReceive gate) so natives run immediately; on empty-area
-            // presses ours recognizes and the natives stay blocked.
+            // for ours to fail. On text presses `EmptyAreaLongPressRecognizer`
+            // enters `.failed` synchronously from `touchesBegan`, releasing the
+            // native recognizers immediately; on empty-area presses ours
+            // recognizes and the natives stay blocked.
             // cancelsTouchesInView can't do this — touch cancellation stops
             // view delivery, not other gesture recognizers.
             if let ours = noteLongPress, let view {
@@ -404,6 +446,15 @@ struct PdfKitView_iOS: UIViewRepresentable {
                 }
             }
             controller.layoutChanged()
+        }
+
+        private func configureChromeObserver(for scroll: UIScrollView) {
+            chromeScrollObserver.configure(
+                scrollView: scroll,
+                action: readerChromeScrollAction,
+                sourceInteractionBlocked: { [weak self] in
+                    self?.controller.blocksAutomaticChromeChanges ?? true
+                })
         }
 
         private var noteLongPress: UILongPressGestureRecognizer?
@@ -450,24 +501,12 @@ struct PdfKitView_iOS: UIViewRepresentable {
             true
         }
 
-        nonisolated func gestureRecognizer(
-            _ gestureRecognizer: UIGestureRecognizer,
-            shouldReceive touch: UITouch
-        ) -> Bool {
-            // The long-press only takes empty-area touches; on/near text it
-            // must not receive at all so the native selection engages cleanly.
-            guard gestureRecognizer is UILongPressGestureRecognizer else { return true }
-            return MainActor.assumeIsolated {
-                guard let view = self.view else { return false }
-                return self.controller.isEmptyPageArea(atTopLeft: touch.location(in: view))
-            }
-        }
-
         func detach() {
             for observer in observers { NotificationCenter.default.removeObserver(observer) }
             observers = []
             offsetObservation?.invalidate()
             offsetObservation = nil
+            chromeScrollObserver.detach()
             // The PDFView is NOT released here. It belongs to the tab's
             // `LiveTabRuntime`, not to this host: nil'ing the controller's
             // reference on dismantle is what used to make every remount rebuild

--- a/Vellum/Platform/iOS/PdfViewerController_iOS.swift
+++ b/Vellum/Platform/iOS/PdfViewerController_iOS.swift
@@ -92,6 +92,13 @@ final class PdfViewerControlleriOS: HighlightResizeControlling {
 
     var isNoteMode: Bool { app?.mode == .note }
 
+    /// Native scrolling may dismiss these transient surfaces, but a pan that
+    /// STARTED as selection/note work must never also change phone chrome.
+    var blocksAutomaticChromeChanges: Bool {
+        guard let app, let tabId, app.activeTabId == tabId else { return true }
+        return selection != nil || contextMenu != nil || highlightResize != nil
+    }
+
     // MARK: - Lifecycle
 
     func adopt(

--- a/Vellum/Platform/iOS/PhoneHome_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneHome_iOS.swift
@@ -56,6 +56,7 @@ struct PhoneHome_iOS: View {
     @Environment(\.palette) private var palette
     @Environment(\.undoManager) private var undoManager
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @State private var actions: HomeLibraryActions_iOS
     @State private var continueReading: [ContinueReadingItem] = []
@@ -156,15 +157,17 @@ struct PhoneHome_iOS: View {
 
     // MARK: - Header
 
-    /// Wordmark plus the two things Home is the entry point for when no document
-    /// is open: the tab switcher and Settings. Help lives in the switcher-free
-    /// half of Settings' reach, so it is offered from the first-run hero and
-    /// from the reader's More menu (P5) rather than taking a third slot here.
+    /// Wordmark plus Home's persistent actions: Add PDF, the tab switcher when
+    /// documents are open, and Settings. Help stays in the first-run hero and
+    /// the reader's More menu (P5) rather than crowding this primary pod.
     private var header: some View {
         HStack(spacing: 8) {
             Wordmark(size: 30)
             Spacer(minLength: 12)
             GlassToolPod(label: "Library") {
+                GlassToolButton(system: "doc.badge.plus", label: "Add PDF", action: onOpen)
+                    .accessibilityIdentifier("phone.home.addPdf")
+
                 // Only when there is something to switch to. Home IS the
                 // no-documents state, so an always-present Tabs button would be
                 // a control whose only honest answer is "nothing".
@@ -205,7 +208,7 @@ struct PhoneHome_iOS: View {
         let count = appStore.tabs.count
         if count > 0 {
             Text("\(count)")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.caption2.bold())
                 .monospacedDigit()
                 .foregroundStyle(palette.primaryForeground)
                 .padding(.horizontal, 4)
@@ -249,10 +252,11 @@ struct PhoneHome_iOS: View {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 16))
                 .foregroundStyle(palette.mutedForeground)
+                .accessibilityHidden(true)
 
             TextField("Search your library — or paste a link", text: $store.query)
                 .textFieldStyle(.plain)
-                .font(.system(size: 16))
+                .font(.body)
                 .foregroundStyle(palette.foreground)
                 .focused($searchFocused)
                 .textInputAutocapitalization(.never)
@@ -273,7 +277,7 @@ struct PhoneHome_iOS: View {
                         .foregroundStyle(palette.mutedForeground)
                         // The whole trailing slot, not the 16pt glyph — the
                         // hit-target rule the toolbar buttons follow.
-                        .frame(width: 36, height: 44)
+                        .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -283,7 +287,7 @@ struct PhoneHome_iOS: View {
         }
         .padding(.leading, HomeLayout.rowInset)
         .padding(.trailing, store.query.isEmpty ? HomeLayout.rowInset : 4)
-        .frame(height: 52)
+        .frame(minHeight: 52)
         .glassEffect(.regular, in: .capsule)
         .overlay {
             Capsule().strokeBorder(
@@ -292,59 +296,76 @@ struct PhoneHome_iOS: View {
         .animation(.easeOut(duration: 0.12), value: searchFocused)
     }
 
-    /// Filters, then sort. A horizontal scroller rather than the iPad's
-    /// space-between row: four chips and a sort menu do not fit across 390pt,
-    /// and a wrapped second line would make the header taller than the first
-    /// result.
+    /// Filters, then sort. Accessibility sizes move sort onto its own row so
+    /// “Recently opened” is visible rather than stranded beyond the horizontal
+    /// filter viewport.
+    @ViewBuilder
     private var filterScroller: some View {
-        ScrollView(.horizontal) {
-            HStack(spacing: 8) {
-                ForEach(HomeSearchFilter.allCases, id: \.self) { option in
-                    HomeFilterChip(label: option.label, isSelected: store.filter == option) {
-                        store.filter = option
-                    }
-                    .accessibilityIdentifier("phone.home.filter.\(option.label)")
-                }
-
-                Divider().frame(height: 18).padding(.horizontal, 2)
-
-                if store.isSearching {
-                    Text(store.resultCount == 1 ? "1 result" : "\(store.resultCount) results")
-                        .font(.system(size: 12))
-                        .monospacedDigit()
-                        .foregroundStyle(palette.mutedForeground)
-                        .accessibilityIdentifier("phone.home.resultCount")
-                } else {
-                    sortMenu
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 0) {
+                ScrollView(.horizontal) { filterChips }
+                    .scrollIndicators(.hidden)
+                sortOrResult
+                    .padding(.leading, 4)
+            }
+        } else {
+            ScrollView(.horizontal) {
+                HStack(spacing: 5) {
+                    filterChips
+                    Divider()
+                        .frame(height: 18)
+                        .accessibilityHidden(true)
+                    sortOrResult
                 }
             }
-            .padding(.horizontal, HomeLayout.rowInset - Self.gutter)
+            .scrollIndicators(.hidden)
         }
-        .scrollIndicators(.hidden)
+    }
+
+    private var filterChips: some View {
+        HStack(spacing: 5) {
+            ForEach(HomeSearchFilter.allCases, id: \.self) { option in
+                HomeFilterChip(label: option.label, isSelected: store.filter == option) {
+                    store.filter = option
+                }
+                .accessibilityIdentifier("phone.home.filter.\(option.label)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sortOrResult: some View {
+        if store.isSearching {
+            Text(store.resultCount == 1 ? "1 result" : "\(store.resultCount) results")
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(palette.mutedForeground)
+                .fixedSize(horizontal: true, vertical: false)
+                .accessibilityIdentifier("phone.home.resultCount")
+        } else {
+            sortMenu
+        }
     }
 
     private var sortMenu: some View {
-        Menu {
+        Menu(store.sort.label, systemImage: "arrow.up.arrow.down") {
             Picker("Sort by", selection: $store.sort) {
                 ForEach(HomeSearchSortOrder.allCases, id: \.self) { option in
                     Text(option.label).tag(option)
                 }
             }
             .pickerStyle(.inline)
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: "arrow.up.arrow.down")
-                    .font(.system(size: 12))
-                Text(store.sort.label)
-                    .font(.system(size: 12, weight: .medium))
-            }
-            .frame(height: 32)
-            .contentShape(Rectangle())
         }
+        .labelStyle(.titleAndIcon)
+        .font(.caption.weight(.medium))
+        .lineLimit(1)
+        .frame(minWidth: 44, minHeight: 44)
+        .contentShape(Rectangle())
         .menuStyle(.button)
         .buttonStyle(.plain)
         .fixedSize()
         .foregroundStyle(palette.mutedForeground)
+        .accessibilityLabel("Sort by \(store.sort.label)")
         .accessibilityIdentifier("phone.home.sort")
     }
 
@@ -415,13 +436,13 @@ struct PhoneHome_iOS: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 6) {
                 Image(systemName: "arrow.trianglehead.2.clockwise.rotate.90")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                 Text("Continue Reading")
-                    .font(.system(size: 11, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                     .textCase(.uppercase)
                     .kerning(0.4)
                 Text("\(continueReading.count)")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption.weight(.medium))
                     .monospacedDigit()
                     .foregroundStyle(palette.mutedForeground.opacity(0.7))
                 Spacer(minLength: 0)
@@ -455,21 +476,24 @@ struct PhoneHome_iOS: View {
                 .font(.system(size: 26, weight: .light))
                 .foregroundStyle(palette.mutedForeground)
                 .padding(.bottom, 4)
+                .accessibilityHidden(true)
 
             if store.isSearching {
                 Text("No matches for “\(store.trimmedQuery)”")
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(palette.foreground)
+                    .multilineTextAlignment(.center)
                 Text("Search matches titles, filenames, and web addresses. Try fewer words.")
-                    .font(.system(size: 12))
+                    .font(.footnote)
                     .foregroundStyle(palette.mutedForeground)
                     .multilineTextAlignment(.center)
             } else {
                 Text("Nothing in \(store.filter.label) yet")
-                    .font(.system(size: 15, weight: .medium))
+                    .font(.subheadline.weight(.semibold))
                     .foregroundStyle(palette.foreground)
+                    .multilineTextAlignment(.center)
                 Text("Open a PDF or add a webpage and it will show up here.")
-                    .font(.system(size: 12))
+                    .font(.footnote)
                     .foregroundStyle(palette.mutedForeground)
                     .multilineTextAlignment(.center)
             }
@@ -491,7 +515,7 @@ struct PhoneHome_iOS: View {
             // say so rather than letting the user conclude the document is gone.
             ForEach(store.failures, id: \.self) { failure in
                 Label(failure, systemImage: "exclamationmark.triangle")
-                    .font(.system(size: 11))
+                    .font(.footnote)
                     .foregroundStyle(palette.destructive)
                     .multilineTextAlignment(.center)
             }
@@ -554,12 +578,12 @@ struct PhoneHome_iOS: View {
         } label: {
             HStack(spacing: 5) {
                 Image(systemName: "questionmark.circle")
-                    .font(.system(size: 13))
+                    .font(.footnote)
                 Text("How Vellum works")
-                    .font(.system(size: 13))
+                    .font(.footnote)
             }
             .foregroundStyle(palette.mutedForeground)
-            .frame(height: 44)
+            .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -571,7 +595,7 @@ struct PhoneHome_iOS: View {
     private var errorBanner: some View {
         if let error = appStore.error {
             Text(error)
-                .font(.system(size: 13))
+                .font(.footnote)
                 .foregroundStyle(palette.destructive)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 12)
@@ -721,6 +745,7 @@ private struct ContinueReadingRow_iOS: View {
     let open: () -> Void
 
     @Environment(\.palette) private var palette
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         Button(action: open) {
@@ -735,32 +760,47 @@ private struct ContinueReadingRow_iOS: View {
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text(item.title)
-                        .font(.system(size: 14, weight: .semibold))
+                        .font(.subheadline.weight(.semibold))
                         .foregroundStyle(palette.foreground)
-                        .lineLimit(1)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
                         .truncationMode(.middle)
 
-                    HStack(spacing: 5) {
-                        if !item.progressLabel.isEmpty {
-                            Text(item.progressLabel)
-                        }
-                        if !item.progressLabel.isEmpty, item.deviceLabel != nil {
-                            Text("·").accessibilityHidden(true)
-                        }
-                        if let device = item.deviceLabel {
-                            Text(device)
+                    Group {
+                        if dynamicTypeSize.isAccessibilitySize {
+                            VStack(alignment: .leading, spacing: 2) {
+                                if !item.progressLabel.isEmpty {
+                                    Text(item.progressLabel)
+                                }
+                                if let device = item.deviceLabel {
+                                    Text(device)
+                                }
+                            }
+                        } else {
+                            HStack(spacing: 5) {
+                                if !item.progressLabel.isEmpty {
+                                    Text(item.progressLabel)
+                                }
+                                if !item.progressLabel.isEmpty, item.deviceLabel != nil {
+                                    Text("·").accessibilityHidden(true)
+                                }
+                                if let device = item.deviceLabel {
+                                    Text(device)
+                                }
+                            }
                         }
                     }
-                    .font(.system(size: 12))
+                    .font(.footnote)
                     .foregroundStyle(palette.mutedForeground)
-                    .lineLimit(1)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
                 }
 
                 Spacer(minLength: 8)
 
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(palette.mutedForeground)
+                if !dynamicTypeSize.isAccessibilitySize {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(palette.mutedForeground)
+                }
             }
             .padding(.horizontal, HomeLayout.rowInset)
             .padding(.vertical, 8)

--- a/Vellum/Platform/iOS/PhoneInspectorSheet_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneInspectorSheet_iOS.swift
@@ -70,7 +70,10 @@ struct PhoneInspectorSheet_iOS: View {
     @State private var detent: PresentationDetent = .medium
 
     var body: some View {
-        SidebarContent_iOS(ink: ink)
+        SidebarContent_iOS(
+            ink: ink,
+            presentation: .phoneSheet,
+            onTabSelected: shell.selectInspectorTab)
             .environment(workspace)
             .environment(pane.app)
             .environment(pane.annotations)

--- a/Vellum/Platform/iOS/PhoneLaunchState_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneLaunchState_iOS.swift
@@ -16,8 +16,8 @@ enum PhoneLaunchState: String, Sendable, Hashable, CaseIterable {
     case home
     /// The document, chrome up.
     case reader
-    /// The document, chrome down — the immersive reading state that normally
-    /// costs a tap on the page.
+    /// The document, chrome down — the immersive reading state reached by a
+    /// document tap or by scrolling toward later content.
     case immersive
     /// The document with the inspector sheet presented, on whatever panel the
     /// workspace last selected.

--- a/Vellum/Platform/iOS/PhoneReaderChrome_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneReaderChrome_iOS.swift
@@ -3,14 +3,14 @@ import SwiftUI
 
 // The iPhone reader's chrome (#153 P5): two floating glass capsule bars over a
 // full-bleed document, a legibility scrim behind them, and an immersive mode
-// that reduces them to one explicit reveal handle.
+// driven by document taps and directional scrolling, with no reveal affordance.
 //
 // The iPad's `PdfToolbar_iOS` is a docked row that OWNS a strip of the pane; on
 // a 390pt screen a docked row is a tax paid on every page. So the phone floats
 // its controls instead, in the same `GlassToolPod` / `GlassToolButton` language
 // (the 44pt slot and the 48pt capsule are the iPad's numbers and are not
 // re-derived here — see `PdfChrome_iOS`'s geometry note), and gets the strip
-// back when the reader explicitly hides the controls.
+// back after deliberate travel toward later content.
 
 // MARK: - Geometry
 
@@ -32,6 +32,9 @@ enum PhoneChromeLayout {
 
     /// Gap between two capsules in the same bar.
     static let podGap: CGFloat = 8
+
+    /// One-button GlassToolPod width: 44pt target + 4pt padding per side.
+    static let singleButtonPodWidth: CGFloat = buttonSide + 8
 
     /// Distance from the screen edge to the outermost capsule.
     static let edgeInset: CGFloat = 8
@@ -175,7 +178,8 @@ struct PhoneChromeScrim: View {
 
 // MARK: - Top bar
 
-/// Back to Home, the document's name, and an explicit immersive-mode control.
+/// Back to Home and the document's name. Chrome visibility is driven by direct
+/// document interaction, so this bar carries no dedicated Hide button.
 ///
 /// The title is here rather than in the bottom bar because it is the one piece
 /// of chrome that answers "where am I", and it pairs with the control that
@@ -198,24 +202,20 @@ struct PhoneReaderTopBar: View {
 
             titleCapsule
 
-            GlassToolPod(label: "Reader controls") {
-                GlassToolButton(
-                    system: "arrow.down.right.and.arrow.up.left",
-                    label: "Hide reader controls"
-                ) {
-                    app.hideFind()
-                    shell.hideChrome()
-                }
-                .accessibilityIdentifier("phone.reader.hideChrome")
-            }
+            // Mirror the one-button Home pod without adding a control. A
+            // flexible Spacer has zero intrinsic width here and shifts the
+            // title toward the trailing edge.
+            Color.clear
+                .frame(
+                    width: PhoneChromeLayout.singleButtonPodWidth,
+                    height: PhoneChromeLayout.capsuleHeight)
+                .accessibilityHidden(true)
         }
         .padding(.horizontal, PhoneChromeLayout.edgeInset)
         .padding(.top, PhoneChromeLayout.barEdgeGap)
     }
 
-    /// The equal-width pods on either side make this capsule geometrically
-    /// centered, rather than merely placed after the Back button. `.middle`
-    /// truncation, not `.tail`: phone-sized titles are dominated by
+    /// `.middle` truncation, not `.tail`: phone-sized titles are dominated by
     /// long PDF filenames and article headlines whose distinguishing half is at
     /// the END ("Attention Is All You Need — Revised.pdf"). Dropping the middle
     /// keeps both ends, which is what makes two similar documents tellable
@@ -410,7 +410,7 @@ struct PhoneReaderBottomBar: View {
                 // P7 mounts the `.fullScreenCover` bound to this flag; the
                 // wiring is final either way, so it lands with the button it
                 // belongs to rather than being rediscovered a packet later.
-                shell.switcherPresented = true
+                shell.presentSwitcher()
             }
             .accessibilityIdentifier("phone.reader.tabs")
 

--- a/Vellum/Platform/iOS/PhoneReaderChrome_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneReaderChrome_iOS.swift
@@ -3,14 +3,14 @@ import SwiftUI
 
 // The iPhone reader's chrome (#153 P5): two floating glass capsule bars over a
 // full-bleed document, a legibility scrim behind them, and an immersive mode
-// that is simply the absence of both.
+// that reduces them to one explicit reveal handle.
 //
 // The iPad's `PdfToolbar_iOS` is a docked row that OWNS a strip of the pane; on
 // a 390pt screen a docked row is a tax paid on every page. So the phone floats
 // its controls instead, in the same `GlassToolPod` / `GlassToolButton` language
 // (the 44pt slot and the 48pt capsule are the iPad's numbers and are not
 // re-derived here — see `PdfChrome_iOS`'s geometry note), and gets the strip
-// back the moment the reader taps the page.
+// back when the reader explicitly hides the controls.
 
 // MARK: - Geometry
 
@@ -175,7 +175,7 @@ struct PhoneChromeScrim: View {
 
 // MARK: - Top bar
 
-/// Back to Home, and the document's name.
+/// Back to Home, the document's name, and an explicit immersive-mode control.
 ///
 /// The title is here rather than in the bottom bar because it is the one piece
 /// of chrome that answers "where am I", and it pairs with the control that
@@ -198,26 +198,38 @@ struct PhoneReaderTopBar: View {
 
             titleCapsule
 
-            Spacer(minLength: 0)
+            GlassToolPod(label: "Reader controls") {
+                GlassToolButton(
+                    system: "arrow.down.right.and.arrow.up.left",
+                    label: "Hide reader controls"
+                ) {
+                    app.hideFind()
+                    shell.hideChrome()
+                }
+                .accessibilityIdentifier("phone.reader.hideChrome")
+            }
         }
         .padding(.horizontal, PhoneChromeLayout.edgeInset)
         .padding(.top, PhoneChromeLayout.barEdgeGap)
     }
 
-    /// `.middle` truncation, not `.tail`: phone-sized titles are dominated by
+    /// The equal-width pods on either side make this capsule geometrically
+    /// centered, rather than merely placed after the Back button. `.middle`
+    /// truncation, not `.tail`: phone-sized titles are dominated by
     /// long PDF filenames and article headlines whose distinguishing half is at
     /// the END ("Attention Is All You Need — Revised.pdf"). Dropping the middle
     /// keeps both ends, which is what makes two similar documents tellable
     /// apart at 200pt.
     private var titleCapsule: some View {
         Text(title)
-            .font(.system(size: 15, weight: .medium))
+            .font(.subheadline.weight(.medium))
             .foregroundStyle(palette.foreground)
             .lineLimit(1)
             .truncationMode(.middle)
+            .minimumScaleFactor(0.75)
             .padding(.horizontal, 14)
             .frame(height: PhoneChromeLayout.capsuleHeight)
-            .frame(maxWidth: 240)
+            .frame(maxWidth: .infinity)
             .glassEffect(.regular, in: .capsule)
             .accessibilityIdentifier("phone.reader.title")
             .accessibilityLabel(title.isEmpty ? "Untitled document" : title)
@@ -331,8 +343,12 @@ struct PhoneReaderBottomBar: View {
     private var positionPod: some View {
         if isWeb {
             PhoneGlassToolPod(label: "Page history") {
-                GlassToolButton(system: "arrow.left", label: "Back") { webHistory(-1) }
-                GlassToolButton(system: "arrow.right", label: "Forward") { webHistory(1) }
+                GlassToolButton(
+                    system: "arrow.left", label: "Back", disabled: !canGoBack
+                ) { webHistory(-1) }
+                GlassToolButton(
+                    system: "arrow.right", label: "Forward", disabled: !canGoForward
+                ) { webHistory(1) }
             }
         } else {
             PhoneGlassToolPod(label: "Page navigation") {
@@ -341,7 +357,7 @@ struct PhoneReaderBottomBar: View {
                     showPageJump = true
                 } label: {
                     Text("\(app.currentPage) / \(app.numPages)")
-                        .font(.system(size: 15, weight: .medium))
+                        .font(.subheadline.weight(.medium))
                         .monospacedDigit()
                         .foregroundStyle(palette.foreground)
                         .lineLimit(1)
@@ -411,7 +427,7 @@ struct PhoneReaderBottomBar: View {
     /// minus the split items and the ink toggle, plus the three things the phone
     /// has nowhere else to put: Help, Settings and Close Document.
     private var moreMenu: some View {
-        Menu {
+        Menu("More actions", systemImage: "ellipsis") {
             Button {
                 app.findVisible ? app.hideFind() : app.showFind()
             } label: { Label("Find", systemImage: "magnifyingglass") }
@@ -481,16 +497,27 @@ struct PhoneReaderBottomBar: View {
                     shell.didCloseTab()
                 }
             } label: { Label("Close Document", systemImage: "xmark") }
-        } label: {
-            Image(systemName: "ellipsis")
-                .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(palette.foreground)
-                .frame(width: PhoneChromeLayout.buttonSide, height: PhoneChromeLayout.buttonSide)
-                .contentShape(Rectangle())
         }
+        .labelStyle(.iconOnly)
+        .font(.title3.weight(.medium))
+        .foregroundStyle(palette.foreground)
+        .frame(width: PhoneChromeLayout.buttonSide, height: PhoneChromeLayout.buttonSide)
+        .contentShape(Rectangle())
         .accessibilityLabel("More actions")
         .accessibilityIdentifier("phone.reader.more")
     }
+
+    private var activeWebController: WebViewerController_iOS? {
+        guard let tabId = app.activeTabId,
+              let runtime = workspace.existingLiveTabRuntime(for: tabId),
+              !runtime.isEvicted,
+              runtime.webController.hasWebView
+        else { return nil }
+        return runtime.webController
+    }
+
+    private var canGoBack: Bool { activeWebController?.canGoBack ?? false }
+    private var canGoForward: Bool { activeWebController?.canGoForward ?? false }
 
     /// In-page history for web tabs — same channel both other toolbars use.
     private func webHistory(_ delta: Int) {

--- a/Vellum/Platform/iOS/PhoneShellStore.swift
+++ b/Vellum/Platform/iOS/PhoneShellStore.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import Foundation
+import UIKit
 
 /// Where the phone shell currently is. Home is a ROUTE, not a tab (#153 D1):
 /// going Home leaves the current tab active in `AppStore`, so its residency pin
@@ -41,12 +42,28 @@ final class PhoneShellStore {
     /// so route changes can close it — SwiftUI presentations that outlive the
     /// screen underneath them are how a phone shell ends up with two things on
     /// screen claiming to be "current".
-    var switcherPresented = false
+    private(set) var switcherPresented = false
 
     /// Whether the reader chrome (top/bottom capsules) is showing. Immersive
     /// reading is the absence of chrome, not a separate route, so this is plain
     /// shell state rather than a third `PhoneRoute` case.
     private(set) var chromeVisible = true
+
+    /// About one thumb-width of deliberate page travel. The native adapters
+    /// send points, so PDF and web readers share the exact same threshold.
+    static let chromeTravelThreshold: CGFloat = 28
+    private static let chromeJitterTolerance: CGFloat = 3
+
+    private enum ScrollDirection {
+        case later
+        case earlier
+    }
+
+    private var scrollDirection: ScrollDirection?
+    private var accumulatedScrollTravel: CGFloat = 0
+    private var pendingReverseTravel: CGFloat = 0
+    private var scrollGestureFrozen = false
+    private var alwaysShowReaderControls = false
 
     /// D3 — the compact default for `sidebarOpen` is `false`.
     ///
@@ -167,18 +184,35 @@ final class PhoneShellStore {
 
     // MARK: - Routing
 
+    func presentSwitcher() {
+        switcherPresented = true
+    }
+
+    /// Handles interactive/system dismissal as well as the switcher's Done
+    /// button. Returning to an already-mounted reader is still a navigation
+    /// arrival, so it restores controls and discards pre-switcher travel.
+    func setSwitcherPresented(_ isPresented: Bool) {
+        guard switcherPresented != isPresented else { return }
+        switcherPresented = isPresented
+        if !isPresented, route == .reader {
+            resetChromeScrollGesture()
+            chromeVisible = true
+        }
+    }
+
     func showHome() {
         // The switcher is a full-screen cover over the reader; leaving the
         // reader with it still presented would stack it over Home.
         switcherPresented = false
+        resetChromeScrollGesture()
         route = .home
     }
 
-    /// Returns to the document. Chrome comes back visible: arriving at a
-    /// document with no chrome would leave only the compact reveal handle and no
-    /// visible way back to Home.
+    /// Every navigation arrival starts with stable, visible controls. Automatic
+    /// hiding only begins after a fresh direct document scroll on this visit.
     func showReader() {
         switcherPresented = false
+        resetChromeScrollGesture()
         chromeVisible = true
         route = .reader
     }
@@ -199,18 +233,155 @@ final class PhoneShellStore {
         showHome()
     }
 
-    // MARK: - Chrome
+    // MARK: - Document-driven chrome
 
-    func hideChrome() {
-        chromeVisible = false
-    }
-
-    func showChrome() {
+    /// Find is rendered inside the chrome. A hardware shortcut can open it
+    /// while bars are hidden, so presentation must reveal the field before it
+    /// takes keyboard focus (which then freezes automatic changes).
+    func findPresentationChanged(isVisible: Bool) {
+        guard isVisible else { return }
+        resetChromeScrollGesture()
         chromeVisible = true
     }
 
+    /// Applies the persisted Settings → Reader preference live. Enabling it
+    /// while controls are hidden reveals them immediately.
+    func updateAlwaysShowReaderControls(_ enabled: Bool) {
+        alwaysShowReaderControls = enabled
+        resetChromeScrollGesture()
+        if enabled { chromeVisible = true }
+    }
+
+    /// Called for VoiceOver/Switch Control status changes. Stable-control
+    /// navigation is behaviorally equivalent to the preference while active.
+    func accessibilityRequirementDidChange() {
+        resetChromeScrollGesture()
+        if Self.assistiveNavigationRequiresStableControls {
+            chromeVisible = true
+        }
+    }
+
+    /// Consumes normalized, direct vertical travel from PDFKit or WebKit. A
+    /// blocked source freezes the WHOLE pan, so a selection that is cleared by
+    /// the first few points cannot cause the tail of that same gesture to hide
+    /// controls unexpectedly.
+    func handleReaderScroll(_ event: ReaderChromeScrollEvent) {
+        switch event {
+        case .tapped(let sourceInteractionBlocked):
+            resetChromeScrollGesture()
+            guard !sourceInteractionBlocked, !automaticChromeChangesBlocked else { return }
+            chromeVisible.toggle()
+
+        case .began(let sourceInteractionBlocked):
+            scrollGestureFrozen = sourceInteractionBlocked || automaticChromeChangesBlocked
+            if scrollGestureFrozen { resetChromeScrollProgress() }
+
+        case .changed(let deltaY, let sourceInteractionBlocked):
+            if sourceInteractionBlocked || automaticChromeChangesBlocked {
+                scrollGestureFrozen = true
+                resetChromeScrollProgress()
+            }
+            guard !scrollGestureFrozen else { return }
+            accumulateReaderTravel(deltaY)
+
+        case .ended:
+            // Keep valid partial travel across finger lifts: "accumulated"
+            // scrolling can be two short direct pans. Only the per-pan freeze
+            // latch ends here.
+            scrollGestureFrozen = false
+
+        case .reset:
+            resetChromeScrollGesture()
+        }
+    }
+
+    /// Kept for the DEBUG launch-state screenshot hook and direct state tests.
+    /// Runtime reader UI has no explicit hide/reveal action.
     func setChrome(_ visible: Bool) {
+        guard visible || !automaticChromeChangesBlocked else {
+            chromeVisible = true
+            return
+        }
         chromeVisible = visible
+        resetChromeScrollGesture()
+    }
+
+    private var automaticChromeChangesBlocked: Bool {
+        alwaysShowReaderControls
+            || Self.assistiveNavigationRequiresStableControls
+            || route != .reader
+            || switcherPresented
+            || inspectorPresented
+            || app.findVisible
+            || app.mode != .view
+            || textInputFocusRequiresStableChrome
+    }
+
+    /// PDFKit's private `PDFDocumentView` conforms to `UITextInput` so it can
+    /// host native selection, even when nobody is typing. Treating that as a
+    /// keyboard field freezes every PDF pan. Real editors (Find, note text,
+    /// webpage inputs) are outside `VellumPDFView` and remain blocked.
+    private var textInputFocusRequiresStableChrome: Bool {
+        guard VellumKeyboardFocus.isTextInputFirstResponder else { return false }
+        return !Self.isPDFDocumentSurfaceResponder(UIResponder.vellumCurrentFirstResponder)
+    }
+
+    /// Testable ancestry check for PDFKit's private text-input responder.
+    static func isPDFDocumentSurfaceResponder(_ responder: UIResponder?) -> Bool {
+        guard let view = responder as? UIView else { return false }
+        var ancestor: UIView? = view
+        while let current = ancestor {
+            if current is VellumPDFView { return true }
+            ancestor = current.superview
+        }
+        return false
+    }
+
+    private static var assistiveNavigationRequiresStableControls: Bool {
+        UIAccessibility.isVoiceOverRunning || UIAccessibility.isSwitchControlRunning
+    }
+
+    private func accumulateReaderTravel(_ deltaY: CGFloat) {
+        guard abs(deltaY) > 0.01 else { return }
+        let nextDirection: ScrollDirection = deltaY > 0 ? .later : .earlier
+        let travel = abs(deltaY)
+
+        if let scrollDirection, scrollDirection != nextDirection {
+            // Accumulate the deadband, not just each sample: repeated 1-point
+            // samples eventually become a deliberate reversal rather than
+            // being ignored forever.
+            pendingReverseTravel += travel
+            guard pendingReverseTravel > Self.chromeJitterTolerance else { return }
+            self.scrollDirection = nextDirection
+            accumulatedScrollTravel = pendingReverseTravel
+            pendingReverseTravel = 0
+        } else {
+            scrollDirection = nextDirection
+            pendingReverseTravel = 0
+            accumulatedScrollTravel += travel
+        }
+
+        guard accumulatedScrollTravel >= Self.chromeTravelThreshold else { return }
+        switch nextDirection {
+        case .later where chromeVisible:
+            chromeVisible = false
+        case .earlier where !chromeVisible:
+            chromeVisible = true
+        default:
+            break
+        }
+        resetChromeScrollProgress()
+    }
+
+    private func resetChromeScrollProgress() {
+        scrollDirection = nil
+        accumulatedScrollTravel = 0
+        pendingReverseTravel = 0
+    }
+
+    private func resetChromeScrollGesture() {
+        resetChromeScrollProgress()
+        scrollGestureFrozen = false
     }
 }
 #endif

--- a/Vellum/Platform/iOS/PhoneShellStore.swift
+++ b/Vellum/Platform/iOS/PhoneShellStore.swift
@@ -113,6 +113,17 @@ final class PhoneShellStore {
         workspace.sidebarTab
     }
 
+    /// Changes the visible panel without changing whether the sheet is open.
+    ///
+    /// The switcher lives inside an already-presented sheet, so its buttons mean
+    /// only "show this panel". Keeping this separate from `revealInspector`
+    /// prevents a tab choice from being coupled to presentation geometry or a
+    /// detent transition.
+    func selectInspectorTab(_ tab: WorkspaceStore.SidebarTab) {
+        guard app.document != nil else { return }
+        workspace.sidebarTab = tab
+    }
+
     /// The ink controller the inspector's Handwriting section reads — the live
     /// tab's own, taken straight off its runtime.
     ///
@@ -164,8 +175,8 @@ final class PhoneShellStore {
     }
 
     /// Returns to the document. Chrome comes back visible: arriving at a
-    /// document with no chrome would leave no visible way back to Home, and the
-    /// tap-to-reveal gesture that fixes that is not discoverable.
+    /// document with no chrome would leave only the compact reveal handle and no
+    /// visible way back to Home.
     func showReader() {
         switcherPresented = false
         chromeVisible = true
@@ -190,8 +201,12 @@ final class PhoneShellStore {
 
     // MARK: - Chrome
 
-    func toggleChrome() {
-        chromeVisible.toggle()
+    func hideChrome() {
+        chromeVisible = false
+    }
+
+    func showChrome() {
+        chromeVisible = true
     }
 
     func setChrome(_ visible: Bool) {

--- a/Vellum/Platform/iOS/PhoneShell_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneShell_iOS.swift
@@ -1,5 +1,6 @@
 #if os(iOS)
 import SwiftUI
+import UIKit
 
 /// The compact-width (iPhone) shell (#153).
 ///
@@ -47,6 +48,8 @@ private struct PhoneShellRoot_iOS: View {
 
     @State private var addWebpagePresented = false
     @State private var isImporting = false
+    @AppStorage(ReaderControlPreferences.alwaysShowReaderControlsKey)
+    private var alwaysShowReaderControls = false
 
     /// A one-shot request to put the keyboard in Home's search field, raised
     /// when ⌘F arrives with nothing to find (#153 P8).
@@ -193,6 +196,24 @@ private struct PhoneShellRoot_iOS: View {
             .onChange(of: colorScheme, initial: true) { _, scheme in
                 themeStore.systemAppearanceChanged(isDark: scheme == .dark)
             }
+            .onChange(of: alwaysShowReaderControls, initial: true) { _, enabled in
+                shell.updateAlwaysShowReaderControls(enabled)
+            }
+            .onChange(of: pane.app.findVisible) { _, isVisible in
+                shell.findPresentationChanged(isVisible: isVisible)
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: UIAccessibility.voiceOverStatusDidChangeNotification)
+            ) { _ in
+                shell.accessibilityRequirementDidChange()
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: UIAccessibility.switchControlStatusDidChangeNotification)
+            ) { _ in
+                shell.accessibilityRequirementDidChange()
+            }
             // Safety net for opens the shell did not initiate: a Files-app
             // hand-off that raced the route, a restored session at launch, ⌘O,
             // later widgets and Spotlight. Home's own actions call
@@ -235,7 +256,7 @@ private struct PhoneShellRoot_iOS: View {
             onAddWebpage: { addWebpagePresented = true },
             onShowTabs: {
                 guard !pane.app.tabs.isEmpty else { return }
-                shell.switcherPresented = true
+                shell.presentSwitcher()
             },
             onDocumentOpened: { shell.didOpenDocument() })
     }
@@ -261,17 +282,14 @@ private struct PhoneShellRoot_iOS: View {
     private var readerRoute: some View {
         ZStack {
             LiveTabStack_iOS(app: pane.app)
+                // The shared PDF/web viewers see a no-op action on iPad. Only
+                // the phone shell installs the policy callback.
+                .environment(
+                    \.readerChromeScrollAction,
+                    ReaderChromeScrollAction(handler: { event in
+                        shell.handleReaderScroll(event)
+                    }))
                 .ignoresSafeArea()
-
-            // Immersive reading keeps one explicit, system-safe way to restore
-            // the bars. This consumes only its own 44pt button instead of
-            // observing every tap delivered to PDFKit or WebKit.
-            ChromeRevealControl_iOS(
-                isActive: !shell.switcherPresented,
-                chromeVisible: shell.chromeVisible
-            ) {
-                shell.showChrome()
-            }
 
             PhoneReaderChrome_iOS(
                 shell: shell,
@@ -333,7 +351,7 @@ private struct PhoneShellRoot_iOS: View {
     private var switcherPresented: Binding<Bool> {
         Binding(
             get: { shell.switcherPresented },
-            set: { shell.switcherPresented = $0 }
+            set: { shell.setSwitcherPresented($0) }
         )
     }
 
@@ -422,7 +440,7 @@ private struct PhoneShellRoot_iOS: View {
             shell.revealInspector(shell.inspectorTab)
         case .tabs:
             shell.showReader()
-            shell.switcherPresented = true
+            shell.presentSwitcher()
         }
     }
     #endif

--- a/Vellum/Platform/iOS/PhoneShell_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneShell_iOS.swift
@@ -263,17 +263,15 @@ private struct PhoneShellRoot_iOS: View {
             LiveTabStack_iOS(app: pane.app)
                 .ignoresSafeArea()
 
-            // Never in the touch path (see `ChromeTapCatcher_iOS`) — it is a
-            // window-level recognizer plus a geometry probe, which is why it can
-            // sit above the viewer without taking anything from it.
-            ChromeTapCatcher_iOS(
+            // Immersive reading keeps one explicit, system-safe way to restore
+            // the bars. This consumes only its own 44pt button instead of
+            // observing every tap delivered to PDFKit or WebKit.
+            ChromeRevealControl_iOS(
                 isActive: !shell.switcherPresented,
                 chromeVisible: shell.chromeVisible
             ) {
-                shell.toggleChrome()
+                shell.showChrome()
             }
-            .ignoresSafeArea()
-            .allowsHitTesting(false)
 
             PhoneReaderChrome_iOS(
                 shell: shell,

--- a/Vellum/Platform/iOS/PhoneTabCard.swift
+++ b/Vellum/Platform/iOS/PhoneTabCard.swift
@@ -34,6 +34,22 @@ struct PhoneTabCard: Identifiable, Equatable, Sendable {
     /// for PDFs whose page count is not known yet.
     let pageLabel: String?
 
+    /// The current 1-based PDF page. A resident PDF can render this page from
+    /// its existing `PDFDocument`; a cold PDF falls back to Quick Look's file
+    /// thumbnail. Webpages and start tabs have no page number.
+    let previewPageNumber: Int?
+
+    /// Filesystem path used only for a cold PDF's Quick Look thumbnail. Merely
+    /// carrying the path is free: the lazy grid asks Quick Look only for cards
+    /// that are actually on screen, and never creates a live-tab runtime.
+    let thumbnailPath: String?
+
+    /// Ordinal shown when the workspace contains the same document more than
+    /// once. This is intentionally derived from current tab order rather than
+    /// persisted; it distinguishes identical title/source pairs without adding
+    /// a second identity system.
+    let duplicateLabel: String?
+
     /// The tab the reader is showing. Exactly one card carries this, and it is
     /// the one that gets the ring.
     let isCurrent: Bool
@@ -73,13 +89,17 @@ enum PhoneTabCardBuilder {
         activeTabId: String?,
         isResident: (String) -> Bool
     ) -> [PhoneTabCard] {
-        tabs.map { tab in
+        let duplicateLabels = duplicateLabels(for: tabs)
+        return tabs.map { tab in
             PhoneTabCard(
                 id: tab.id,
                 title: title(for: tab),
                 subtitle: subtitle(for: tab),
                 kind: tab.document?.kind,
                 pageLabel: pageLabel(for: tab),
+                previewPageNumber: previewPageNumber(for: tab),
+                thumbnailPath: thumbnailPath(for: tab),
+                duplicateLabel: duplicateLabels[tab.id],
                 isCurrent: tab.id == activeTabId,
                 isResident: isResident(tab.id))
         }
@@ -124,6 +144,46 @@ enum PhoneTabCardBuilder {
         guard let document = tab.document, document.kind != .web else { return nil }
         guard tab.numPages > 0 else { return nil }
         return "\(tab.currentPage) / \(tab.numPages)"
+    }
+
+    static func previewPageNumber(for tab: PdfTab) -> Int? {
+        guard tab.document?.kind == .pdf, tab.numPages > 0 else { return nil }
+        return min(max(tab.currentPage, 1), tab.numPages)
+    }
+
+    static func thumbnailPath(for tab: PdfTab) -> String? {
+        guard let document = tab.document,
+              document.kind == .pdf,
+              !document.pdfPath.isEmpty
+        else { return nil }
+        return document.pdfPath
+    }
+
+    /// Labels repeated instances of the same source in their current visual
+    /// order. `docId` wins when available so a moved PDF still counts as the
+    /// same document; otherwise the document kind and source URI are the stable
+    /// identity already stored by `DocumentInfo`.
+    private static func duplicateLabels(for tabs: [PdfTab]) -> [String: String] {
+        let keys = tabs.map(duplicateKey(for:))
+        let totals = keys.reduce(into: [String: Int]()) { counts, key in
+            counts[key, default: 0] += 1
+        }
+        var positions: [String: Int] = [:]
+        var labels: [String: String] = [:]
+
+        for (tab, key) in zip(tabs, keys) where totals[key, default: 0] > 1 {
+            positions[key, default: 0] += 1
+            labels[tab.id] = "Duplicate \(positions[key, default: 0]) of \(totals[key, default: 0])"
+        }
+        return labels
+    }
+
+    private static func duplicateKey(for tab: PdfTab) -> String {
+        guard let document = tab.document else { return "start" }
+        if let docId = document.docId, !docId.isEmpty {
+            return "\(document.kind.rawValue):id:\(docId)"
+        }
+        return "\(document.kind.rawValue):source:\(document.pdfPath)"
     }
 }
 #endif

--- a/Vellum/Platform/iOS/PhoneTabSwitcher_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneTabSwitcher_iOS.swift
@@ -212,7 +212,7 @@ struct PhoneTabSwitcher_iOS: View {
     }
 
     private var doneButton: some View {
-        Button("Done") { shell.switcherPresented = false }
+        Button("Done") { shell.setSwitcherPresented(false) }
             .font(.body.bold())
             .foregroundStyle(palette.primary)
             .frame(

--- a/Vellum/Platform/iOS/PhoneTabSwitcher_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneTabSwitcher_iOS.swift
@@ -1,5 +1,9 @@
 #if os(iOS)
+import PDFKit
+import QuickLookThumbnailing
 import SwiftUI
+import UIKit
+import WebKit
 
 /// Geometry for the tab switcher, in one place so the grid, the cards and the
 /// bar cannot drift apart (and so a later thumbnail pass — P9 — has one aspect
@@ -13,10 +17,12 @@ enum PhoneTabSwitcherLayout {
     static let columnGap: CGFloat = 14
     static let rowGap: CGFloat = 18
 
-    /// Width ÷ height of a card's preview. Portrait, close to a page's 1 / √2 —
-    /// the placeholder is typographic today and a page thumbnail tomorrow, and
-    /// the shape should not change when that lands.
+    /// Width ÷ height of a card's preview. Portrait, close to a page's 1 / √2,
+    /// so PDF thumbnails and webpage snapshots share one stable card shape.
     static let previewAspect: CGFloat = 0.72
+    /// Accessibility layouts prioritize the readable card identity below the
+    /// image. A bounded crop survives both portrait and short landscape screens.
+    static let accessibilityPreviewHeight: CGFloat = 160
 
     /// Corner radius of a preview. The largest token in the scale: at 180pt
     /// wide a card wants to read as a sheet of paper, not as a table row.
@@ -32,8 +38,13 @@ enum PhoneTabSwitcherLayout {
     /// actually needs.
     static let closeDisc: CGFloat = 24
 
-    /// Height of the opaque bottom bar, excluding the home indicator's inset.
-    static let barHeight: CGFloat = 52
+    /// Minimum height of the opaque bottom bar, excluding the home indicator's
+    /// inset. It grows when Dynamic Type needs a second row.
+    static let minimumBarHeight: CGFloat = 52
+
+    static func columnCount(for dynamicTypeSize: DynamicTypeSize) -> Int {
+        dynamicTypeSize.isAccessibilitySize ? 1 : 2
+    }
 }
 
 /// The Safari-style tab switcher (#153 P7).
@@ -44,11 +55,12 @@ enum PhoneTabSwitcherLayout {
 ///
 /// ## Two rules this screen exists to honour
 ///
-/// **It must not allocate.** With a phone-sized residency budget (hot 2,
-/// resident 3) the switcher is the one surface that sees every tab at once, and
-/// asking `WorkspaceStore.liveTabRuntime(for:)` per card would mint a runtime
-/// for each of them. Residency is asked through `existingLiveTabRuntime(for:)`
-/// plus `residency.isResident(tabId:)` — both pure reads.
+/// **It must not allocate reader state.** With a phone-sized residency budget
+/// (hot 2, resident 3) the switcher is the one surface that sees every tab at
+/// once, and asking `WorkspaceStore.liveTabRuntime(for:)` per card would mint a
+/// runtime for each of them. Residency is asked through
+/// `existingLiveTabRuntime(for:)` plus `residency.isResident(tabId:)` — both
+/// pure reads. Only visible cards allocate their bounded thumbnail bitmap.
 ///
 /// **The bar is opaque, not glass.** Every other floating surface on the phone
 /// is a glass capsule over a document, because there is a document under it
@@ -56,6 +68,8 @@ enum PhoneTabSwitcherLayout {
 /// glass over it would blur the cards into the control that acts on them. So:
 /// `palette.surface`, a hairline divider, and the bottom safe area filled.
 struct PhoneTabSwitcher_iOS: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     /// The shell, for the three transitions this screen can cause: open a tab,
     /// go Home, dismiss. It owns `switcherPresented`, so the screen never
     /// dismisses itself by any other route.
@@ -97,11 +111,13 @@ struct PhoneTabSwitcher_iOS: View {
 
     var body: some View {
         ScrollView {
-            LazyVGrid(columns: Self.columns, spacing: PhoneTabSwitcherLayout.rowGap) {
+            LazyVGrid(columns: columns, spacing: PhoneTabSwitcherLayout.rowGap) {
                 ForEach(cards) { card in
                     PhoneTabCardView(
                         card: card,
                         palette: palette,
+                        thumbnailRevision: thumbnailRevision(for: card),
+                        loadThumbnail: { await thumbnail(for: card) },
                         open: { open(card) },
                         close: { close(card) })
                 }
@@ -125,10 +141,13 @@ struct PhoneTabSwitcher_iOS: View {
         .accessibilityIdentifier("phone.tabs")
     }
 
-    private static let columns = [
-        GridItem(.flexible(), spacing: PhoneTabSwitcherLayout.columnGap),
-        GridItem(.flexible(), spacing: PhoneTabSwitcherLayout.columnGap),
-    ]
+    /// Two page-like cards at normal sizes; one readable card when accessibility
+    /// text would otherwise crush the title and close control into half a phone.
+    private var columns: [GridItem] {
+        return Array(
+            repeating: GridItem(.flexible(), spacing: PhoneTabSwitcherLayout.columnGap),
+            count: PhoneTabSwitcherLayout.columnCount(for: dynamicTypeSize))
+    }
 
     // MARK: - Actions
 
@@ -162,42 +181,20 @@ struct PhoneTabSwitcher_iOS: View {
     private var bottomBar: some View {
         ZStack {
             HStack(spacing: 12) {
-                Text(countLabel)
-                    .font(.system(size: 13))
-                    .monospacedDigit()
-                    .foregroundStyle(palette.mutedForeground)
-                    .accessibilityIdentifier("phone.tabs.count")
+                countText
                 Spacer(minLength: 8)
-                Button("Done") { shell.switcherPresented = false }
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(palette.primary)
-                    .frame(minWidth: PhoneChromeLayout.buttonSide,
-                           minHeight: PhoneChromeLayout.buttonSide)
-                    .contentShape(Rectangle())
-                    .accessibilityIdentifier("phone.tabs.done")
+                doneButton
             }
 
-            // Centred independently of the two labels beside it, so a
-            // three-digit count cannot nudge it off centre.
-            Button {
-                // Home, never `newStartTab()` (D1). A start tab would grow a
-                // leaf in the pane tree and a fourth card here that opens
-                // nothing; Home is the phone's new-document surface.
-                shell.showHome()
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 20, weight: .medium))
-                    .foregroundStyle(palette.primary)
-                    .frame(width: PhoneChromeLayout.buttonSide,
-                           height: PhoneChromeLayout.buttonSide)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open another document")
-            .accessibilityIdentifier("phone.tabs.new")
+            // Keep the compact system-style plus at every text size. Its
+            // VoiceOver label carries the full action without turning the
+            // bottom bar into a multi-line panel that covers the cards.
+            newDocumentButton
         }
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
         .padding(.horizontal, PhoneTabSwitcherLayout.gutter)
-        .frame(height: PhoneTabSwitcherLayout.barHeight)
+        .padding(.vertical, 4)
+        .frame(minHeight: PhoneTabSwitcherLayout.minimumBarHeight)
         .background(alignment: .top) {
             Rectangle()
                 .fill(palette.border)
@@ -206,33 +203,132 @@ struct PhoneTabSwitcher_iOS: View {
         .background(palette.surface.ignoresSafeArea(edges: .bottom))
     }
 
+    private var countText: some View {
+        Text(countLabel)
+            .font(.subheadline)
+            .monospacedDigit()
+            .foregroundStyle(palette.mutedForeground)
+            .accessibilityIdentifier("phone.tabs.count")
+    }
+
+    private var doneButton: some View {
+        Button("Done") { shell.switcherPresented = false }
+            .font(.body.bold())
+            .foregroundStyle(palette.primary)
+            .frame(
+                minWidth: PhoneChromeLayout.buttonSide,
+                minHeight: PhoneChromeLayout.buttonSide)
+            .contentShape(Rectangle())
+            .accessibilityIdentifier("phone.tabs.done")
+    }
+
+    private var newDocumentButton: some View {
+        Button {
+            // Home, never `newStartTab()` (D1). A start tab would grow a
+            // leaf in the pane tree and a fourth card here that opens
+            // nothing; Home is the phone's new-document surface.
+            shell.showHome()
+        } label: {
+            Image(systemName: "plus")
+                .font(.title3.weight(.medium))
+                .frame(
+                    width: PhoneChromeLayout.buttonSide,
+                    height: PhoneChromeLayout.buttonSide)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(palette.primary)
+        .accessibilityLabel("Open another document")
+        .accessibilityIdentifier("phone.tabs.new")
+    }
+
     private var countLabel: String {
         let count = app.tabs.count
         return count == 1 ? "1 tab" : "\(count) tabs"
+    }
+
+    // MARK: - Thumbnails
+
+    /// Changes when a resident reader finishes loading or a webpage navigates,
+    /// causing a visible card's thumbnail task to retry with fresh content.
+    private func thumbnailRevision(for card: PhoneTabCard) -> Int {
+        guard let runtime = workspace.existingLiveTabRuntime(for: card.id),
+              !runtime.isEvicted else { return 0 }
+        switch card.kind {
+        case .pdf:
+            if case .loaded = runtime.pdfLoadState { return 1 }
+            return 0
+        case .web:
+            return runtime.webController.hasWebView ? runtime.webController.initCount : 0
+        case nil:
+            return 0
+        }
+    }
+
+    /// Prefer the exact page/view already held by a resident runtime. The
+    /// side-effect-free guards are important: `existingLiveTabRuntime` never
+    /// creates a runtime, and `hasWebView` is checked before touching the lazy
+    /// `webView` property. A cold PDF asks Quick Look for a file thumbnail; a
+    /// cold webpage keeps the lightweight URL preview because rendering it
+    /// would require allocating a WKWebView and loading the page.
+    private func thumbnail(for card: PhoneTabCard) async -> UIImage? {
+        if let runtime = workspace.existingLiveTabRuntime(for: card.id),
+           !runtime.isEvicted {
+            switch card.kind {
+            case .pdf:
+                if case .loaded(let document) = runtime.pdfLoadState,
+                   document.pageCount > 0,
+                   let page = document.page(
+                    at: min(max((card.previewPageNumber ?? 1) - 1, 0), document.pageCount - 1)) {
+                    return page.thumbnail(
+                        of: CGSize(width: 360, height: 500), for: .cropBox)
+                }
+            case .web:
+                guard runtime.webController.hasWebView else { break }
+                let webView = runtime.webController.webView
+                guard webView.bounds.width >= 4, webView.bounds.height >= 4 else { break }
+                let configuration = WKSnapshotConfiguration()
+                configuration.rect = webView.bounds
+                return try? await webView.takeSnapshot(configuration: configuration)
+            case nil:
+                break
+            }
+        }
+
+        guard let path = card.thumbnailPath else { return nil }
+        let request = QLThumbnailGenerator.Request(
+            fileAt: URL(fileURLWithPath: path),
+            size: CGSize(width: 360, height: 500),
+            scale: 1,
+            representationTypes: .thumbnail)
+        return try? await QLThumbnailGenerator.shared
+            .generateBestRepresentation(for: request)
+            .uiImage
     }
 
     /// Only reachable for a beat: `didCloseTab()` routes Home the moment the
     /// last tab goes. It exists so that beat is not a blank screen.
     private var emptyState: some View {
         Text("No open documents")
-            .font(.system(size: 15))
+            .font(.body)
             .foregroundStyle(palette.mutedForeground)
     }
 }
 
-/// One card: a typographic preview, the ring when it is current, a close
-/// affordance, and two lines of label beneath.
-///
-/// The preview is deliberately text, not a screenshot. P9 may put a real
-/// thumbnail behind it; until then a title set large on paper-coloured stock
-/// identifies a document better than a grey rectangle would, and it costs
-/// nothing for an evicted tab — which is precisely the tab a screenshot cannot
-/// be produced for.
-private struct PhoneTabCardView: View {
+/// One card: a lazy document thumbnail when one can be produced without
+/// creating native reader state, the ring when it is current, a close
+/// affordance, and an adaptive label beneath.
+struct PhoneTabCardView: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     let card: PhoneTabCard
     let palette: ThemePalette
+    let thumbnailRevision: Int
+    let loadThumbnail: () async -> UIImage?
     let open: () -> Void
     let close: () -> Void
+
+    @State private var thumbnail: UIImage?
 
     /// The current tab is never drawn as needing a reload. It is the document
     /// the reader is showing; `LiveTabStack_iOS.shouldRender` guarantees it is
@@ -248,32 +344,60 @@ private struct PhoneTabCardView: View {
         }
     }
 
-    var body: some View {
-        Button(action: open) {
-            VStack(alignment: .leading, spacing: 8) {
-                preview
-                label
-            }
-        }
-        .buttonStyle(.plain)
-        // Outside the button rather than inside its label: a button nested in
-        // another button's label is not reliably tappable on iOS, and this way
-        // the close target sits above the card's own hit area.
-        .overlay(alignment: .topTrailing) { closeButton }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("phone.tabs.card")
-        .accessibilityLabel(card.title)
-        .accessibilityValue(
-            [card.subtitle, card.isCurrent ? "Current document" : "",
-             showsReloadNote ? "Reloads on open" : ""]
-                .filter { !$0.isEmpty }
-                .joined(separator: ", "))
+    private var thumbnailIdentity: String {
+        "\(card.id):\(card.thumbnailPath ?? card.subtitle):\(card.previewPageNumber ?? 0):\(card.isResident):\(thumbnailRevision)"
     }
 
+    private var accessibilityTitle: String {
+        [card.title, card.duplicateLabel ?? ""]
+            .filter { !$0.isEmpty }
+            .joined(separator: ", ")
+    }
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Button(action: open) {
+                VStack(alignment: .leading, spacing: 8) {
+                    preview
+                    label
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("phone.tabs.card")
+            .accessibilityLabel(accessibilityTitle)
+            .accessibilityValue(
+                [card.subtitle, card.isCurrent ? "Current document" : "",
+                 showsReloadNote ? "Reloads on open" : ""]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: ", "))
+
+            // A sibling, not a Button overlay. SwiftUI folds controls inside a
+            // Button's overlay into the parent's accessibility element even
+            // though touch still works; sibling placement keeps Close exposed.
+            closeButton
+        }
+        .task(id: thumbnailIdentity) {
+            thumbnail = nil
+            let loaded = await loadThumbnail()
+            guard !Task.isCancelled else { return }
+            thumbnail = loaded
+        }
+    }
+
+    @ViewBuilder
     private var preview: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            previewSurface
+                .frame(height: PhoneTabSwitcherLayout.accessibilityPreviewHeight)
+        } else {
+            previewSurface
+                .aspectRatio(PhoneTabSwitcherLayout.previewAspect, contentMode: .fit)
+        }
+    }
+
+    private var previewSurface: some View {
         RoundedRectangle(cornerRadius: PhoneTabSwitcherLayout.cardCorner)
             .fill(palette.surface)
-            .aspectRatio(PhoneTabSwitcherLayout.previewAspect, contentMode: .fit)
             .overlay { previewContent }
             .clipShape(RoundedRectangle(cornerRadius: PhoneTabSwitcherLayout.cardCorner))
             .overlay {
@@ -284,28 +408,70 @@ private struct PhoneTabCardView: View {
                             ? PhoneTabSwitcherLayout.ringWidth
                             : PhoneTabSwitcherLayout.edgeWidth)
             }
-            // The whole preview is tappable, including the gaps between its
-            // glyph and its text.
             .contentShape(RoundedRectangle(cornerRadius: PhoneTabSwitcherLayout.cardCorner))
     }
 
     private var previewContent: some View {
-        VStack(spacing: 10) {
-            Image(systemName: symbol)
-                .font(.system(size: 24, weight: .light))
-                .foregroundStyle(palette.mutedForeground)
-
-            Text(card.title)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(palette.foreground)
-                .multilineTextAlignment(.center)
-                .lineLimit(3)
-                .truncationMode(.middle)
+        ZStack(alignment: .bottomLeading) {
+            if let thumbnail {
+                Image(uiImage: thumbnail)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .clipped()
+            } else {
+                fallbackPreview
+            }
 
             if let pageLabel = card.pageLabel {
                 Text(pageLabel)
-                    .font(.system(size: 11))
-                    .monospacedDigit()
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(palette.foreground)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.regularMaterial, in: Capsule())
+                    .padding(8)
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    /// Cold webpages intentionally stop here: creating a WKWebView to render a
+    /// card would defeat tab residency. The source-shaped browser tile is still
+    /// more useful than repeating the title because it foregrounds the host and
+    /// path that distinguish one article from another.
+    private var fallbackPreview: some View {
+        VStack(spacing: 12) {
+            Image(systemName: symbol)
+                .font(.largeTitle.weight(.light))
+                .foregroundStyle(palette.mutedForeground)
+
+            Text(card.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(palette.mutedForeground)
+                .multilineTextAlignment(.center)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
+                .truncationMode(.middle)
+        }
+        .padding()
+    }
+
+    private var label: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(card.title)
+                .font(card.isCurrent ? .headline.bold() : .headline)
+                .foregroundStyle(palette.foreground)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 3 : 2)
+                .truncationMode(.middle)
+            Text(card.subtitle)
+                .font(.subheadline)
+                .foregroundStyle(palette.mutedForeground)
+                .lineLimit(dynamicTypeSize.isAccessibilitySize ? 2 : 1)
+                .truncationMode(.middle)
+
+            if let duplicateLabel = card.duplicateLabel {
+                Label(duplicateLabel, systemImage: "square.on.square")
+                    .font(.caption)
                     .foregroundStyle(palette.mutedForeground)
             }
 
@@ -315,30 +481,9 @@ private struct PhoneTabCardView: View {
                 // document again. `LiveTabHost_iOS` shows "Restoring tab…" for
                 // the moment that takes.
                 Label("Reloads on open", systemImage: "arrow.clockwise")
-                    .font(.system(size: 10))
+                    .font(.caption)
                     .foregroundStyle(palette.mutedForeground)
-                    .labelStyle(.titleAndIcon)
             }
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 14)
-        // Dimmed as a whole, so "this one is not loaded" reads before any of
-        // the text does.
-        .opacity(showsReloadNote ? 0.55 : 1)
-    }
-
-    private var label: some View {
-        VStack(alignment: .leading, spacing: 1) {
-            Text(card.title)
-                .font(.system(size: 12, weight: card.isCurrent ? .semibold : .medium))
-                .foregroundStyle(palette.foreground)
-                .lineLimit(1)
-                .truncationMode(.middle)
-            Text(card.subtitle)
-                .font(.system(size: 10))
-                .foregroundStyle(palette.mutedForeground)
-                .lineLimit(1)
-                .truncationMode(.middle)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 2)
@@ -358,7 +503,7 @@ private struct PhoneTabCardView: View {
                         width: PhoneTabSwitcherLayout.closeDisc,
                         height: PhoneTabSwitcherLayout.closeDisc)
                 Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.caption.bold())
                     .foregroundStyle(palette.mutedForeground)
             }
             .frame(
@@ -366,10 +511,9 @@ private struct PhoneTabCardView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        // Pulled up and out so the disc straddles the card's corner rather than
-        // covering the first line of its title.
-        .offset(x: 10, y: -10)
-        .accessibilityLabel("Close \(card.title)")
+        // Keep the full 44pt target inside this card so it cannot overlap the
+        // adjacent card or extend beyond the screen gutter.
+        .accessibilityLabel("Close \(accessibilityTitle)")
         .accessibilityIdentifier("phone.tabs.close")
     }
 }

--- a/Vellum/Platform/iOS/SettingsSheet_iOS.swift
+++ b/Vellum/Platform/iOS/SettingsSheet_iOS.swift
@@ -17,14 +17,38 @@ import SwiftUI
 /// rather than any one pane's conversation.
 ///
 /// Which tab it opens on is `workspace.settingsSection` — set it *before*
-/// presenting, and `SettingsView`'s `TabView` binds straight to it.
+/// presenting, and `SettingsView` routes straight to it.
 struct SettingsSheet_iOS: View {
     @Environment(WorkspaceStore.self) private var workspace
+
+    var body: some View {
+        SettingsView()
+            .environment(workspace)
+            // Settings ▸ Integrations and both of its sheets read the store via
+            // @Environment(IntegrationsStore.self), and a missing @Environment
+            // observable is a fatalError, not a nil — so it has to be injected into
+            // this separate presentation host too.
+            .environment(workspace.integrations)
+            .environment(workspace.settingsAi)
+            .environment(workspace.openRouterCatalog)
+            .environment(workspace.chatgptAuth)
+            .presentationDetents([.large])
+    }
+}
+
+/// Each visible bottom tab owns its navigation container. This keeps the
+/// Settings title and Done action stable when the selected tab changes.
+struct SettingsTabNavigation<Content: View>: View {
     @Environment(\.dismiss) private var dismiss
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
 
     var body: some View {
         NavigationStack {
-            SettingsView()
+            content
                 .navigationTitle("Settings")
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -33,16 +57,102 @@ struct SettingsSheet_iOS: View {
                     }
                 }
         }
-        .environment(workspace)
-        // Settings ▸ Integrations and both of its sheets read the store via
-        // @Environment(IntegrationsStore.self), and a missing @Environment
-        // observable is a fatalError, not a nil — so it has to be injected into
-        // this separate presentation host too.
-        .environment(workspace.integrations)
-        .environment(workspace.settingsAi)
-        .environment(workspace.openRouterCatalog)
-        .environment(workspace.chatgptAuth)
-        .presentationDetents([.large])
+    }
+}
+
+enum SettingsNavigationDestination: Hashable {
+    case storage
+    case integrations
+
+    init?(section: WorkspaceStore.SettingsSection) {
+        switch section {
+        case .storage: self = .storage
+        case .integrations: self = .integrations
+        case .general, .reading, .annotations, .ai: return nil
+        }
+    }
+
+    var settingsSection: WorkspaceStore.SettingsSection {
+        switch self {
+        case .storage: .storage
+        case .integrations: .integrations
+        }
+    }
+}
+
+/// A deliberate fifth tab replaces iOS's automatic TabView "More" screen.
+/// Its rows are real NavigationLinks, so VoiceOver and touch both expose the
+/// Storage and Integrations destinations as actions.
+struct MoreSettingsNavigation: View {
+    @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.dismiss) private var dismiss
+    @State private var path: [SettingsNavigationDestination] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            Form {
+                Section {
+                    NavigationLink(value: SettingsNavigationDestination.storage) {
+                        Label("Storage", systemImage: "internaldrive")
+                    }
+                    .accessibilityIdentifier("settings.more.storage")
+
+                    NavigationLink(value: SettingsNavigationDestination.integrations) {
+                        Label("Integrations", systemImage: "link")
+                    }
+                    .accessibilityIdentifier("settings.more.integrations")
+                } footer: {
+                    Text("Manage stored data, storage location, and connected read-later services.")
+                }
+            }
+            .formStyle(.grouped)
+            .contentMargins(.bottom, 32, for: .scrollContent)
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .navigationDestination(for: SettingsNavigationDestination.self) { destination in
+                switch destination {
+                case .storage:
+                    StorageSettingsTab()
+                        .navigationTitle("Storage")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { dismiss() }
+                            }
+                        }
+                case .integrations:
+                    IntegrationsSettingsTab()
+                        .navigationTitle("Integrations")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .confirmationAction) {
+                                Button("Done") { dismiss() }
+                            }
+                        }
+                }
+            }
+        }
+        .onAppear {
+            route(to: workspace.settingsSection)
+        }
+        .onChange(of: workspace.settingsSection) { _, section in
+            route(to: section)
+        }
+        .onChange(of: path) { _, path in
+            if let destination = path.last {
+                workspace.settingsSection = destination.settingsSection
+            }
+        }
+    }
+
+    private func route(to section: WorkspaceStore.SettingsSection) {
+        let destination = SettingsNavigationDestination(section: section)
+        path = destination.map { [$0] } ?? []
     }
 }
 #endif

--- a/Vellum/Platform/iOS/WalkthroughSheet_iOS.swift
+++ b/Vellum/Platform/iOS/WalkthroughSheet_iOS.swift
@@ -27,6 +27,8 @@ import SwiftUI
 struct WalkthroughSheet_iOS: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.palette) private var palette
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     @State private var index = 0
     /// Direction of the last page change, so the outgoing and incoming pages
@@ -37,12 +39,10 @@ struct WalkthroughSheet_iOS: View {
 
     // MARK: - Metrics
     //
-    // The sheet's fixed geometry, named once here so `WalkthroughLayoutTests`
-    // can assert against the real numbers rather than re-typing them. The two
-    // chrome bars get explicit heights so the space left for a page is exactly
-    // derivable — otherwise the title bar sizes itself to whatever is in it,
-    // and adding a control silently takes points away from every page while the
-    // layout test fails pointing at the copy instead of at the cause.
+    // The sheet's bounds and minimum chrome geometry, named once here so
+    // `WalkthroughLayoutTests` can measure the real views rather than re-typing
+    // layout constants. The bars have minimums, not fixed heights: accessibility
+    // text is allowed to reflow and the page area scrolls in the remaining room.
 
     /// Maximum content width. iPad gets the intended reading column; compact
     /// phones accept their sheet's narrower proposal instead of forcing a
@@ -51,10 +51,11 @@ struct WalkthroughSheet_iOS: View {
     /// Backstop on the sheet's height. Past this the page area scrolls rather
     /// than growing — see `pageContent`.
     static let maxSheetHeight: CGFloat = 720
-    /// 44pt is below the iOS touch target once the close button lives in it.
-    static let titleBarHeight: CGFloat = 52
-    /// Likewise for Skip / Back / Next, which are `.md` here rather than `.sm`.
-    static let footerHeight: CGFloat = 60
+    /// Minimum chrome heights. Both regions may grow when Dynamic Type or a
+    /// narrow phone makes their content reflow.
+    static let minimumTitleBarHeight: CGFloat = 52
+    static let minimumFooterHeight: CGFloat = 60
+    static let controlSide: CGFloat = 44
     /// Height of each of the two rules between the chrome and the page.
     ///
     /// Pinned rather than left to `Divider()`'s intrinsic size, and this is not
@@ -65,9 +66,6 @@ struct WalkthroughSheet_iOS: View {
     /// the failure mode the explicit bar heights above exist to prevent, so the
     /// dividers get the same treatment: pinned, named, and scale-independent.
     static let dividerHeight: CGFloat = 1
-    /// Title bar + footer + the two dividers between them and the page.
-    static var chromeHeight: CGFloat { titleBarHeight + footerHeight + dividerHeight * 2 }
-
     private var page: WalkthroughPage { pages[index] }
     private var isFirst: Bool { index == 0 }
     private var isLast: Bool { index == pages.count - 1 }
@@ -125,47 +123,97 @@ struct WalkthroughSheet_iOS: View {
     /// Persistent identity + orientation strip. Naming the step count up front
     /// answers "how long is this?" before the user has to guess from the dots.
     private var titleBar: some View {
-        HStack(spacing: 8) {
-            Wordmark(size: 14)
-            Text("Walkthrough")
-                .font(.system(size: 12))
-                .foregroundStyle(palette.mutedForeground)
-
-            Spacer(minLength: 12)
-
-            Text("\(index + 1) of \(pages.count)")
-                .font(.system(size: 11).monospacedDigit())
-                .foregroundStyle(palette.mutedForeground)
-
-            // The only dismiss affordance present on EVERY page. The footer's
-            // Skip button cannot own this: it is hidden on the last page, which
-            // is exactly where a reader who wants out has no other exit.
-            IconButton(help: "Close the walkthrough", action: { dismiss() }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .medium))
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                walkthroughIdentity
+                Spacer(minLength: 12)
+                stepCount
+                closeButton
             }
-            .keyboardShortcut(.cancelAction)
-            .accessibilityIdentifier("walkthrough.close")
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 8) {
+                    wordmark
+                    Spacer(minLength: 12)
+                    closeButton
+                }
+                HStack(spacing: 8) {
+                    Text("Walkthrough")
+                        .font(.subheadline)
+                        .foregroundStyle(palette.mutedForeground)
+                    Spacer(minLength: 12)
+                    stepCount
+                }
+            }
         }
         .padding(.horizontal, 20)
-        // Pinned rather than padded: the page area's height is the sheet's
-        // height minus the chrome, so the chrome must not float.
-        .frame(height: Self.titleBarHeight)
+        .padding(.vertical, 4)
+        .frame(minHeight: Self.minimumTitleBarHeight)
+        .fixedSize(horizontal: false, vertical: true)
     }
 
+    private var walkthroughIdentity: some View {
+        HStack(spacing: 8) {
+            wordmark
+            Text("Walkthrough")
+                .font(.subheadline)
+                .foregroundStyle(palette.mutedForeground)
+        }
+    }
+
+    private var wordmark: some View {
+        HStack(spacing: 0) {
+            Text("Vellum").foregroundStyle(palette.foreground)
+            Text(".").foregroundStyle(palette.primary)
+        }
+        .font(.headline.bold())
+        .fontDesign(.serif)
+        .lineLimit(1)
+        .accessibilityHidden(true)
+    }
+
+    private var stepCount: some View {
+        Text("\(index + 1) of \(pages.count)")
+            .font(.subheadline.monospacedDigit())
+            .foregroundStyle(palette.mutedForeground)
+            .lineLimit(1)
+    }
+
+    /// The only dismiss affordance present on every page. Its visible glyph can
+    /// scale while the interactive frame remains at least 44×44pt.
+    private var closeButton: some View {
+        Button("Close the walkthrough", systemImage: "xmark") { dismiss() }
+            .labelStyle(.iconOnly)
+            .font(.body.weight(.medium))
+            .frame(minWidth: Self.controlSide, minHeight: Self.controlSide)
+            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+            .accessibilityIdentifier("walkthrough.close")
+    }
+
+    @ViewBuilder
     private var pageContent: some View {
-        // Scrolls, but only when the content genuinely does not fit. A fixed
-        // box with `.clipped()` would mean a page one line too tall silently
-        // loses that line — no scroll indicator, no warning. A longer
-        // translation or a larger Dynamic Type size is enough to trigger it.
+        // At normal sizes the scroll view adopts the tallest page so the sheet
+        // opens at its natural compact height. Accessibility text must instead
+        // accept the height offered by the phone; its content then scrolls
+        // inside that bound rather than making the sheet taller than the screen.
+        if dynamicTypeSize.isAccessibilitySize || verticalSizeClass == .compact {
+            // Accessibility text and short landscape screens must accept the
+            // offered height so the persistent title/footer remain reachable.
+            walkthroughPages
+        } else {
+            walkthroughPages
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var walkthroughPages: some View {
         ScrollView(.vertical) {
             ZStack(alignment: .topLeading) {
                 // Every page is laid out here, but only the current one is
-                // drawn. The hidden copies still take part in sizing, so this
-                // ZStack adopts the height of the TALLEST page and holds it —
-                // which is what keeps the footer buttons from jumping as you
-                // page through. Sizing to the real content instead of a
-                // constant means copy edits can't outgrow the sheet.
+                // drawn. The hidden copies keep the footer stable at the height
+                // of the tallest page.
                 ForEach(pages) { item in
                     WalkthroughPageBody(page: item)
                         .hidden()
@@ -173,9 +221,6 @@ struct WalkthroughSheet_iOS: View {
                 }
 
                 WalkthroughPageBody(page: page)
-                    // Re-identify on the page slug so SwiftUI treats each page
-                    // as a new view and actually runs the transition, rather
-                    // than cross-fading text in place.
                     .id(page.id)
                     .transition(
                         .asymmetric(
@@ -186,54 +231,73 @@ struct WalkthroughSheet_iOS: View {
             }
             .frame(maxWidth: .infinity, alignment: .topLeading)
         }
-        // No rubber-banding on pages that already fit, so the scroll only shows
-        // itself when it is actually doing something.
         .scrollBounceBehavior(.basedOnSize)
-        // Take the ZStack's height instead of greedily filling whatever is
-        // offered. On macOS `NSHostingView.fittingSize` resolves a bare
-        // ScrollView to its content; UIKit's `sizeThatFits` does not — the
-        // ScrollView reports no intrinsic height at all, so without this the
-        // sheet collapses to just its two chrome bars and the "size to the
-        // tallest page" contract silently stops holding. The outer
-        // `.frame(maxHeight:)` still clamps it, which is what re-enables real
-        // scrolling once the tallest page passes the backstop.
-        .fixedSize(horizontal: false, vertical: true)
     }
 
     private var footer: some View {
-        HStack(spacing: 12) {
-            if !isLast {
-                TextButton(variant: .ghost, size: .md) { dismiss() } label: {
-                    Text("Skip")
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                if !isLast {
+                    skipButton
                 }
-                .accessibilityIdentifier("walkthrough.skip")
+
+                Spacer(minLength: 12)
+
+                pageIndicator
+
+                Spacer(minLength: 12)
+
+                backButton
+                nextButton
             }
 
-            Spacer(minLength: 12)
-
-            pageIndicator
-
-            Spacer(minLength: 12)
-
-            TextButton(variant: .secondary, size: .md, disabled: isFirst) {
-                go(to: index - 1)
-            } label: {
-                Text("Back")
+            VStack(spacing: 4) {
+                pageIndicator
+                HStack(spacing: 12) {
+                    if !isLast {
+                        skipButton
+                    }
+                    Spacer(minLength: 12)
+                    backButton
+                    nextButton
+                }
             }
-            .accessibilityIdentifier("walkthrough.back")
-
-            TextButton(variant: .primary, size: .md) {
-                if isLast { dismiss() } else { go(to: index + 1) }
-            } label: {
-                Text(isLast ? "Done" : "Next")
-            }
-            // Return advances, and finishes on the last page — the whole
-            // walkthrough is reachable from a keyboard.
-            .keyboardShortcut(.defaultAction)
-            .accessibilityIdentifier("walkthrough.next")
         }
         .padding(.horizontal, 20)
-        .frame(height: Self.footerHeight)
+        .padding(.vertical, 4)
+        .frame(minHeight: Self.minimumFooterHeight)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var skipButton: some View {
+        Button("Skip") { dismiss() }
+            .font(.body)
+            .frame(minWidth: Self.controlSide, minHeight: Self.controlSide)
+            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("walkthrough.skip")
+    }
+
+    private var backButton: some View {
+        Button("Back") { go(to: index - 1) }
+            .font(.body)
+            .frame(minWidth: Self.controlSide, minHeight: Self.controlSide)
+            .buttonStyle(.glass)
+            .disabled(isFirst)
+            .accessibilityIdentifier("walkthrough.back")
+    }
+
+    private var nextButton: some View {
+        Button(isLast ? "Done" : "Next") {
+            if isLast { dismiss() } else { go(to: index + 1) }
+        }
+        .font(.body.bold())
+        .frame(minWidth: Self.controlSide, minHeight: Self.controlSide)
+        .buttonStyle(.glassProminent)
+        // Return advances, and finishes on the last page — the whole
+        // walkthrough is reachable from a keyboard.
+        .keyboardShortcut(.defaultAction)
+        .accessibilityIdentifier("walkthrough.next")
     }
 
     /// Dots double as direct navigation — someone reopening this from the Help
@@ -252,9 +316,8 @@ struct WalkthroughSheet_iOS: View {
                         // schemes (#d6cdbb / #45413a), so it reads in each.
                         .fill(isCurrent ? palette.primary : palette.borderStrong)
                         .frame(width: isCurrent ? 18 : 6, height: 6)
-                        // -12 rather than main's -6: a 6pt dot needs a real
-                        // finger-sized hit area, not a cursor-sized one.
-                        .contentShape(Capsule().inset(by: -12))
+                        .frame(width: Self.controlSide, height: Self.controlSide)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(item.title)
@@ -296,23 +359,24 @@ struct WalkthroughPageBody: View {
                 // Same glass tile as the home screen's hero, one size down —
                 // the walkthrough should read as the same room as the app.
                 Image(systemName: page.symbol)
-                    .font(.system(size: 20, weight: .regular))
+                    .font(.title3)
                     .foregroundStyle(.tint)
-                    .frame(width: 44, height: 44)
+                    .padding(10)
+                    .frame(minWidth: 44, minHeight: 44)
                     .glassEffect(.regular, in: .rect(cornerRadius: Radius.xl))
                     .accessibilityHidden(true)
 
                 Text(page.title)
-                    .font(.system(size: 21, weight: .semibold))
+                    .font(.title2.bold())
                     .foregroundStyle(palette.foreground)
+                    .fixedSize(horizontal: false, vertical: true)
                     .accessibilityAddTraits(.isHeader)
             }
 
             Text(page.summary)
-                .font(.system(size: 13))
+                .font(.body)
                 .foregroundStyle(palette.mutedForeground)
                 .fixedSize(horizontal: false, vertical: true)
-                .lineSpacing(2)
 
             VStack(alignment: .leading, spacing: 12) {
                 ForEach(page.points) { point in
@@ -322,7 +386,7 @@ struct WalkthroughPageBody: View {
 
             if let footnote = page.footnote {
                 Text(footnote)
-                    .font(.system(size: 12))
+                    .font(.footnote)
                     .foregroundStyle(palette.mutedForeground)
                     .fixedSize(horizontal: false, vertical: true)
             }
@@ -334,30 +398,60 @@ struct WalkthroughPageBody: View {
     }
 
     private func bullet(_ point: WalkthroughPoint) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             Image(systemName: point.symbol)
-                .font(.system(size: 13))
+                .font(.body)
                 .foregroundStyle(.tint)
                 // Fixed gutter so every line of body text starts on the same
                 // vertical, whatever each symbol's intrinsic width happens to be.
-                .frame(width: 18, alignment: .center)
+                .frame(minWidth: 24, alignment: .center)
                 .accessibilityHidden(true)
 
-            // Text and keycap share a line and wrap together, so a trailing
-            // shortcut sits at the end of the sentence rather than pinned to
-            // the far right of the sheet where it reads as a separate column.
-            Text(point.text)
-                .font(.system(size: 13))
-                .foregroundStyle(palette.foreground)
-                .fixedSize(horizontal: false, vertical: true)
-                .lineSpacing(2)
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    pointText(point)
+                    if let shortcut = point.shortcut {
+                        WalkthroughKeycap(keys: shortcut)
+                    }
+                    Spacer(minLength: 0)
+                }
 
-            if let shortcut = point.shortcut {
-                Keycap(keys: shortcut)
+                VStack(alignment: .leading, spacing: 6) {
+                    pointText(point)
+                    if let shortcut = point.shortcut {
+                        WalkthroughKeycap(keys: shortcut)
+                    }
+                }
             }
-
-            Spacer(minLength: 0)
         }
+    }
+
+    private func pointText(_ point: WalkthroughPoint) -> some View {
+        Text(point.text)
+            .font(.body)
+            .foregroundStyle(palette.foreground)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private struct WalkthroughKeycap: View {
+    let keys: String
+
+    @Environment(\.palette) private var palette
+
+    var body: some View {
+        Text(keys)
+            .font(.caption.monospaced())
+            .foregroundStyle(palette.foreground)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 3)
+            .background(palette.muted, in: RoundedRectangle(cornerRadius: Radius.sm))
+            .overlay {
+                RoundedRectangle(cornerRadius: Radius.sm)
+                    .strokeBorder(palette.borderStrong)
+            }
+            .accessibilityElement()
+            .accessibilityLabel("Keyboard shortcut \(keys)")
     }
 }
 #endif

--- a/Vellum/Platform/iOS/WebViewerView_iOS.swift
+++ b/Vellum/Platform/iOS/WebViewerView_iOS.swift
@@ -47,7 +47,7 @@ struct WebViewerView_iOS: View {
         if hasActivated || isActive || controller.isAttached {
             GeometryReader { proxy in
                 ZStack(alignment: .topLeading) {
-                    WebViewRepresentable_iOS(controller: controller)
+                    WebViewRepresentable_iOS(controller: controller, isActive: isActive)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                     // Drag-to-crop region snapshot. The scrim intercepts the
@@ -330,8 +330,12 @@ final class VellumWebView: WKWebView, VellumShortcutResponder {
 /// NSViewRepresentable — no AppKit involved.
 private struct WebViewRepresentable_iOS: UIViewRepresentable {
     let controller: WebViewerController_iOS
+    let isActive: Bool
 
     @Environment(WorkspaceStore.self) private var workspace
+    @Environment(\.readerChromeScrollAction) private var readerChromeScrollAction
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeUIView(context: Context) -> VellumWebView {
         // The controller has owned its `WKWebView` outright since this file was
@@ -347,10 +351,45 @@ private struct WebViewRepresentable_iOS: UIViewRepresentable {
         webView.onShortcut = { [workspace] action in
             VellumShortcutRouter.perform(action, workspace: workspace)
         }
+        context.coordinator.configure(
+            scrollView: webView.scrollView,
+            action: isActive ? readerChromeScrollAction : ReaderChromeScrollAction(),
+            controller: controller)
         return webView
     }
 
-    func updateUIView(_ uiView: VellumWebView, context: Context) {}
+    func updateUIView(_ uiView: VellumWebView, context: Context) {
+        context.coordinator.configure(
+            scrollView: uiView.scrollView,
+            action: isActive ? readerChromeScrollAction : ReaderChromeScrollAction(),
+            controller: controller)
+    }
+
+    static func dismantleUIView(_ uiView: VellumWebView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    @MainActor
+    final class Coordinator {
+        private let chromeScrollObserver = ReaderChromeNativeScrollObserver()
+
+        func configure(
+            scrollView: UIScrollView,
+            action: ReaderChromeScrollAction,
+            controller: WebViewerController_iOS
+        ) {
+            chromeScrollObserver.configure(
+                scrollView: scrollView,
+                action: action,
+                sourceInteractionBlocked: { [weak controller] in
+                    controller?.blocksAutomaticChromeChanges ?? true
+                })
+        }
+
+        func detach() {
+            chromeScrollObserver.detach()
+        }
+    }
 }
 
 // MARK: - Controller (the WebViewer bridge logic, iOS)
@@ -394,6 +433,18 @@ final class WebViewerController_iOS: NSObject {
             guard highlightEditor?.id != oldValue?.id else { return }
             pushSelectedHighlight()
         }
+    }
+
+    /// A direct pan that begins as selection, note, or annotation interaction
+    /// is reserved for that work and cannot also change phone chrome.
+    var blocksAutomaticChromeChanges: Bool {
+        guard let app, let mountTabId, app.activeTabId == mountTabId else { return true }
+        return selection != nil
+            || selectionNoteDraft != nil
+            || noteComposer != nil
+            || contextMenu != nil
+            || noteViewer != nil
+            || highlightEditor != nil
     }
 
     @ObservationIgnored private weak var app: AppStore?

--- a/Vellum/Platform/iOS/WebViewerView_iOS.swift
+++ b/Vellum/Platform/iOS/WebViewerView_iOS.swift
@@ -363,6 +363,9 @@ final class WebViewerController_iOS: NSObject {
     // after in-tab navigation replaces the document.
     private(set) var initCount = 0
     private(set) var isOffline = false
+    /// Observable history state for phone/iPad toolbar disabled states.
+    private(set) var canGoBack = false
+    private(set) var canGoForward = false
     private(set) var selection: WebSelection?
     private(set) var popoverPosition: CGPoint?
     /// The selection pinned while the selection popover's note field is open.
@@ -724,6 +727,11 @@ final class WebViewerController_iOS: NSObject {
     func goForward() {
         guard webView.canGoForward else { return }
         webView.goForward()
+    }
+
+    private func updateHistoryAvailability(_ webView: WKWebView) {
+        canGoBack = webView.canGoBack
+        canGoForward = webView.canGoForward
     }
 
     func reload() {
@@ -1665,6 +1673,18 @@ extension WebViewerController_iOS: WKScriptMessageHandler {
 }
 
 extension WebViewerController_iOS: WKNavigationDelegate, WKUIDelegate {
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        updateHistoryAvailability(webView)
+    }
+
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        updateHistoryAvailability(webView)
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        updateHistoryAvailability(webView)
+    }
+
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction

--- a/Vellum/Views/Help/HelpTopic.swift
+++ b/Vellum/Views/Help/HelpTopic.swift
@@ -77,7 +77,7 @@ struct HelpTopic: Identifiable, Sendable, Equatable {
             id: "phone-reader",
             title: "Use the iPhone reader",
             symbol: "iphone",
-            summary: "Tap the page indicator to jump in a PDF. The bottom bar also holds bookmarks, the sticky-note tool, the inspector, open documents, and More actions.",
+            summary: "Tap the document to show or hide both reader bars. Scrolling toward later content also hides them, and a brief reverse scroll reveals them. The bottom bar holds page navigation, bookmarks, notes, the inspector, tabs, and More actions.",
             shortcut: nil,
             keywords: ["phone", "chrome", "page", "toolbar", "controls", "jump"]),
         HelpTopic(

--- a/Vellum/Views/Settings/IntegrationsSettingsTab.swift
+++ b/Vellum/Views/Settings/IntegrationsSettingsTab.swift
@@ -44,6 +44,9 @@ struct IntegrationsSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .contentMargins(.bottom, 32, for: .scrollContent)
+        #endif
         // No `.frame(height: 460)`: on iPad the settings sheet fills its own
         // presentation, and pinning a height would strand the last row.
         .sheet(item: $connectProvider) { ConnectServiceSheet(provider: $0) }

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -11,8 +11,27 @@ struct SettingsView: View {
     /// AI…", a Storage warning — can route to the right tab instead of dumping
     /// the reader on General and making them find it.
     @Environment(WorkspaceStore.self) private var workspace
+    #if os(iOS)
+    @State private var phoneTab: SettingsPhoneTab = .general
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    #endif
 
     var body: some View {
+        #if os(iOS)
+        phoneSettings
+        .onAppear {
+            phoneTab = SettingsPhoneTab(section: workspace.settingsSection)
+        }
+        .onChange(of: workspace.settingsSection) { _, section in
+            phoneTab = SettingsPhoneTab(section: section)
+        }
+        .onChange(of: phoneTab) { _, tab in
+            if let section = tab.settingsSection {
+                workspace.settingsSection = section
+            }
+        }
+        .accessibilityIdentifier("settings.content")
+        #else
         @Bindable var workspace = workspace
         TabView(selection: $workspace.settingsSection) {
             GeneralSettingsTab()
@@ -40,13 +59,136 @@ struct SettingsView: View {
                 .tag(WorkspaceStore.SettingsSection.integrations)
         }
         .accessibilityIdentifier("settings.content")
-        #if os(macOS)
-        // Fixed-width settings window on macOS; on iPad the sheet fills its
-        // presentation and the TabView renders as a bottom tab bar.
+        // Fixed-width settings window on macOS.
         .frame(width: 480)
         #endif
     }
+
+    #if os(iOS)
+    @ViewBuilder
+    private var phoneSettings: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(spacing: 0) {
+                phoneTabContent
+                Divider()
+                accessibilityTabBar
+            }
+        } else {
+            TabView(selection: $phoneTab) {
+                SettingsTabNavigation { GeneralSettingsTab() }
+                    .tabItem { Label("General", systemImage: "gearshape") }
+                    .tag(SettingsPhoneTab.general)
+                SettingsTabNavigation { ReadingSettingsTab() }
+                    .tabItem { Label("Reading", systemImage: "text.book.closed") }
+                    .tag(SettingsPhoneTab.reading)
+                SettingsTabNavigation { AnnotationsSettingsTab() }
+                    .tabItem { Label("Annotations", systemImage: "highlighter") }
+                    .tag(SettingsPhoneTab.annotations)
+                SettingsTabNavigation { AiSettingsTab() }
+                    .tabItem { Label("AI", systemImage: "sparkles") }
+                    .tag(SettingsPhoneTab.ai)
+                MoreSettingsNavigation()
+                    .tabItem { Label("More", systemImage: "ellipsis") }
+                    .tag(SettingsPhoneTab.more)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var phoneTabContent: some View {
+        switch phoneTab {
+        case .general: SettingsTabNavigation { GeneralSettingsTab() }
+        case .reading: SettingsTabNavigation { ReadingSettingsTab() }
+        case .annotations: SettingsTabNavigation { AnnotationsSettingsTab() }
+        case .ai: SettingsTabNavigation { AiSettingsTab() }
+        case .more: MoreSettingsNavigation()
+        }
+    }
+
+    private var accessibilityTabBar: some View {
+        HStack(spacing: 8) {
+            ForEach(SettingsPhoneTab.allCases, id: \.self) { tab in
+                Button {
+                    phoneTab = tab
+                } label: {
+                    VStack(spacing: 2) {
+                        Image(systemName: tab.symbol)
+                            .font(.title3)
+                        Text(tab.title)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.65)
+                    }
+                        .frame(maxWidth: .infinity, minHeight: 52)
+                        .background(
+                            tab == phoneTab ? Color.accentColor.opacity(0.14) : .clear,
+                            in: RoundedRectangle(cornerRadius: 10))
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(tab == phoneTab ? Color.accentColor : .secondary)
+                .accessibilityLabel(tab.title)
+                .accessibilityAddTraits(tab == phoneTab ? [.isButton, .isSelected] : .isButton)
+                .accessibilityIdentifier("settings.tab.\(tab.title.lowercased())")
+            }
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .background(.bar)
+    }
+    #endif
 }
+
+#if os(iOS)
+enum SettingsPhoneTab: Hashable, CaseIterable {
+    case general
+    case reading
+    case annotations
+    case ai
+    case more
+
+    init(section: WorkspaceStore.SettingsSection) {
+        switch section {
+        case .general: self = .general
+        case .reading: self = .reading
+        case .annotations: self = .annotations
+        case .ai: self = .ai
+        case .storage, .integrations: self = .more
+        }
+    }
+
+    var settingsSection: WorkspaceStore.SettingsSection? {
+        switch self {
+        case .general: .general
+        case .reading: .reading
+        case .annotations: .annotations
+        case .ai: .ai
+        case .more: nil
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .reading: "Reading"
+        case .annotations: "Annotations"
+        case .ai: "AI"
+        case .more: "More"
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .general: "gearshape"
+        case .reading: "text.book.closed"
+        case .annotations: "highlighter"
+        case .ai: "sparkles"
+        case .more: "ellipsis"
+        }
+    }
+}
+#endif
 
 // MARK: - General
 
@@ -69,14 +211,23 @@ private struct GeneralSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .contentMargins(.bottom, 32, for: .scrollContent)
+        #else
         .scrollDisabled(true)
+        #endif
     }
 
     private var systemFooter: String {
         #if os(macOS)
         "System follows macOS and updates live when you change appearance in Control Center."
         #else
-        "System follows iPadOS and updates live when you change appearance in Control Center."
+        switch ShellIdiom_iOS.current {
+        case .phone:
+            "System follows iOS and updates live when you change your iPhone’s appearance in Control Center."
+        case .pad:
+            "System follows iPadOS and updates live when you change your iPad’s appearance in Control Center."
+        }
         #endif
     }
 
@@ -109,10 +260,15 @@ private struct ReadingSettingsTab: View {
                 ) {
                     Text("Sidebar text size")
                 } minimumValueLabel: {
-                    Text("A").font(.system(size: 10))
+                    Text("A")
+                        .font(.caption)
+                        .accessibilityHidden(true)
                 } maximumValueLabel: {
-                    Text("A").font(.system(size: 16))
+                    Text("A")
+                        .font(.title3)
+                        .accessibilityHidden(true)
                 }
+                .accessibilityValue("\(Int(workspace.sidebarFontSize)) points")
                 LabeledContent("Current size") {
                     Text("\(Int(workspace.sidebarFontSize)) pt")
                         .foregroundStyle(.secondary)
@@ -156,7 +312,11 @@ private struct ReadingSettingsTab: View {
             #endif
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .contentMargins(.bottom, 32, for: .scrollContent)
+        #else
         .scrollDisabled(true)
+        #endif
     }
 
     private var fontSizeBinding: Binding<Double> {
@@ -192,7 +352,11 @@ private struct AnnotationsSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .contentMargins(.bottom, 32, for: .scrollContent)
+        #else
         .scrollDisabled(true)
+        #endif
     }
 
     private func swatch(_ color: HighlightColor) -> some View {
@@ -209,6 +373,8 @@ private struct AnnotationsSettingsTab: View {
                         lineWidth: selected ? 2.5 : 1
                     )
                 }
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .help(color.name)
@@ -292,7 +458,11 @@ private struct AiSettingsTab: View {
             }
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .contentMargins(.bottom, 32, for: .scrollContent)
+        #else
         .scrollDisabled(true)
+        #endif
         .onChange(of: aiStore.settings.provider) { _, _ in validationState = .idle }
         .onChange(of: aiStore.activeModelName) { _, _ in validationState = .idle }
         .onChange(of: aiStore.apiKeyBinding.wrappedValue) { _, _ in validationState = .idle }

--- a/Vellum/Views/Settings/SettingsView.swift
+++ b/Vellum/Views/Settings/SettingsView.swift
@@ -244,6 +244,8 @@ private struct GeneralSettingsTab: View {
 private struct ReadingSettingsTab: View {
     @Environment(WorkspaceStore.self) private var workspace
     #if os(iOS)
+    @AppStorage(ReaderControlPreferences.alwaysShowReaderControlsKey)
+    private var alwaysShowReaderControls = false
     @AppStorage("twoFingerNoteTap") private var twoFingerNoteTap = true
     @AppStorage(PencilDoubleTapAction.defaultsKey) private var pencilDoubleTap = PencilDoubleTapAction.eraser.rawValue
     @AppStorage(InkController_iOS.autoHideSidebarKey) private var autoHideSidebarWhileInking = true
@@ -283,6 +285,21 @@ private struct ReadingSettingsTab: View {
             }
 
             #if os(iOS)
+            if ShellIdiom_iOS.current == .phone {
+                Section {
+                    Toggle(
+                        "Always show reader controls",
+                        isOn: $alwaysShowReaderControls)
+                        .accessibilityIdentifier("settings.reader.alwaysShowControls")
+                } header: {
+                    Text("Reader")
+                } footer: {
+                    Text("Keeps the iPhone reader’s top and bottom bars visible while you scroll. Assistive navigation also enables this behavior automatically.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             Section {
                 Toggle("Two-finger double-tap adds a note", isOn: $twoFingerNoteTap)
             } header: {

--- a/Vellum/Views/Settings/StorageSettingsTab.swift
+++ b/Vellum/Views/Settings/StorageSettingsTab.swift
@@ -95,6 +95,9 @@ struct StorageSettingsTab: View {
             removeStoredDataSection
         }
         .formStyle(.grouped)
+        #if os(iOS)
+        .contentMargins(.bottom, 32, for: .scrollContent)
+        #endif
         .task {
             refreshSettings()
             await reload()
@@ -372,6 +375,7 @@ struct StorageSettingsTab: View {
                 }
             }
             .disabled(isCleaningUp || StorageHousekeeping.evictionCutoff() == nil)
+            .accessibilityLabel("Run Cleanup Now")
             .accessibilityIdentifier("storage.runCleanup")
             if let cleanupResult {
                 Text(cleanupResult)

--- a/Vellum/Views/Shared/Controls.swift
+++ b/Vellum/Views/Shared/Controls.swift
@@ -22,8 +22,9 @@ struct IconButton<Icon: View>: View {
     @Environment(\.palette) private var palette
     @State private var hovering = false
 
+    @ViewBuilder
     var body: some View {
-        Button(action: action) {
+        let button = Button(action: action) {
             icon()
                 .frame(width: size.side, height: size.side)
                 .background(background)
@@ -35,8 +36,14 @@ struct IconButton<Icon: View>: View {
         .disabled(disabled)
         .opacity(disabled && variant == .ghost ? 0.3 : (disabled ? 0.5 : 1))
         .onHover { hovering = $0 }
-        .help(help ?? "")
-        .accessibilityLabel(help ?? "")
+
+        if let help, !help.isEmpty {
+            button
+                .help(help)
+                .accessibilityLabel(help)
+        } else {
+            button
+        }
     }
 
     private var background: AnyShapeStyle {
@@ -63,7 +70,7 @@ enum TextButtonSize {
     case sm, md, lg
     var height: CGFloat { switch self { case .sm: 28; case .md: 36; case .lg: 44 } }
     var paddingX: CGFloat { switch self { case .sm: 10; case .md: 14; case .lg: 20 } }
-    var fontSize: CGFloat { switch self { case .sm: 12; case .md: 14; case .lg: 14 } }
+    var font: Font { switch self { case .sm: .footnote; case .md, .lg: .subheadline } }
     var gap: CGFloat { switch self { case .sm: 6; case .md: 8; case .lg: 8 } }
 }
 
@@ -79,7 +86,7 @@ struct TextButton<Content: View>: View {
     var body: some View {
         let button = Button(action: action) {
             HStack(spacing: size.gap) { label() }
-                .font(.system(size: size.fontSize, weight: .medium))
+                .font(size.font.weight(.medium))
                 .padding(.horizontal, size.paddingX / 2)
                 .frame(minHeight: size.height - 12)
         }
@@ -113,7 +120,7 @@ struct Keycap: View {
 
     var body: some View {
         Text(keys)
-            .font(.system(size: 11, design: .monospaced))
+            .font(.system(.caption2, design: .monospaced))
             .foregroundStyle(palette.foreground)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
@@ -136,9 +143,10 @@ struct Keycap: View {
 }
 
 /// The Vellum wordmark. Set in the serif display face — the one place the
-/// "parchment" identity is allowed to speak loudly. Render at the real point
-/// size: scaling it up with scaleEffect rasterizes the small glyphs and
-/// produces a blurry bitmap.
+/// "parchment" identity is allowed to speak loudly. The custom face scales with
+/// Dynamic Type up to the largest standard size, then stops: this is decorative
+/// branding, and letting accessibility sizes enlarge it further fragments the
+/// word instead of making functional content easier to read.
 struct Wordmark: View {
     var size: CGFloat = 15
 
@@ -147,8 +155,14 @@ struct Wordmark: View {
     var body: some View {
         (Text("Vellum").foregroundStyle(palette.foreground)
             + Text(".").foregroundStyle(palette.primary))
-            .font(.custom("Iowan Old Style", size: size).weight(.semibold))
+            .font(
+                .custom("Iowan Old Style", size: size, relativeTo: .title)
+                    .weight(.semibold))
             .kerning(-0.2 * size / 15)
+            .lineLimit(1)
+            .minimumScaleFactor(0.75)
+            .allowsTightening(true)
+            .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+            .accessibilityHidden(true)
     }
 }
-

--- a/Vellum/Views/Shared/InspectorTabSwitcher.swift
+++ b/Vellum/Views/Shared/InspectorTabSwitcher.swift
@@ -30,11 +30,9 @@ enum InspectorLayout {
     /// Inset applied to the switcher inside the inspector column.
     static let switcherHorizontalPadding: CGFloat = 12
     static let switcherVerticalPadding: CGFloat = 8
-    /// 36 on iPad, not macOS's 30. A 30 pt segment is well under the 44 pt HIG
-    /// touch target; 36 pt of control inside 8 pt of vertical padding gives a
-    /// 52 pt row, and the segment gets the rest of its reach from the
-    /// `.contentShape(Rectangle())` inside its label.
-    static let switcherHeight: CGFloat = 36
+    /// A real 44pt segment. Padding around a Button does not enlarge that
+    /// Button's accessibility frame, so the control itself owns the HIG floor.
+    static let switcherHeight: CGFloat = 44
 
     /// Height of the inspector's header row — the control plus its inset,
     /// stopping above the divider. On iPad this is a layout fact only: main's
@@ -161,9 +159,7 @@ struct InspectorTabSwitcher: View {
                 let isSelected = selection == tab
                 let isHovering = hovering == tab
                 Button {
-                    withAnimation(.snappy) {
-                        selection = tab
-                    }
+                    selection = tab
                 } label: {
                     Group {
                         if showTitles {


### PR DESCRIPTION
> **TL;DR** — The iPhone UI blockers from the simulator audit are implemented. This branch fixes Settings, reader layout, inspector navigation, persistent Add PDF access, responsive text/tab layouts, and the final tap-plus-scroll reader interaction. The PR stays draft only for the remaining real-device and full-matrix checks.

## Stack

- **Parent application PR:** #189 — `iphone-app-implementation` → `ipad-app`
- **This PR:** `iphone-app` → `iphone-app-implementation`
- **Merge order:** #33 → #189 → this PR
- **Current head:** `c7ea1755`

## Completed linked blockers

- [x] #183 — Settings forms scroll, preserve bottom clearance, and expose Storage/Integrations through an explicit More route.
- [x] #184 — The reader title is geometrically centered and keeps useful context with middle truncation.
- [x] #185 — Annotations, AI, and Scratchpad now select the requested inspector panel rather than only changing the sheet height.
- [x] #186 — Add PDF remains visible and accessible from populated Home.
- [x] #187 / #192 — Reader chrome now uses the agreed tap-plus-directional-scroll interaction described below.

## Final reader interaction

- One non-cancelling tap anywhere in PDF or webpage document content toggles both bars together; links and native document handling still receive the touch.
- About 28 points of direct scrolling toward later content hides both bars; the same accumulated reverse travel reveals them.
- Hidden bars remain hidden at rest. There is no persistent reveal button and no edge gesture competing with system navigation.
- Native multi-taps, selection/note work, keyboard input, Find, inspector interaction, horizontal movement, bounce, programmatic jumps, and pinch zoom are protected.
- **Settings → Reading → Always show reader controls** prevents hiding; VoiceOver and Switch Control receive the same stable-controls behavior.

## Other completed stabilization

- Replaced fixed-size text across the audited phone surfaces with Dynamic Type styles and added accessibility-size layouts for Settings, Home, walkthrough, reader, and tab cards.
- Reworked the tab switcher with identifiable previews, readable duplicate-document metadata, 44-point close controls, and safe-area clearance.
- Removed blank accessibility actions from audited reader/settings controls and expanded undersized interaction targets.
- Fixed webpage back/forward disabled states and kept reader arrivals, Home returns, and tab-switcher returns synchronized with visible controls.
- Preserved the iPad shell: shared PDF/Web adapters receive a no-op chrome action outside the phone shell.

## Validation

- iPhone 17 Pro, iOS 27 simulator build: **passed**
- iPad Pro 13-inch (M5), iOS 27 simulator build: **passed**
- Focused reader suites: **22/22 logical tests passed** (**28** parameterized executions)
- Web runtime: content/link taps preserved navigation, hid both bars, stayed hidden for two seconds, then revealed both bars on the next document tap
- `ChromeTapCatcher_iOS.swift`: zero warnings; `git diff --check`: passed

## Remaining before ready-for-review

- [ ] Perform the real-iPhone gesture checks retained in #167, especially true double-tap zoom, Pencil/note interaction, and hardware accessibility behavior.
- [ ] Re-run the complete PR verification matrix on the final stacked branches.
- [ ] Capture the final screenshot/recording set for Home, reader, inspector, tabs, Settings, and maximum Dynamic Type.

Closes #183
Closes #184
Closes #185
Closes #186
Closes #187
Closes #192
