### PR TITLE
Restore the AI consent onboarding point

### DIFF
--- a/Vellum/Views/Help/WalkthroughContent.swift
+++ b/Vellum/Views/Help/WalkthroughContent.swift
@@ -173,6 +173,11 @@ extension WalkthroughPage {
                     text:
                         "Paste an API key for Gemini, the OpenAI API, OpenRouter, OpenCode Zen, "
                         + "or OpenCode Go."),
+                WalkthroughPoint(
+                    symbol: "hand.raised",
+                    text:
+                        "Before Vellum sends document content to a provider for the first time, "
+                        + "it explains what will be shared and asks for permission."),
             ]
         ),
 


### PR DESCRIPTION
TLDR:
Add the missing privacy-permission point to the Connect onboarding page and restore the release test.

Problem:
The Connect page had only two points, so the onboarding content test failed and first-run guidance did not explain the AI-sharing permission step.

Closes #202