### PR TITLE
Preserve annotations when read-later PDFs update

### DIFF
--- a/Tests/Integrations/IntegrationsCacheTests.swift
+++ b/Tests/Integrations/IntegrationsCacheTests.swift
@@ -89,7 +89,11 @@ struct IntegrationsCacheTests {
         #expect(FileManager.default.fileExists(atPath: partFile.path) == false)
     }
 
-    @Test func installReplacesAStaleCopyButRejectsARepeatOfTheSameRevision() async throws {
+    @Test(
+        "Installing a provider revision preserves the user's previous PDF",
+        .bug("https://github.com/ayushdeolasee/Vellum/issues/164")
+    )
+    func installPreservesAStaleCopyButRejectsARepeatOfTheSameRevision() async throws {
         let root = try IntegrationTemporaryRoot.make()
         defer { try? FileManager.default.removeItem(at: root) }
         let cache = IntegrationsCache(root: root)
@@ -97,7 +101,7 @@ struct IntegrationsCacheTests {
         try Data("%PDF-first".utf8).write(to: first)
         let installed = try await cache.installDownload(temporaryURL: first, manifest: .init(provider: .raindrop, itemID: "item", revision: "r1"))
 
-        #expect(try await cache.currentDownload(provider: .raindrop, itemID: "item", revision: "r1") == installed)
+        #expect(try await cache.currentDownload(provider: .raindrop, itemID: "item", revision: "r1") == installed.currentURL)
         #expect(try await cache.currentDownload(provider: .raindrop, itemID: "item", revision: "r2") == nil)
 
         let duplicate = try await cache.temporaryDownloadURL(provider: .raindrop, itemID: "item")
@@ -108,11 +112,37 @@ struct IntegrationsCacheTests {
 
         let refreshed = try await cache.temporaryDownloadURL(provider: .raindrop, itemID: "item")
         try Data("%PDF-second".utf8).write(to: refreshed)
-        let replaced = try await cache.installDownload(temporaryURL: refreshed, manifest: .init(provider: .raindrop, itemID: "item", revision: "r2"))
+        let replacement = try await cache.installDownload(temporaryURL: refreshed, manifest: .init(provider: .raindrop, itemID: "item", revision: "r2"))
 
-        #expect(replaced == installed)
-        #expect(String(decoding: try Data(contentsOf: replaced), as: UTF8.self) == "%PDF-second")
+        #expect(replacement.currentURL != installed.currentURL)
+        #expect(replacement.preservedRevisionURL == installed.currentURL)
+        #expect(String(decoding: try Data(contentsOf: installed.currentURL), as: UTF8.self) == "%PDF-first")
+        #expect(String(decoding: try Data(contentsOf: replacement.currentURL), as: UTF8.self) == "%PDF-second")
         #expect(try await cache.currentDownload(provider: .raindrop, itemID: "item", revision: "r1") == nil)
+        #expect(try await cache.currentDownload(provider: .raindrop, itemID: "item", revision: "r2") == replacement.currentURL)
+        #expect(try await cache.pendingPreviousRevisionURL(provider: .raindrop, itemID: "item") == installed.currentURL)
+
+        let newest = try await cache.temporaryDownloadURL(provider: .raindrop, itemID: "item")
+        try Data("%PDF-third".utf8).write(to: newest)
+        let third = try await cache.installDownload(
+            temporaryURL: newest,
+            // Providers can roll back to an older revision identifier. That
+            // must not reuse and overwrite the user's first r1 file.
+            manifest: .init(provider: .raindrop, itemID: "item", revision: "r1"))
+        try await cache.acknowledgeRevisionWarning(
+            provider: .raindrop, itemID: "item",
+            previousRevisionURL: installed.currentURL)
+        #expect(try await cache.pendingPreviousRevisionURL(provider: .raindrop, itemID: "item") == replacement.currentURL)
+        try await cache.acknowledgeRevisionWarning(
+            provider: .raindrop, itemID: "item",
+            previousRevisionURL: replacement.currentURL)
+        #expect(try await cache.pendingPreviousRevisionURL(provider: .raindrop, itemID: "item") == nil)
+        #expect(FileManager.default.fileExists(atPath: installed.currentURL.path))
+        #expect(FileManager.default.fileExists(atPath: third.currentURL.path))
+        #expect(third.currentURL != installed.currentURL)
+        #expect(try await cache.currentDownload(
+            provider: .raindrop, itemID: "item", revision: "r1") == third.currentURL)
+        #expect(await cache.downloadURLs(provider: .raindrop, itemID: "item").count == 3)
     }
 
     @Test func downloadArtifactPresenceDistinguishesPDFsFromUnknownArticleIDs() async throws {

--- a/Tests/Integrations/IntegrationsStoreTests.swift
+++ b/Tests/Integrations/IntegrationsStoreTests.swift
@@ -86,6 +86,73 @@ struct IntegrationsStoreTests {
         #expect(store.connectedProviders.contains(.readwise))
     }
 
+    @Test(
+        "Opening a new revision offers the preserved copy once",
+        .bug("https://github.com/ayushdeolasee/Vellum/issues/164")
+    )
+    func openingANewRevisionOffersThePreservedCopyOnce() async throws {
+        let root = try IntegrationTemporaryRoot.make()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let suiteName = "Vellum.IntegrationsStoreTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw IntegrationTestFixtureError.couldNotCreateUserDefaults
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let token = "token"
+        let fingerprint = integrationFingerprint(token)
+        let preferences = IntegrationPreferences(defaults: defaults)
+        preferences.autoRefreshEnabled = false
+        preferences.persist(
+            .init(enabled: true, generation: 1, accountFingerprint: fingerprint),
+            for: .readwise)
+        let item = try makeIntegrationItem(
+            provider: .readwise, id: "revised-pdf",
+            updatedAt: Date(timeIntervalSince1970: 1_700_003_600), kind: .pdf,
+            pdfRetrieval: .readwiseItem(id: "revised-pdf"))
+        let cache = IntegrationsCache(root: root)
+        try await cache.save(.init(
+            provider: .readwise, accountFingerprint: fingerprint,
+            connectionGeneration: 1, items: [item],
+            collections: ReadwiseClient.locationCollections,
+            committedBoundary: item.updatedAt, tentativePagination: nil,
+            lastSuccessfulSync: item.updatedAt, lastFullSweep: nil,
+            skippedRecordCount: 0))
+        let first = try await cache.temporaryDownloadURL(
+            provider: .readwise, itemID: item.vendorID)
+        try Data("%PDF-previous".utf8).write(to: first)
+        let firstInstallation = try await cache.installDownload(
+            temporaryURL: first,
+            manifest: .init(
+                provider: .readwise, itemID: item.vendorID, revision: "old"))
+        let second = try await cache.temporaryDownloadURL(
+            provider: .readwise, itemID: item.vendorID)
+        try Data("%PDF-current".utf8).write(to: second)
+        let currentRevision = ISO8601DateFormatter.integrationString(from: item.updatedAt)
+        let secondInstallation = try await cache.installDownload(
+            temporaryURL: second,
+            manifest: .init(
+                provider: .readwise, itemID: item.vendorID, revision: currentRevision))
+        let engine = IntegrationsSyncEngine(
+            credentials: InMemoryIntegrationCredentials([.readwise: token]),
+            cache: cache,
+            preferences: try makeIntegrationPreferences(suiteName: suiteName),
+            readwise: ScriptedReadwiseService(),
+            raindrop: ScriptedRaindropService())
+        let store = IntegrationsStore(engine: engine)
+        await store.start()
+
+        #expect(try await store.route(for: item) == .file(secondInstallation.currentURL))
+        #expect(store.previousRevisionURL(for: item.id) == firstInstallation.currentURL)
+        #expect(store.downloads[item.id]?.message.contains("previous copy") == true)
+        #expect(store.readLaterItem(forOpenDocumentPath: firstInstallation.currentURL.path) == item)
+        #expect(store.takePreviousRevision(for: item.id) == firstInstallation.currentURL)
+        #expect(store.previousRevisionURL(for: item.id) == nil)
+        await store.awaitQuiescence()
+        #expect(try await cache.pendingPreviousRevisionURL(
+            provider: item.provider, itemID: item.vendorID) == nil)
+        #expect(FileManager.default.fileExists(atPath: firstInstallation.currentURL.path))
+    }
+
     @Test func missingCredentialAtLaunchKeepsCachedProviderAvailableForReconnect() async throws {
         let root = try IntegrationTemporaryRoot.make()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/Integrations/IntegrationsSyncEngineTests.swift
+++ b/Tests/Integrations/IntegrationsSyncEngineTests.swift
@@ -740,7 +740,11 @@ struct IntegrationsSyncEngineTests {
         #expect(full.lastFullSweep != nil)
     }
 
-    @Test func anItemUpdatedOnTheServiceIsDownloadedAgainInsteadOfServingTheStaleCopy() async throws {
+    @Test(
+        "A provider update downloads separately and leaves the previous revision available",
+        .bug("https://github.com/ayushdeolasee/Vellum/issues/164")
+    )
+    func anItemUpdatedOnTheServiceIsDownloadedAgainInsteadOfServingTheStaleCopy() async throws {
         let updatedAt = Date(timeIntervalSince1970: 1_700_000_000)
         let item = try makeIntegrationItem(provider: .readwise, id: "rw-pdf", updatedAt: updatedAt, kind: .pdf, pdfRetrieval: .readwiseItem(id: "rw-pdf"))
         let harness = try await IntegrationEngineHarness.make(provider: .readwise) { fingerprint, generation in
@@ -763,10 +767,20 @@ struct IntegrationsSyncEngineTests {
         let second = try await engine.download(updated) { _ in }
 
         #expect(staleRoute == nil)
-        #expect(second == first)
+        #expect(second != first)
         #expect(await downloader.requests().count == 2)
         #expect(await engine.existingRoute(for: updated) == second)
         #expect(await engine.existingRoute(for: item) == nil)
+        guard case .file(let previousURL) = first else {
+            Issue.record("Expected the first revision to be a local PDF")
+            return
+        }
+        #expect(await engine.pendingPreviousRevisionURL(for: updated) == previousURL)
+        #expect(FileManager.default.fileExists(atPath: previousURL.path))
+        await engine.acknowledgeRevisionWarning(
+            for: updated, previousRevisionURL: previousURL)
+        #expect(await engine.pendingPreviousRevisionURL(for: updated) == nil)
+        #expect(FileManager.default.fileExists(atPath: previousURL.path))
         let manifestURL = try await harness.cache.manifestURL(provider: .readwise, itemID: item.vendorID)
         let manifest = try JSONDecoder().decode(IntegrationsCache.DownloadManifest.self, from: Data(contentsOf: manifestURL))
         #expect(manifest.revision == ISO8601DateFormatter.integrationString(from: updated.updatedAt))

--- a/Vellum/Platform/iOS/ExternalLibraryList_iOS.swift
+++ b/Vellum/Platform/iOS/ExternalLibraryList_iOS.swift
@@ -73,7 +73,12 @@ struct ExternalLibraryList_iOS: View {
                 FloatingNotice(
                     message: notice.state.message, progress: notice.state.progress,
                     isActive: notice.state.isActive, isSuccess: notice.state.isSuccess,
-                    accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice"
+                    accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice",
+                    actionTitle: integrations.previousRevisionURL(for: notice.id) == nil ? nil : "Open Previous",
+                    action: {
+                        guard let url = integrations.takePreviousRevision(for: notice.id) else { return }
+                        Task { await appStore.openFile(path: url.path) }
+                    }
                 ) {
                     if notice.isMove { integrations.dismissMoveNotice(notice.id) } else { integrations.dismissDownloadNotice(notice.id) }
                 }

--- a/Vellum/Platform/iOS/PaneView_iOS.swift
+++ b/Vellum/Platform/iOS/PaneView_iOS.swift
@@ -195,7 +195,12 @@ struct PaneView_iOS: View {
             FloatingNotice(
                 message: notice.state.message, progress: notice.state.progress,
                 isActive: notice.state.isActive, isSuccess: notice.state.isSuccess,
-                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice"
+                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice",
+                actionTitle: integrations.previousRevisionURL(for: item.id) == nil ? nil : "Open Previous",
+                action: {
+                    guard let url = integrations.takePreviousRevision(for: item.id) else { return }
+                    Task { await app.openFile(path: url.path) }
+                }
             ) {
                 if notice.isMove { integrations.dismissMoveNotice(item.id) } else { integrations.dismissDownloadNotice(item.id) }
             }

--- a/Vellum/Platform/iOS/PhoneHome_iOS.swift
+++ b/Vellum/Platform/iOS/PhoneHome_iOS.swift
@@ -621,7 +621,12 @@ struct PhoneHome_iOS: View {
             FloatingNotice(
                 message: notice.state.message, progress: notice.state.progress,
                 isActive: notice.state.isActive, isSuccess: notice.state.isSuccess,
-                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice"
+                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice",
+                actionTitle: integrations.previousRevisionURL(for: notice.id) == nil ? nil : "Open Previous",
+                action: {
+                    guard let url = integrations.takePreviousRevision(for: notice.id) else { return }
+                    Task { await appStore.openFiles(paths: [url.path]) }
+                }
             ) {
                 if notice.isMove {
                     integrations.dismissMoveNotice(notice.id)

--- a/Vellum/Platform/iOS/WelcomeScreen_iOS.swift
+++ b/Vellum/Platform/iOS/WelcomeScreen_iOS.swift
@@ -248,7 +248,12 @@ struct WelcomeLibrary_iOS: View {
             FloatingNotice(
                 message: notice.state.message, progress: notice.state.progress,
                 isActive: notice.state.isActive, isSuccess: notice.state.isSuccess,
-                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice"
+                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice",
+                actionTitle: integrations.previousRevisionURL(for: notice.id) == nil ? nil : "Open Previous",
+                action: {
+                    guard let url = integrations.takePreviousRevision(for: notice.id) else { return }
+                    Task { await appStore.openFiles(paths: [url.path]) }
+                }
             ) {
                 if notice.isMove {
                     integrations.dismissMoveNotice(notice.id)

--- a/Vellum/Services/Integrations/IntegrationThumbnailCache.swift
+++ b/Vellum/Services/Integrations/IntegrationThumbnailCache.swift
@@ -1,7 +1,13 @@
 import CryptoKit
 import Foundation
 import ImageIO
+#if os(macOS)
+import AppKit
+typealias IntegrationThumbnailImage = NSImage
+#else
 import UIKit
+typealias IntegrationThumbnailImage = UIImage
+#endif
 
 actor IntegrationThumbnailCache {
     private let root: URL
@@ -42,9 +48,9 @@ actor IntegrationThumbnailCache {
     /// downsampled to `maximumThumbnailPixelSize` so a 4000px hero image doesn't
     /// sit in memory to fill a 34pt well.
     ///
-    /// `sending` because `UIImage` isn't Sendable — this instance is created
+    /// `sending` because the platform image type isn't Sendable — this instance is created
     /// here, never stored, and never touched again once handed back.
-    func image(for candidate: URL?) async -> sending UIImage? {
+    func image(for candidate: URL?) async -> sending IntegrationThumbnailImage? {
         guard let url = await imageURL(for: candidate) else { return nil }
         guard let data = try? Data(contentsOf: url, options: .mappedIfSafe),
               let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
@@ -59,7 +65,11 @@ actor IntegrationThumbnailCache {
         // `maximumThumbnailPixelSize` and the row applies
         // `.resizable().scaledToFill()` inside a fixed frame. `UIScreen.main.scale`
         // would be wrong here anyway — it is main-actor-bound and deprecated.
+#if os(macOS)
+        return NSImage(cgImage: cgImage, size: .zero)
+#else
         return UIImage(cgImage: cgImage)
+#endif
     }
 
     /// Enough for the library well at 3x, with headroom. The iPad rows are
@@ -81,7 +91,11 @@ actor IntegrationThumbnailCache {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil), let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any], let width = properties[kCGImagePropertyPixelWidth] as? NSNumber, let height = properties[kCGImagePropertyPixelHeight] as? NSNumber else { return false }
         let (pixels, overflow) = width.int64Value.multipliedReportingOverflow(by: height.int64Value)
         guard !overflow, width.intValue > 0, height.intValue > 0, pixels > 0, pixels <= Int64(maximumPixelCount) else { return false }
+#if os(macOS)
+        return NSImage(data: data) != nil
+#else
         return UIImage(data: data) != nil
+#endif
     }
     static func key(_ url: URL) -> String { SHA256.hash(data: Data(url.absoluteString.utf8)).map { String(format: "%02x", $0) }.joined() }
 }

--- a/Vellum/Services/Integrations/IntegrationsCache.swift
+++ b/Vellum/Services/Integrations/IntegrationsCache.swift
@@ -3,10 +3,40 @@ import Foundation
 
 actor IntegrationsCache {
     struct SnapshotEnvelope: Codable, Sendable { static let currentVersion = 3; let version: Int; var snapshot: ProviderSnapshot }
+    struct PreservedRevision: Codable, Hashable, Sendable {
+        let revision: String?
+        let fileName: String
+    }
     /// What an installed PDF is a copy *of*. `revision` is the item's server
     /// revision at install time and is read back on every open, so an item the
     /// service has since replaced is re-downloaded instead of reused forever.
-    struct DownloadManifest: Codable, Hashable, Sendable { let provider: IntegrationProvider; let itemID: String; let revision: String? }
+    /// Optional fields keep manifests written by older builds readable: those
+    /// builds always stored the active bytes at the legacy `<item-key>.pdf`.
+    struct DownloadManifest: Codable, Hashable, Sendable {
+        let provider: IntegrationProvider
+        let itemID: String
+        let revision: String?
+        var fileName: String?
+        var preservedRevisions: [PreservedRevision]?
+        var revisionWarningPending: Bool?
+
+        init(
+            provider: IntegrationProvider, itemID: String, revision: String?,
+            fileName: String? = nil, preservedRevisions: [PreservedRevision]? = nil,
+            revisionWarningPending: Bool? = nil
+        ) {
+            self.provider = provider
+            self.itemID = itemID
+            self.revision = revision
+            self.fileName = fileName
+            self.preservedRevisions = preservedRevisions
+            self.revisionWarningPending = revisionWarningPending
+        }
+    }
+    struct DownloadInstallation: Hashable, Sendable {
+        let currentURL: URL
+        let preservedRevisionURL: URL?
+    }
     struct StagedPath: Sendable { let original: URL; let staged: URL }
     struct DisconnectStaging: Sendable { let directory: URL; let paths: [StagedPath] }
     enum LoadResult: Sendable { case missing, snapshot(ProviderSnapshot), corrupt }
@@ -55,6 +85,8 @@ actor IntegrationsCache {
         try save(snapshot)
     }
     func downloadsDirectory(provider: IntegrationProvider) throws -> URL { let url = providerDirectory(provider).appendingPathComponent("downloads", isDirectory: true); try fileManager.createDirectory(at: url, withIntermediateDirectories: true); return url }
+    /// The path used by manifests written before revision preservation. Kept as
+    /// an internal compatibility seam and for tests that stage legacy state.
     func downloadURL(provider: IntegrationProvider, itemID: String) throws -> URL { try downloadsDirectory(provider: provider).appendingPathComponent(Self.downloadKey(provider: provider, itemID: itemID) + ".pdf") }
     func manifestURL(provider: IntegrationProvider, itemID: String) throws -> URL { try downloadsDirectory(provider: provider).appendingPathComponent(Self.downloadKey(provider: provider, itemID: itemID) + ".json") }
 
@@ -63,43 +95,99 @@ actor IntegrationsCache {
     /// reusing one on existence alone pins the reader to a version the service
     /// replaced days ago, and no later sync would ever dislodge it.
     func currentDownload(provider: IntegrationProvider, itemID: String, revision: String?) throws -> URL? {
-        let url = try downloadURL(provider: provider, itemID: itemID)
-        guard fileManager.fileExists(atPath: url.path), manifest(provider: provider, itemID: itemID)?.revision == revision else { return nil }
+        guard let manifest = manifest(provider: provider, itemID: itemID),
+              manifest.revision == revision else { return nil }
+        let url = try downloadURL(for: manifest)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
         return url
     }
 
-    /// Installs a freshly downloaded PDF, replacing a stale copy in place.
-    /// An existing copy of the *same* revision means two downloads raced, so
-    /// that stays an `existingDownload` error rather than pointless rewriting.
-    func installDownload(temporaryURL: URL, manifest newManifest: DownloadManifest) throws -> URL {
-        let destination = try downloadURL(provider: newManifest.provider, itemID: newManifest.itemID)
-        if fileManager.fileExists(atPath: destination.path) {
-            guard manifest(provider: newManifest.provider, itemID: newManifest.itemID)?.revision != newManifest.revision else { throw IntegrationError.existingDownload }
-            _ = try fileManager.replaceItemAt(destination, withItemAt: temporaryURL)
-        } else {
-            try fileManager.moveItem(at: temporaryURL, to: destination)
+    /// Installs every server revision at an immutable path, then atomically
+    /// advances the manifest. The old path is never rewritten or removed, so a
+    /// user's embedded annotations remain recoverable and an already-open tab
+    /// cannot have its backing file changed underneath PDFKit.
+    func installDownload(temporaryURL: URL, manifest requested: DownloadManifest) throws -> DownloadInstallation {
+        let oldManifest = manifest(provider: requested.provider, itemID: requested.itemID)
+        if let oldManifest, oldManifest.revision == requested.revision,
+           fileManager.fileExists(atPath: try downloadURL(for: oldManifest).path) {
+            throw IntegrationError.existingDownload
         }
-        do { try JSONEncoder.integrations.encode(newManifest).write(to: try manifestURL(provider: newManifest.provider, itemID: newManifest.itemID), options: .atomic) }
-        catch { try? fileManager.removeItem(at: destination); throw error }
-        return destination
+
+        let directory = try downloadsDirectory(provider: requested.provider)
+        let destination = directory.appendingPathComponent(
+            Self.revisionFileName(
+                provider: requested.provider, itemID: requested.itemID,
+                revision: requested.revision))
+        try fileManager.moveItem(at: temporaryURL, to: destination)
+
+        var preserved = oldManifest?.preservedRevisions ?? []
+        var preservedURL: URL?
+        if let oldManifest {
+            let oldURL = try downloadURL(for: oldManifest)
+            if fileManager.fileExists(atPath: oldURL.path), oldURL != destination {
+                let record = PreservedRevision(
+                    revision: oldManifest.revision, fileName: oldURL.lastPathComponent)
+                preserved.removeAll { $0.fileName == record.fileName }
+                preserved.append(record)
+                preservedURL = oldURL
+            }
+        }
+
+        let installedManifest = DownloadManifest(
+            provider: requested.provider,
+            itemID: requested.itemID,
+            revision: requested.revision,
+            fileName: destination.lastPathComponent,
+            preservedRevisions: preserved.isEmpty ? nil : preserved,
+            revisionWarningPending: preservedURL == nil ? nil : true)
+        do {
+            try writeManifest(installedManifest)
+        } catch {
+            // The old manifest and every old revision are still intact. Remove
+            // only the uncommitted new bytes so a failed metadata write cannot
+            // turn into either data loss or an ambiguous active revision.
+            try? fileManager.removeItem(at: destination)
+            throw error
+        }
+        return DownloadInstallation(
+            currentURL: destination, preservedRevisionURL: preservedURL)
+    }
+
+    func pendingPreviousRevisionURL(provider: IntegrationProvider, itemID: String) throws -> URL? {
+        guard let manifest = manifest(provider: provider, itemID: itemID),
+              manifest.revisionWarningPending == true,
+              let previous = manifest.preservedRevisions?.last else { return nil }
+        let url = try revisionURL(
+            fileName: previous.fileName, provider: provider, itemID: itemID)
+        return fileManager.fileExists(atPath: url.path) ? url : nil
+    }
+
+    func acknowledgeRevisionWarning(
+        provider: IntegrationProvider, itemID: String, previousRevisionURL: URL
+    ) throws {
+        guard var manifest = manifest(provider: provider, itemID: itemID),
+              manifest.revisionWarningPending == true,
+              manifest.preservedRevisions?.last?.fileName == previousRevisionURL.lastPathComponent
+        else { return }
+        manifest.revisionWarningPending = false
+        try writeManifest(manifest)
     }
 
     /// Whether an id names real download artifacts. The id-only retention path
     /// uses this to distinguish a vanished PDF (reclaimable by provider/id)
     /// from an article whose URL-keyed archive cannot be reconstructed.
     func existingDownloadURL(provider: IntegrationProvider, itemID: String) -> URL? {
-        guard let pdf = try? downloadURL(provider: provider, itemID: itemID),
+        guard let manifest = manifest(provider: provider, itemID: itemID),
+            let pdf = try? downloadURL(for: manifest),
             fileManager.fileExists(atPath: pdf.path)
         else { return nil }
         return pdf
     }
 
     func hasDownloadArtifacts(provider: IntegrationProvider, itemID: String) -> Bool {
-        guard let manifest = try? manifestURL(provider: provider, itemID: itemID) else {
-            return existingDownloadURL(provider: provider, itemID: itemID) != nil
-        }
-        return existingDownloadURL(provider: provider, itemID: itemID) != nil
-            || fileManager.fileExists(atPath: manifest.path)
+        let manifestExists = (try? manifestURL(provider: provider, itemID: itemID))
+            .map { fileManager.fileExists(atPath: $0.path) } ?? false
+        return manifestExists || !downloadURLs(provider: provider, itemID: itemID).isEmpty
     }
 
     /// Deletes one installed copy and its manifest — the retention sweep's
@@ -108,23 +196,31 @@ actor IntegrationsCache {
     /// as the caller is concerned, while a file that refused to go keeps the
     /// item tracked for the next sweep.
     func deleteDownload(provider: IntegrationProvider, itemID: String) -> Bool {
-        guard let pdf = try? downloadURL(provider: provider, itemID: itemID) else { return false }
-        if fileManager.fileExists(atPath: pdf.path) {
-            try? fileManager.removeItem(at: pdf)
-        }
+        let downloads = downloadURLs(provider: provider, itemID: itemID)
+        for pdf in downloads { try? fileManager.removeItem(at: pdf) }
         if let manifest = try? manifestURL(provider: provider, itemID: itemID),
             fileManager.fileExists(atPath: manifest.path)
         {
             try? fileManager.removeItem(at: manifest)
         }
-        return !fileManager.fileExists(atPath: pdf.path)
+        return downloadURLs(provider: provider, itemID: itemID).isEmpty
     }
 
     func downloadByteSize(provider: IntegrationProvider, itemID: String) -> Int {
-        guard let url = try? downloadURL(provider: provider, itemID: itemID),
+        downloadURLs(provider: provider, itemID: itemID).reduce(0) { total, url in
             let attributes = try? fileManager.attributesOfItem(atPath: url.path)
-        else { return 0 }
-        return (attributes[.size] as? NSNumber)?.intValue ?? 0
+            return total + ((attributes?[.size] as? NSNumber)?.intValue ?? 0)
+        }
+    }
+
+    func downloadURLs(provider: IntegrationProvider, itemID: String) -> [URL] {
+        guard let directory = try? downloadsDirectory(provider: provider) else { return [] }
+        let key = Self.downloadKey(provider: provider, itemID: itemID)
+        return contents(of: directory).filter {
+            $0.pathExtension.lowercased() == "pdf"
+                && ($0.lastPathComponent == key + ".pdf"
+                    || $0.lastPathComponent.hasPrefix(key + "-"))
+        }
     }
 
     func managedDownloadURLs(provider: IntegrationProvider) -> [URL] {
@@ -183,6 +279,28 @@ actor IntegrationsCache {
         let decoder = JSONDecoder(); decoder.dateDecodingStrategy = .iso8601
         return try? decoder.decode(DownloadManifest.self, from: data)
     }
+    private func downloadURL(for manifest: DownloadManifest) throws -> URL {
+        guard let fileName = manifest.fileName else {
+            return try downloadURL(provider: manifest.provider, itemID: manifest.itemID)
+        }
+        return try revisionURL(
+            fileName: fileName, provider: manifest.provider, itemID: manifest.itemID)
+    }
+    private func revisionURL(
+        fileName: String, provider: IntegrationProvider, itemID: String
+    ) throws -> URL {
+        let key = Self.downloadKey(provider: provider, itemID: itemID)
+        guard fileName == (fileName as NSString).lastPathComponent,
+              fileName.hasPrefix(key + "-"),
+              fileName.lowercased().hasSuffix(".pdf")
+        else { throw IntegrationError.invalidResponse }
+        return try downloadsDirectory(provider: provider).appendingPathComponent(fileName)
+    }
+    private func writeManifest(_ manifest: DownloadManifest) throws {
+        try JSONEncoder.integrations.encode(manifest).write(
+            to: try manifestURL(provider: manifest.provider, itemID: manifest.itemID),
+            options: .atomic)
+    }
     private func decodeSnapshot(at url: URL) -> DecodeResult {
         guard let data = try? Data(contentsOf: url) else { return .absent }
         let decoder = JSONDecoder()
@@ -206,4 +324,10 @@ actor IntegrationsCache {
     /// nothing here benefits from a stable key order.
     private static var snapshotEncoder: JSONEncoder { let value = JSONEncoder(); value.dateEncodingStrategy = .iso8601; value.outputFormatting = [.withoutEscapingSlashes]; return value }
     static func downloadKey(provider: IntegrationProvider, itemID: String) -> String { SHA256.hash(data: Data("\(provider.rawValue):\(itemID)".utf8)).map { String(format: "%02x", $0) }.joined() }
+    private static func revisionFileName(provider: IntegrationProvider, itemID: String, revision: String?) -> String {
+        let key = downloadKey(provider: provider, itemID: itemID)
+        let revisionKey = SHA256.hash(data: Data((revision ?? "unknown").utf8))
+            .prefix(8).map { String(format: "%02x", $0) }.joined()
+        return "\(key)-\(revisionKey)-\(UUID().uuidString.lowercased()).pdf"
+    }
 }

--- a/Vellum/Services/Integrations/IntegrationsSyncEngine.swift
+++ b/Vellum/Services/Integrations/IntegrationsSyncEngine.swift
@@ -270,8 +270,12 @@ actor IntegrationsSyncEngine {
     /// article uses a URL-derived web-archive key that cannot be recovered from
     /// its provider id; reporting a missing PDF as success would forget its
     /// retention entry while leaving those bytes behind.
-    func downloadedCopyURL(provider: IntegrationProvider, itemID: String) async -> URL? {
-        await cache.existingDownloadURL(provider: provider, itemID: itemID)
+    func downloadedCopyURLs(provider: IntegrationProvider, itemID: String) async -> [URL] {
+        await cache.downloadURLs(provider: provider, itemID: itemID)
+    }
+
+    func downloadedCopyURLs(for item: ReadLaterItem) async -> [URL] {
+        await downloadedCopyURLs(provider: item.provider, itemID: item.vendorID)
     }
 
     func removeDownloadedCopyIfPresent(
@@ -301,14 +305,24 @@ actor IntegrationsSyncEngine {
             downloadTasks[key] = nil
             _ = await entry.task.result
         }
-        guard let url = try? await cache.downloadURL(provider: provider, itemID: itemID) else {
-            return false
-        }
+        let urls = await cache.downloadURLs(provider: provider, itemID: itemID)
+        guard !urls.isEmpty else { return false }
         let normalizedOpenPaths = Set(openDocumentPaths.map(Self.normalizedPath))
-        guard !normalizedOpenPaths.contains(Self.normalizedPath(url.path)) else { return false }
+        guard urls.allSatisfy({ !normalizedOpenPaths.contains(Self.normalizedPath($0.path)) }) else { return false }
         let removed = await cache.deleteDownload(provider: provider, itemID: itemID)
-        if removed { RecentFilesService.remove(paths: [url.path]) }
+        if removed { RecentFilesService.remove(paths: Set(urls.map(\.path))) }
         return removed
+    }
+
+    func pendingPreviousRevisionURL(for item: ReadLaterItem) async -> URL? {
+        try? await cache.pendingPreviousRevisionURL(
+            provider: item.provider, itemID: item.vendorID)
+    }
+
+    func acknowledgeRevisionWarning(for item: ReadLaterItem, previousRevisionURL: URL) async {
+        try? await cache.acknowledgeRevisionWarning(
+            provider: item.provider, itemID: item.vendorID,
+            previousRevisionURL: previousRevisionURL)
     }
 
     private func runDownload(_ item: ReadLaterItem, id: UUID, generation: Int, fingerprint: String, progress: @escaping @Sendable (Double?) async -> Void) async throws -> ExternalOpenRoute {
@@ -420,7 +434,9 @@ actor IntegrationsSyncEngine {
             try await Task.detached(priority: .userInitiated) { try Self.validatePDF(at: downloaded) }.value
             try ensureCurrent(item.provider, generation, fingerprint)
             let manifest = IntegrationsCache.DownloadManifest(provider: item.provider, itemID: item.vendorID, revision: Self.revision(item))
-            return .file(try await cache.installDownload(temporaryURL: downloaded, manifest: manifest))
+            let installation = try await cache.installDownload(
+                temporaryURL: downloaded, manifest: manifest)
+            return .file(installation.currentURL)
         } catch { try? FileManager.default.removeItem(at: downloaded); throw error }
     }
 

--- a/Vellum/Services/Integrations/ReadLaterOfflineStore.swift
+++ b/Vellum/Services/Integrations/ReadLaterOfflineStore.swift
@@ -139,9 +139,10 @@ struct IntegrationsOfflineStore: ReadLaterOfflineStoring {
             // user saying keep it, and annotating promotes to saved anyway.
             return record.saved || !record.annotations.isEmpty
         case .pdf:
-            guard case .file(let url)? = await engine.existingRoute(for: item) else { return false }
+            let urls = await engine.downloadedCopyURLs(for: item)
+            guard !urls.isEmpty else { return false }
             return await Task.detached(priority: .utility) {
-                Self.pdfHasAnnotations(at: url)
+                urls.contains(where: Self.pdfHasAnnotations)
             }.value
         case .epub, .video, .other:
             return false
@@ -155,11 +156,10 @@ struct IntegrationsOfflineStore: ReadLaterOfflineStoring {
     ) async -> Bool {
         switch item.kind {
         case .pdf:
-            guard case .file(let url)? = await engine.existingRoute(for: item) else {
-                return false
-            }
+            let urls = await engine.downloadedCopyURLs(for: item)
+            guard !urls.isEmpty else { return false }
             let hasAnnotations = await Task.detached(priority: .utility) {
-                Self.pdfHasAnnotations(at: url)
+                urls.contains(where: Self.pdfHasAnnotations)
             }.value
             guard !hasAnnotations else { return false }
             return await engine.removeDownloadedCopy(
@@ -231,12 +231,12 @@ struct IntegrationsOfflineStore: ReadLaterOfflineStoring {
         guard let provider = IntegrationProvider(rawValue: providerID), !vendorID.isEmpty else {
             return removedLocatedArtifact
         }
-        guard let pdfURL = await engine.downloadedCopyURL(
+        let pdfURLs = await engine.downloadedCopyURLs(
             provider: provider, itemID: vendorID)
-        else { return removedLocatedArtifact }
-        guard !openDocumentPaths.contains(pdfURL.path) else { return false }
+        guard !pdfURLs.isEmpty else { return removedLocatedArtifact }
+        guard pdfURLs.allSatisfy({ !openDocumentPaths.contains($0.path) }) else { return false }
         let hasAnnotations = await Task.detached(priority: .utility) {
-            Self.pdfHasAnnotations(at: pdfURL)
+            pdfURLs.contains(where: Self.pdfHasAnnotations)
         }.value
         guard !hasAnnotations else { return false }
         return await engine.removeDownloadedCopyIfPresent(

--- a/Vellum/Stores/IntegrationsStore.swift
+++ b/Vellum/Stores/IntegrationsStore.swift
@@ -1,11 +1,19 @@
-import UIKit
 import Foundation
 import Observation
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
 
 @MainActor @Observable
 final class IntegrationsStore {
     private(set) var providers: [IntegrationProvider: IntegrationProviderViewState]
     private(set) var downloads: [ReadLaterItem.ID: IntegrationDownloadState] = [:]
+    /// A retained older PDF revision that the user can reopen after the
+    /// provider supplied a replacement. The file remains on disk after this
+    /// one-time warning is dismissed.
+    private(set) var previousRevisionURLs: [ReadLaterItem.ID: URL] = [:]
     /// Success/error toasts for move-to-collection actions. Kept separate from
     /// `downloads` so a move toast can never stomp live download progress.
     private(set) var moveNotices: [ReadLaterItem.ID: IntegrationDownloadState] = [:]
@@ -69,6 +77,10 @@ final class IntegrationsStore {
     /// Fade-out timers for success toasts, keyed by item and stamped with the
     /// notice they belong to so a newer toast can cancel the older one's timer.
     @ObservationIgnored private var noticeExpiries: [ReadLaterItem.ID: (sequence: Int, task: Task<Void, Never>)] = [:]
+    /// Prevents an immediate reopen from re-showing a warning while its
+    /// acknowledgement is queued behind actor work. A later provider revision
+    /// points at a different previous URL and is therefore still shown.
+    @ObservationIgnored private var acknowledgedRevisionURLs: [ReadLaterItem.ID: URL] = [:]
 
     init(engine: IntegrationsSyncEngine, thumbnails: IntegrationThumbnailCache = IntegrationThumbnailCache(), scheduler: any IntegrationSleeper = ContinuousIntegrationSleeper(), now: @escaping @Sendable () -> Date = { .now }, refreshInterval: Duration = .seconds(30 * 60), staleInterval: TimeInterval = 30 * 60, prefetcher: ReadLaterPrefetcher? = nil, webLibraryStorage: WebLibraryStorage = WebLibraryStorage()) {
         self.engine = engine; self.thumbnails = thumbnails; self.scheduler = scheduler; self.now = now; self.refreshInterval = refreshInterval; self.staleInterval = staleInterval
@@ -288,6 +300,8 @@ final class IntegrationsStore {
         itemsRevisions[provider, default: 0] += 1
         let prefix = provider.rawValue + ":"
         downloads = downloads.filter { !$0.key.hasPrefix(prefix) }
+        previousRevisionURLs = previousRevisionURLs.filter { !$0.key.hasPrefix(prefix) }
+        acknowledgedRevisionURLs = acknowledgedRevisionURLs.filter { !$0.key.hasPrefix(prefix) }
         moveNotices = moveNotices.filter { !$0.key.hasPrefix(prefix) }
         pendingMoves = pendingMoves.filter { !$0.key.hasPrefix(prefix) }
         inFlightMoves = inFlightMoves.filter { !$0.hasPrefix(prefix) }
@@ -301,17 +315,40 @@ final class IntegrationsStore {
         // delays putting the document on screen.
         run { [prefetcher] in await prefetcher.markRead(item) }
         if item.kind != .pdf { return .web(item.sourceURL) }
-        if let existing = await engine.acquireExistingRoute(for: item) { return existing }
+        if let existing = await engine.acquireExistingRoute(for: item) {
+            await surfaceRevisionWarning(for: item)
+            return existing
+        }
         downloads[item.id] = .init(progress: nil, message: "Downloading \(item.title)…", isActive: true, sequence: nextSequence())
-        do { let route = try await engine.download(item) { [weak self] value in await MainActor.run { guard let self else { return }; let old = self.downloads[item.id]; self.downloads[item.id] = .init(progress: value.map { max(old?.progress ?? 0, min(1, $0)) }, message: "Downloading \(item.title)…", isActive: true, sequence: old?.sequence ?? self.nextSequence()) } }; downloads[item.id] = nil; return route }
+        do { let route = try await engine.download(item) { [weak self] value in await MainActor.run { guard let self else { return }; let old = self.downloads[item.id]; self.downloads[item.id] = .init(progress: value.map { max(old?.progress ?? 0, min(1, $0)) }, message: "Downloading \(item.title)…", isActive: true, sequence: old?.sequence ?? self.nextSequence()) } }; await surfaceRevisionWarning(for: item); return route }
         catch { downloads[item.id] = .init(progress: nil, message: error.localizedDescription, isActive: false, sequence: nextSequence()); throw error }
     }
 
     /// A ready-to-draw thumbnail. The fetch, the file read AND the decode all
     /// happen inside the cache actor, so a library row never blocks the main
     /// actor on disk I/O or ImageIO.
-    func thumbnailImage(for item: ReadLaterItem) async -> UIImage? { await thumbnails.image(for: item.thumbnailURL) }
-    func dismissDownloadNotice(_ id: ReadLaterItem.ID) { downloads[id] = nil }
+    func thumbnailImage(for item: ReadLaterItem) async -> IntegrationThumbnailImage? { await thumbnails.image(for: item.thumbnailURL) }
+
+    func previousRevisionURL(for id: ReadLaterItem.ID) -> URL? { previousRevisionURLs[id] }
+
+    func takePreviousRevision(for id: ReadLaterItem.ID) -> URL? {
+        let url = previousRevisionURLs[id]
+        dismissDownloadNotice(id)
+        return url
+    }
+
+    func dismissDownloadNotice(_ id: ReadLaterItem.ID) {
+        downloads[id] = nil
+        let previousURL = previousRevisionURLs[id]
+        previousRevisionURLs[id] = nil
+        guard let previousURL,
+              let item = searchableItems.first(where: { $0.id == id }) else { return }
+        acknowledgedRevisionURLs[id] = previousURL
+        run { [engine] in
+            await engine.acknowledgeRevisionWarning(
+                for: item, previousRevisionURL: previousURL)
+        }
+    }
 
     // MARK: - Moving items between collections
 
@@ -391,7 +428,8 @@ final class IntegrationsStore {
                     if let candidate = index.byStrippedAddress[stripped], !candidate.isEmpty { id = candidate }
                 }
             } else {
-                id = index.byDownloadKey[String((path as NSString).lastPathComponent.dropLast(4))]
+                let fileStem = String((path as NSString).lastPathComponent.dropLast(4))
+                id = index.byDownloadKey[String(fileStem.prefix(64))]
             }
             if let id, let item = index.byID[id] { return item }
         }
@@ -418,6 +456,21 @@ final class IntegrationsStore {
     }
 
     func dismissMoveNotice(_ id: ReadLaterItem.ID) { moveNotices[id] = nil }
+
+    private func surfaceRevisionWarning(for item: ReadLaterItem) async {
+        guard let previousURL = await engine.pendingPreviousRevisionURL(for: item) else {
+            previousRevisionURLs[item.id] = nil
+            downloads[item.id] = nil
+            return
+        }
+        guard acknowledgedRevisionURLs[item.id] != previousURL else { return }
+        previousRevisionURLs[item.id] = previousURL
+        downloads[item.id] = .init(
+            progress: nil,
+            message: "A newer revision was downloaded. Your previous copy was preserved.",
+            isActive: false,
+            sequence: nextSequence())
+    }
 
     private func replace(id: ReadLaterItem.ID, in provider: IntegrationProvider, with value: ReadLaterItem) {
         // Deliberately no re-sort: a locally-originated move keeps the row where

--- a/Vellum/Views/Panes/PaneView.swift
+++ b/Vellum/Views/Panes/PaneView.swift
@@ -34,7 +34,7 @@ struct PaneView: View {
                     // this pane's whole body.
                     .overlay(alignment: .bottomTrailing) {
                         if app.document != nil {
-                            PaneIntegrationNotice(path: app.document?.pdfPath)
+                            PaneIntegrationNotice(app: app, path: app.document?.pdfPath)
                                 .padding(18)
                         }
                     }
@@ -299,6 +299,7 @@ private struct PaneDocumentIdentity: Hashable {
 /// confirmations/errors, download progress). Owns the integrations-store
 /// lookup so only this small view re-renders on store churn.
 private struct PaneIntegrationNotice: View {
+    let app: AppStore
     let path: String?
 
     @Environment(IntegrationsStore.self) private var integrations
@@ -309,7 +310,12 @@ private struct PaneIntegrationNotice: View {
             FloatingNotice(
                 message: notice.state.message, progress: notice.state.progress,
                 isActive: notice.state.isActive, isSuccess: notice.state.isSuccess,
-                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice"
+                accessibilityID: notice.isMove ? "integrations.notice" : "integrations.downloadNotice",
+                actionTitle: integrations.previousRevisionURL(for: item.id) == nil ? nil : "Open Previous",
+                action: {
+                    guard let url = integrations.takePreviousRevision(for: item.id) else { return }
+                    Task { await app.openFile(path: url.path) }
+                }
             ) {
                 if notice.isMove { integrations.dismissMoveNotice(item.id) } else { integrations.dismissDownloadNotice(item.id) }
             }

--- a/Vellum/Views/Shared/FloatingNotice.swift
+++ b/Vellum/Views/Shared/FloatingNotice.swift
@@ -6,6 +6,8 @@ struct FloatingNotice: View {
     let isActive: Bool
     var isSuccess: Bool = false
     var accessibilityID: String = "integrations.downloadNotice"
+    var actionTitle: String? = nil
+    var action: (() -> Void)? = nil
     let dismiss: () -> Void
 
     @Environment(\.palette) private var palette
@@ -16,6 +18,11 @@ struct FloatingNotice: View {
                 Image(systemName: symbol).foregroundStyle(tint)
                 Text(message).font(.system(size: 12)).foregroundStyle(palette.foreground).lineLimit(2)
                 Spacer(minLength: 8)
+                if let actionTitle, let action {
+                    Button(actionTitle, action: action)
+                        .buttonStyle(.borderless)
+                        .font(.system(size: 12, weight: .semibold))
+                }
                 // The frame and contentShape must live INSIDE the label: on a
                 // .plain button, applied outside they change layout only and the
                 // hit region stays the bare glyph (root CLAUDE.md hit-target rule).


### PR DESCRIPTION
## What changed

- Store each downloaded PDF revision at a new immutable path instead of replacing the existing file.
- Keep the manifest backward-compatible while recording the current and preserved revisions.
- Warn once when a newer revision is opened, with an **Open Previous** action on Mac, iPad, and iPhone.
- Protect every retained revision from open-file deletion and annotation-based retention cleanup.
- Match both legacy and revisioned cache paths back to their read-later item.

## Why

Read-later refreshes previously replaced one fixed cache file in place. Any PDF annotations embedded in that file disappeared when the provider supplied a newer revision, and an already-open PDF could have its backing file changed underneath it.

The replacement now advances only the manifest. Older bytes remain untouched and recoverable.

## Validation

- `xcodegen generate`
- Universal iOS Simulator build: passed
- iPhone 17 Pro: 48 focused integration tests passed
- iPad Pro 13-inch: 48 focused integration tests passed
- Final immutable-path regression: 9 cache tests passed
- Mac source path covered, but a full Mac build from current `main` is blocked before these files compile by the existing unconditional `UIKit` import in `Vellum/Services/Ai/AiImageAttachment.swift:3`. The tracked project is currently iOS-only.

UI interaction was compiled but not manually exercised.

Closes #164